### PR TITLE
Remove default node pool creation from `kubectl gs template cluster`

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"net"
 	"regexp"
-	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/mpvl/unique"
@@ -15,49 +14,31 @@ import (
 )
 
 const (
-	flagClusterID               = "cluster-id"
-	flagDomain                  = "domain"
-	flagMasterAZ                = "master-az"
-	flagName                    = "name"
-	flagNoCache                 = "no-cache"
-	flagPodsCIDR                = "pods-cidr"
-	flagExternalSNAT            = "external-snat"
-	flagOutput                  = "output"
-	flagOwner                   = "owner"
-	flagRegion                  = "region"
-	flagRelease                 = "release"
-	flagTemplateDefaultNodepool = "template-default-nodepool"
-
-	// nodepool flags
-	flagAvailabilityZones    = "availability-zones"
-	flagAWSInstanceType      = "aws-instance-type"
-	flagNodepoolName         = "nodepool-name"
-	flagNodesMax             = "nodex-max"
-	flagNodesMin             = "nodex-min"
-	flagNumAvailabilityZones = "num-availability-zones"
+	flagClusterID    = "cluster-id"
+	flagDomain       = "domain"
+	flagMasterAZ     = "master-az"
+	flagName         = "name"
+	flagNoCache      = "no-cache"
+	flagPodsCIDR     = "pods-cidr"
+	flagExternalSNAT = "external-snat"
+	flagOutput       = "output"
+	flagOwner        = "owner"
+	flagRegion       = "region"
+	flagRelease      = "release"
 )
 
 type flag struct {
-	ClusterID               string
-	Domain                  string
-	MasterAZ                []string
-	Name                    string
-	NoCache                 bool
-	PodsCIDR                string
-	ExternalSNAT            bool
-	Output                  string
-	Owner                   string
-	Region                  string
-	Release                 string
-	TemplateDefaultNodepool bool
-
-	// nodepool fields
-	AvailabilityZones    string
-	AWSInstanceType      string
-	NodepoolName         string
-	NodesMax             int
-	NodesMin             int
-	NumAvailabilityZones int
+	ClusterID    string
+	Domain       string
+	MasterAZ     []string
+	Name         string
+	NoCache      bool
+	PodsCIDR     string
+	ExternalSNAT bool
+	Output       string
+	Owner        string
+	Region       string
+	Release      string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -70,18 +51,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
-	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region(e.g. eu-central-1).")
+	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
-	cmd.Flags().BoolVar(&f.TemplateDefaultNodepool, flagTemplateDefaultNodepool, false, "Template default nodepool CRs with cluster CRs.")
-
-	// nodepool validation
-	// required only when template-default-nodepool
-	cmd.Flags().StringVar(&f.AvailabilityZones, flagAvailabilityZones, "", "List of availability zones to use, instead of setting a number. Use comma to separate values (when --template-default-nodepool=true).")
-	cmd.Flags().StringVar(&f.AWSInstanceType, flagAWSInstanceType, "m5.xlarge", "EC2 instance type to use for workers, e. g. 'm5.2xlarge' (when --template-default-nodepool=true).")
-	cmd.Flags().StringVar(&f.NodepoolName, flagNodepoolName, "Unnamed node pool", "NodepoolName or purpose description of the node pool (when --template-default-nodepool=true).")
-	cmd.Flags().IntVar(&f.NodesMax, flagNodesMax, 10, "Maximum number of worker nodes for the node pool (when --template-default-nodepool=true).")
-	cmd.Flags().IntVar(&f.NodesMin, flagNodesMin, 3, "Minimum number of worker nodes for the node pool (when --template-default-nodepool=true).")
-	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 1, "Number of availability zones to use. Default is 1 (when --template-default-nodepool=true).")
 }
 
 func (f *flag) Validate() error {
@@ -160,49 +131,6 @@ func (f *flag) Validate() error {
 
 	if !release.Validate(f.Release) {
 		return microerror.Maskf(invalidFlagError, "--%s must be a valid release", flagRelease)
-	}
-
-	if f.TemplateDefaultNodepool {
-		if f.AWSInstanceType == "" {
-			return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagAWSInstanceType)
-		}
-		if f.NodepoolName == "" {
-			return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagNodepoolName)
-		}
-		if f.NodesMax < 1 {
-			return microerror.Maskf(invalidFlagError, "--%s must be > 0", flagNodesMax)
-		}
-		if f.NodesMin < 1 {
-			return microerror.Maskf(invalidFlagError, "--%s must be > 0", flagNodesMin)
-		}
-		if f.NodesMin > f.NodesMax {
-			return microerror.Maskf(invalidFlagError, "--%s must be <= --%s", flagNodesMin, flagNodesMax)
-		}
-
-		if f.AvailabilityZones != "" {
-			azs := strings.Split(f.AvailabilityZones, ",")
-			if len(azs) < 1 {
-				return microerror.Maskf(invalidFlagError, "--%s must be configured with at least 1 AZ", flagAvailabilityZones)
-			}
-			if len(azs) > aws.AvailableAZs(f.Region) {
-				return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region)", flagAvailabilityZones)
-			}
-			for _, az := range azs {
-				if !aws.ValidateAZ(f.Region, az) {
-					return microerror.Maskf(invalidFlagError, "--%s must be a list with valid AZs for selected region", flagAvailabilityZones)
-
-				}
-			}
-		} else {
-			if f.NumAvailabilityZones < 1 {
-				if f.AvailabilityZones == "" {
-					return microerror.Maskf(invalidFlagError, "--%s must be > 1 when --%s not specified)", flagNumAvailabilityZones, flagAvailabilityZones)
-				}
-				if f.NumAvailabilityZones > aws.AvailableAZs(f.Region) {
-					return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region)", flagNumAvailabilityZones)
-				}
-			}
-		}
 	}
 
 	return nil

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -50,7 +50,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 1, "Number of availability zones to use. Default is 1.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
-	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region(e.g. eu-central-1).")
+	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
 }
 

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -13,30 +13,28 @@ The command to execute is `kubectl gs template cluster`.
 
 It supports the following flags:
 
