### PR TITLE
add "ap-southeast-1a"

### DIFF
--- a/pkg/aws/infrastructure.go
+++ b/pkg/aws/infrastructure.go
@@ -26,6 +26,7 @@ var infrastructure = map[string][]string{
 	},
 
 	"ap-southeast-1": []string{
+		"ap-southeast-1a",
 		"ap-southeast-1b",
 		"ap-southeast-1c",
 	},


### PR DESCRIPTION
Joel reported the AZ `a` was missing for Singapour region, but it appaer present from AWS.

any reason that I don't why it was not there?

https://gigantic.slack.com/archives/C6L8J93N0/p1590502258386500