### PR TITLE
Generate control plane CRs

### DIFF
--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -71,7 +71,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		ReleaseVersion:    r.flag.Release,
 	}
 
-	clusterCR, awsClusterCR, err := cluster.NewClusterCRs(config)
+	clusterCR, awsClusterCR, g8sControlPlaneCR, awsControlPlaneCR, err := cluster.NewClusterCRs(config)
 
 	clusterCRYaml, err := yaml.Marshal(clusterCR)
 	if err != nil {
@@ -79,6 +79,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	awsClusterCRYaml, err := yaml.Marshal(awsClusterCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	g8sControlPlaneCRYaml, err := yaml.Marshal(g8sControlPlaneCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	awsControlPlaneCRYaml, err := yaml.Marshal(awsControlPlaneCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -124,8 +134,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	type ClusterCRsOutput struct {
 		AWSClusterCR            string
+		AWSControlPlaneCR       string
 		AWSMachineDeploymentCR  string
 		ClusterCR               string
+		G8sControlPlaneCR       string
 		MachineDeploymentCR     string
 		TemplateDefaultNodepool bool
 	}
@@ -135,6 +147,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		AWSMachineDeploymentCR:  string(awsMDCRYaml),
 		ClusterCR:               string(clusterCRYaml),
 		MachineDeploymentCR:     string(mdCRYaml),
+		G8sControlPlaneCR:       string(g8sControlPlaneCRYaml),
+		AWSControlPlaneCR:       string(awsControlPlaneCRYaml),
 		TemplateDefaultNodepool: r.flag.TemplateDefaultNodepool,
 	}
 

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -4,6 +4,8 @@ In order to create a cluster using custom resources, kubectl-gs will help you cr
 
 - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`) - holds the base cluster specification.
 - `AWSCluster` (API version `infrastructure.giantswarm.io/v1alpha2`) - holds AWS-specific configuration.
+- `G8sControlPlane` (API version `infrastructure.giantswarm.io/v1alpha2`) - specifies the master nodes
+- `AWSControlPlane` (API version `infrastructure.giantswarm.io/v1alpha2`) - specifies the master nodes with AWS-specific details
 
 ## Usage
 
@@ -103,4 +105,43 @@ status:
   provider:
     network:
       cidr: ""
+---
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: G8sControlPlane
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster-operator.giantswarm.io/version: 2.1.10
+    giantswarm.io/cluster: o4omf
+    giantswarm.io/control-plane: osss7
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 11.2.1
+  name: osss7
+  namespace: default
+spec:
+  infrastructureRef:
+    apiVersion: infrastructure.giantswarm.io/v1alpha2
+    kind: AWSControlPlane
+    name: osss7
+    namespace: default
+  replicas: 1
+status: {}
+---
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: AWSControlPlane
+metadata:
+  creationTimestamp: null
+  labels:
+    aws-operator.giantswarm.io/version: 8.4.0
+    giantswarm.io/cluster: o4omf
+    giantswarm.io/control-plane: osss7
+    giantswarm.io/organization: giantswarm
+    release.giantswarm.io/version: 11.2.1
+  name: osss7
+  namespace: default
+spec:
+  availabilityZones:
+  - eu-central-1a
+  instanceType: m5.xlarge
+status: {}
 ```

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -20,6 +20,10 @@ const ClusterCRsTemplate = `
 {{ .ClusterCR -}}
 ---
 {{ .AWSClusterCR -}}
+---
+{{ .G8sControlPlaneCR -}}
+---
+{{ .AWSControlPlaneCR -}}
 {{ if .TemplateDefaultNodepool}}
 ---
 {{ .MachineDeploymentCR -}}

--- a/pkg/template/cluster/cluster.go
+++ b/pkg/template/cluster/cluster.go
@@ -29,7 +29,8 @@ type Config struct {
 	ReleaseVersion    string
 }
 
-func NewClusterCRs(config Config) (*apiv1alpha2.Cluster, *infrastructurev1alpha2.AWSCluster, error) {
+// NewClusterCRs returns the custom resources to represent the given cluster.
+func NewClusterCRs(config Config) (*apiv1alpha2.Cluster, *infrastructurev1alpha2.AWSCluster, *infrastructurev1alpha2.G8sControlPlane, *infrastructurev1alpha2.AWSControlPlane, error) {
 
 	clusterID := key.GenerateID()
 	if config.ClusterID != "" {
@@ -38,15 +39,23 @@ func NewClusterCRs(config Config) (*apiv1alpha2.Cluster, *infrastructurev1alpha2
 
 	awsClusterCR, err := newAWSClusterCR(clusterID, config)
 	if err != nil {
-		return nil, nil, microerror.Mask(err)
+		return nil, nil, nil, nil, microerror.Mask(err)
 	}
 
 	clusterCR, err := newClusterCR(awsClusterCR, clusterID, config)
 	if err != nil {
-		return nil, nil, microerror.Mask(err)
+		return nil, nil, nil, nil, microerror.Mask(err)
 	}
 
-	return clusterCR, awsClusterCR, nil
+	controlPlaneID := key.GenerateID()
+
+	awsControlPlaneCR := newAWSControlPlaneCR(clusterID, controlPlaneID, config)
+	g8sControlPlaneCR, err := newG8sControlPlaneCR(awsControlPlaneCR, clusterID, controlPlaneID, config)
+	if err != nil {
+		return nil, nil, nil, nil, microerror.Mask(err)
+	}
+
+	return clusterCR, awsClusterCR, g8sControlPlaneCR, awsControlPlaneCR, nil
 }
 
 func newClusterCR(obj interface{}, clusterID string, c Config) (*apiv1alpha2.Cluster, error) {
@@ -123,4 +132,59 @@ func newAWSClusterCR(clusterID string, c Config) (*infrastructurev1alpha2.AWSClu
 	}
 
 	return awsClusterCR, nil
+}
+
+func newAWSControlPlaneCR(clusterID string, controlPlaneID string, c Config) *infrastructurev1alpha2.AWSControlPlane {
+	return &infrastructurev1alpha2.AWSControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AWSControlPlane",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlaneID,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
+				label.Cluster:            clusterID,
+				label.Organization:       c.Owner,
+				label.ReleaseVersion:     c.ReleaseVersion,
+			},
+		},
+		Spec: infrastructurev1alpha2.AWSControlPlaneSpec{
+			AvailabilityZones: []string{c.MasterAZ},
+			InstanceType:      defaultMasterInstanceType,
+		},
+	}
+}
+
+func newG8sControlPlaneCR(obj interface{}, clusterID string, controlPlaneID string, c Config) (*infrastructurev1alpha2.G8sControlPlane, error) {
+	runtimeObj, _ := obj.(runtime.Object)
+
+	infrastructureCRRef, err := reference.GetReference(infrastructurev1alpha2scheme.Scheme, runtimeObj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	cr := &infrastructurev1alpha2.G8sControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "G8sControlPlane",
+			APIVersion: "infrastructure.giantswarm.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlaneID,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],
+				label.Cluster:                clusterID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+			},
+		},
+		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{
+			Replicas:          1,
+			InfrastructureRef: *infrastructureCRRef,
+		},
+	}
+
+	return cr, nil
 }

--- a/pkg/template/cluster/cluster.go
+++ b/pkg/template/cluster/cluster.go
@@ -146,6 +146,7 @@ func newAWSControlPlaneCR(clusterID string, controlPlaneID string, c Config) *in
 			Labels: map[string]string{
 				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
 				label.Cluster:            clusterID,
+				label.ControlPlane:       controlPlaneID,
 				label.Organization:       c.Owner,
 				label.ReleaseVersion:     c.ReleaseVersion,
 			},
@@ -176,6 +177,7 @@ func newG8sControlPlaneCR(obj interface{}, clusterID string, controlPlaneID stri
 			Labels: map[string]string{
 				label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],
 				label.Cluster:                clusterID,
+				label.ControlPlane:           controlPlaneID,
 				label.Organization:           c.Owner,
 				label.ReleaseVersion:         c.ReleaseVersion,
 			},


### PR DESCRIPTION
On the path to making kubectl-gs usable for creating HA masters clusters, this adds the creation of 

- G8sControlPlane
- AWSControlPlane

resources when creating cluster manifests.

## For testing

```
go run main.go template cluster \
  --domain foo.bar \
  --name testcluster \
  --owner acme \
  --region eu-central-1 \
  --master-az eu-central-1b \
  --release 11.3.0
```

## Output

<details>

```yaml
apiVersion: cluster.x-k8s.io/v1alpha2
kind: Cluster
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.1.10
    giantswarm.io/cluster: 6du6s
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: 6du6s
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSCluster
    name: 6du6s
    namespace: default
status:
  controlPlaneInitialized: false
  infrastructureReady: false
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSCluster
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.5.0
    giantswarm.io/cluster: 6du6s
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: 6du6s
  namespace: default
spec:
  cluster:
    description: testcluster
    dns:
      domain: foo.bar
    oidc:
      claims: {}
  provider:
    credentialSecret:
      name: credential-default
      namespace: giantswarm
    master:
      availabilityZone: eu-central-1b
      instanceType: m5.xlarge
    pods:
      cidrBlock: ""
    region: eu-central-1
status:
  cluster:
    id: ""
  provider:
    network:
      cidr: ""
      vpcID: ""
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: G8sControlPlane
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.1.10
    giantswarm.io/cluster: 6du6s
    giantswarm.io/control-plane: osss7
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: osss7
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSControlPlane
    name: osss7
    namespace: default
  replicas: 1
status: {}
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSControlPlane
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.5.0
    giantswarm.io/cluster: 6du6s
    giantswarm.io/control-plane: osss7
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: osss7
  namespace: default
spec:
  availabilityZones:
  - eu-central-1b
  instanceType: m5.xlarge
status: {}
```

</details>