-  - `--master-az` - AWS availability zone(s) of master instance.
-    Must be configured with AZ of the installation region. E.g. for region *eu-central-1* valid value is *eu-central-1a*.
-    Use the flag once with a single value to create a cluster with one master node. For master node high availability,
-    specify three distinct availability zones instead. This can be done by separating AZ names with comma or using the flag
-    three times with a single AZ name.
-  - `--domain`  - base domain of your installation. Customer solution engineer can provide this value.
-  - `--external-snat` - AWS CNI configuration to disable (is enabled by default) the [external source network address translation](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). Only versions *11.3.1+ support this feature.
-  - `--name` - cluster name.
-  - `--pods-cidr` - CIDR applied to the pods. If you don't set any, the installation default will be applied. Only versions *11.1.4+ support this feature.
-  - `--owner` - organization, owning tenant cluster. Must be configured with existing organization in installation.
-  - `--region` - tenant cluster AWS region. Must be configured with installation region.
-  - `--release` - valid release version.
-    Can be retrieved with `gsctl list releases` for your installation. Only versions *10.x.x*+ support cluster CRs.
-  - `--template-default-nodepool` - set to *true* if you want to template nodepool CRs altogether with cluster CRs.
+- `--master-az` - AWS availability zone(s) of master instance.
+  Must be configured with AZ of the installation region. E.g. for region *eu-central-1* valid value is *eu-central-1a*.
+  Use the flag once with a single value to create a cluster with one master node. For master node high availability,
+  specify three distinct availability zones instead. This can be done by separating AZ names with comma or using the flag
+  three times with a single AZ name.
+- `--domain`  - base domain of your installation. Customer solution engineer can provide this value.
+- `--external-snat` - AWS CNI configuration to disable (is enabled by default) the [external source network address translation](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). Only versions *11.3.1+ support this feature.
+- `--name` - cluster name.
+- `--pods-cidr` - CIDR applied to the pods. If you don't set any, the installation default will be applied. Only versions *11.1.4+ support this feature.
+- `--owner` - organization, owning tenant cluster. Must be configured with existing organization in installation.
+- `--region` - tenant cluster AWS region. Must be configured with installation region.
+- `--release` - valid release version.
+  Can be retrieved with `gsctl list releases` for your installation. Only versions above *10.x.x*+ support cluster CRs.
 
-Note: If you'd like to add specific worker nodes and not make use of `--template-default-nodepool`, please see [Node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions how to create worker nodes.
-
+**Note:** The CRs generated won't trigger the creation of any worker nodes. Please see [node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions on how to create worker node pools.
 
 ## Example
 
 Example command:
 
-```
-gs template cluster \
+```nohighlight
+kubectl gs template cluster \
   --master-az="eu-central-1a" \
   --domain="gauss.eu-central-1.aws.gigantic.io" \
   --external-snat=true \
@@ -44,8 +42,7 @@ gs template cluster \
   --pods-cidr="10.2.0.0/16" \
   --owner="giantswarm" \
   --release="11.2.1" \
-  --region="eu-central-1" \
-  --template-default-nodepool=false
+  --region="eu-central-1"
 ```
 
 Generates output

--- a/docs/template-nodepool-cr.md
+++ b/docs/template-nodepool-cr.md
@@ -1,6 +1,6 @@
 # Creating a node pool based on custom resources using kubectl-gs
 
-Node pools are groups of worker nodes sharing common configuration. In terms of custom resources they consist of
+Node pools are groups of worker nodes sharing common configuration. In terms of custom resources they consist of custom resources of type
 
 - `MachineDeployment` (API version `cluster.x-k8s.io/v1alpha2`)
 - `AWSMachineDeployment` (API version `infrastructure.giantswarm.io/v1alpha2`)


### PR DESCRIPTION
This removes the default node pool creation from the cluster templating.

Reason: With this function, there are two ways for users to think about node pools. One for the first node pool, the other for all other node pools. This actually complicates things for users. Plus it bloats the code base.

In `gsctl` we introduced the "default node pool" concept when we added node pool functionality for AWS, so that it would still be easy and simple to create a functional cluster by using a relatively short command. We basically had existing users with adopted behaviour in mind. This is not relevant for kubectl-gs.

So for user, with this change it will be:

1. Run `kubectl gs template cluster` once
2. Run `kubectl gs template nodepool` as often as required