### PR TITLE
Allow multiple master availability zones

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/giantswarm/microerror"
+	"github.com/mpvl/unique"
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
@@ -121,8 +122,13 @@ func (f *flag) Validate() error {
 	if !aws.ValidateRegion(f.Region) {
 		return microerror.Maskf(invalidFlagError, "--%s must be valid region name", flagRegion)
 	}
+
+	// AZ name(s)
 	if len(f.MasterAZ) != 1 && len(f.MasterAZ) != 3 {
 		return microerror.Maskf(invalidFlagError, "--%s must be set to either one or three availabiliy zone names", flagMasterAZ)
+	}
+	if !unique.StringsAreUnique(f.MasterAZ) {
+		return microerror.Maskf(invalidFlagError, "--%s values must contain each AZ name only once", flagMasterAZ)
 	}
 
 	// TODO: validate that len(f.MasterAZ) == 3 is occurring in releases >= v11.5.0

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -28,6 +29,11 @@ type runner struct {
 
 func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+
+	// Sorting is required before validation for uniqueness.
+	sort.Slice(r.flag.MasterAZ, func(i, j int) bool {
+		return r.flag.MasterAZ[i] < r.flag.MasterAZ[j]
+	})
 
 	err := r.flag.Validate()
 	if err != nil {

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -13,8 +13,11 @@ The command to execute is `kubectl gs template cluster`.
 
 It supports the following flags:
 
-  - `--master-az` - AWS availability zone of master instance.
+  - `--master-az` - AWS availability zone(s) of master instance.
     Must be configured with AZ of the installation region. E.g. for region *eu-central-1* valid value is *eu-central-1a*.
+    Use the flag once with a single value to create a cluster with one master node. For master node high availability,
+    specify three distinct availability zones instead. This can be done by separating AZ names with comma or using the flag
+    three times with a single AZ name.
   - `--domain`  - base domain of your installation. Customer solution engineer can provide this value.
   - `--name` - cluster name.
   - `--pods-cidr` - CIDR applied to the pods. If you don't set any, the installation default will be applied. Only versions *11.1.4+ support this feature.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/micrologger v0.3.1
 	github.com/go-openapi/strfmt v0.19.5 // indirect
+	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.7
 	github.com/stretchr/testify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=
+github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de/go.mod h1:kJun4WP5gFuHZgRjZUWWuH1DTxCtxbHDOIJsudS8jzY=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/pkg/template/cluster/cluster.go
+++ b/pkg/template/cluster/cluster.go
@@ -187,7 +187,7 @@ func newG8sControlPlaneCR(obj interface{}, clusterID string, controlPlaneID stri
 			},
 		},
 		Spec: infrastructurev1alpha2.G8sControlPlaneSpec{
-			Replicas:          1,
+			Replicas:          len(c.MasterAZ),
 			InfrastructureRef: *infrastructureCRRef,
 		},
 	}

--- a/pkg/template/cluster/cluster.go
+++ b/pkg/template/cluster/cluster.go
@@ -47,7 +47,7 @@ func NewClusterCRs(config Config) (*apiv1alpha2.Cluster, *infrastructurev1alpha2
 		return nil, nil, nil, nil, microerror.Mask(err)
 	}
 
-	controlPlaneID := key.GenerateID()
+	controlPlaneID := "cp-" + key.GenerateID()
 
 	awsControlPlaneCR := newAWSControlPlaneCR(clusterID, controlPlaneID, config)
 	g8sControlPlaneCR, err := newG8sControlPlaneCR(awsControlPlaneCR, clusterID, controlPlaneID, config)

--- a/pkg/template/cluster/cluster.go
+++ b/pkg/template/cluster/cluster.go
@@ -47,7 +47,7 @@ func NewClusterCRs(config Config) (*apiv1alpha2.Cluster, *infrastructurev1alpha2
 		return nil, nil, nil, nil, microerror.Mask(err)
 	}
 
-	controlPlaneID := "cp-" + key.GenerateID()
+	controlPlaneID := key.GenerateID()
 
 	awsControlPlaneCR := newAWSControlPlaneCR(clusterID, controlPlaneID, config)
 	g8sControlPlaneCR, err := newG8sControlPlaneCR(awsControlPlaneCR, clusterID, controlPlaneID, config)


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/8346

This adds support for multiple master node availability zones in cluster templating.

Effectively, this allows the user to chose whether the cluster created should have one or three master nodes.

## Usage

The `--master-az` flags can either be used once or three times, or it can have one or three values (separated by comma).

Examples:

```nohighlight
go run main.go template cluster \
    --domain foo.bar \
    --name testcluster \
    --owner acme \
    --region eu-central-1 \
    --release 11.3.0 \
    --master-az eu-central-1b,eu-central-1c,eu-central-1a

go run main.go template cluster \
    --domain foo.bar \
    --name testcluster \
    --owner acme \
    --region eu-central-1 \
    --release 11.3.0 \
    --master-az eu-central-1a \
    --master-az eu-central-1b \
    --master-az eu-central-1c
```

**Note:** Currently there is no validation with regard to the usage of 3 master node AZs and the release. Ideally, if HA masters becomes available with v11.5.0, an error should be thrown if the user tries to create an HA masters cluster with a release below that. However, that would require  encoding release/feature information here.

## Example output

<details>

```yaml
apiVersion: cluster.x-k8s.io/v1alpha2
kind: Cluster
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.1.10
    giantswarm.io/cluster: in0qc
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: in0qc
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSCluster
    name: in0qc
    namespace: default
status:
  controlPlaneInitialized: false
  infrastructureReady: false
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSCluster
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.5.0
    giantswarm.io/cluster: in0qc
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: in0qc
  namespace: default
spec:
  cluster:
    description: testcluster
    dns:
      domain: foo.bar
    oidc:
      claims: {}
  provider:
    credentialSecret:
      name: credential-default
      namespace: giantswarm
    master:
      availabilityZone: ""
      instanceType: ""
    pods:
      cidrBlock: ""
    region: eu-central-1
status:
  cluster:
    id: ""
  provider:
    network:
      cidr: ""
      vpcID: ""
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: G8sControlPlane
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.1.10
    giantswarm.io/cluster: in0qc
    giantswarm.io/control-plane: 9nvry
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: 9nvry
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSControlPlane
    name: 9nvry
    namespace: default
  replicas: 1
status: {}
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSControlPlane
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.5.0
    giantswarm.io/cluster: in0qc
    giantswarm.io/control-plane: 9nvry
    giantswarm.io/organization: acme
    release.giantswarm.io/version: 11.3.0
  name: 9nvry
  namespace: default
spec:
  availabilityZones:
  - eu-central-1a
  - eu-central-1b
  - eu-central-1c
  instanceType: m5.xlarge
status: {}
```
</details>