### PR TITLE
Allow specifying tenant cluster labels through --label flags

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
 	"net"
 	"regexp"
 
@@ -26,6 +27,7 @@ const (
 	flagOwner        = "owner"
 	flagRegion       = "region"
 	flagRelease      = "release"
+	flagLabel        = "label"
 )
 
 type flag struct {
@@ -41,6 +43,7 @@ type flag struct {
 	Owner        string
 	Region       string
 	Release      string
+	Label        []string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -56,6 +59,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
+	cmd.Flags().StringSliceVar(&f.Label, flagLabel, []string{}, "Tenant cluster label.")
 }
 
 func (f *flag) Validate() error {
@@ -134,6 +138,11 @@ func (f *flag) Validate() error {
 
 	if !release.Validate(f.Release) {
 		return microerror.Maskf(invalidFlagError, "--%s must be a valid release", flagRelease)
+	}
+
+	_, err = clusterlabels.Parse(f.Label)
+	if err != nil {
+		return microerror.Maskf(invalidFlagError, "--%s must contain valid label definitions (%s)", flagLabel, err)
 	}
 
 	return nil

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -59,7 +59,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
-	cmd.Flags().StringSliceVar(&f.Label, flagLabel, []string{}, "Tenant cluster label.")
+	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Tenant cluster label.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
 	"github.com/giantswarm/kubectl-gs/pkg/gsrelease"
 	"github.com/giantswarm/kubectl-gs/pkg/template/cluster"
 )
@@ -62,6 +63,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	releaseComponents := release.ReleaseComponents(r.flag.Release)
 
+	userLabels, _ := clusterlabels.Parse(r.flag.Label)
+
 	config := cluster.Config{
 		ClusterID:         r.flag.ClusterID,
 		Credential:        r.flag.Credential,
@@ -74,6 +77,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		Region:            r.flag.Region,
 		ReleaseComponents: releaseComponents,
 		ReleaseVersion:    r.flag.Release,
+		Labels:            userLabels,
 	}
 
 	clusterCR, awsClusterCR, g8sControlPlaneCR, awsControlPlaneCR, err := cluster.NewClusterCRs(config)

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -27,6 +27,7 @@ It supports the following flags:
 - `--region` - tenant cluster AWS region. Must be configured with installation region.
 - `--release` - valid release version.
   Can be retrieved with `gsctl list releases` for your installation. Only versions above *10.x.x*+ support cluster CRs.
+- `--label` - tenant cluster label in form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
 
 **Note:** The CRs generated won't trigger the creation of any worker nodes. Please see [node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions on how to create worker node pools.
 
@@ -44,7 +45,9 @@ kubectl gs template cluster \
   --owner="giantswarm" \
   --credential="credential-34hg5" \
   --release="11.2.1" \
-  --region="eu-central-1"
+  --region="eu-central-1" \
+  --label="environment=testing" \
+  --label="team=upstate"
 ```
 
 Generates output
@@ -59,6 +62,8 @@ metadata:
     giantswarm.io/cluster: o4omf
     giantswarm.io/organization: giantswarm
     release.giantswarm.io/version: 11.2.1
+    environment: testing
+    team: upstate
   name: o4omf
   namespace: default
 spec:

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -27,7 +27,7 @@ It supports the following flags:
 - `--region` - tenant cluster AWS region. Must be configured with installation region.
 - `--release` - valid release version.
   Can be retrieved with `gsctl list releases` for your installation. Only versions above *10.x.x*+ support cluster CRs.
-- `--label` - tenant cluster label in form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
+- `--label` - tenant cluster label in the form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
 
 **Note:** The CRs generated won't trigger the creation of any worker nodes. Please see [node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions on how to create worker node pools.
 

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -22,3 +22,5 @@ const (
 const (
 	MachineDeploymentSubnet = "machine-deployment.giantswarm.io/subnet"
 )
+
+const ForbiddenLabelKeyPart = "giantswarm.io"

--- a/pkg/clusterlabels/error.go
+++ b/pkg/clusterlabels/error.go
@@ -1,0 +1,27 @@
+package clusterlabels
+
+import "github.com/giantswarm/microerror"
+
+var invalidLabelSpecError = &microerror.Error{
+	Kind: "invalidLabelSpecError",
+}
+
+func IsInvalidLabelSpec(err error) bool {
+	return microerror.Cause(err) == invalidLabelSpecError
+}
+
+var invalidLabelKeyError = &microerror.Error{
+	Kind: "invalidLabelKeyError",
+}
+
+func IsInvalidLabelKey(err error) bool {
+	return microerror.Cause(err) == invalidLabelKeyError
+}
+
+var invalidLabelValueError = &microerror.Error{
+	Kind: "invalidLabelValueError",
+}
+
+func IsInvalidLabelValue(err error) bool {
+	return microerror.Cause(err) == invalidLabelValueError
+}

--- a/pkg/clusterlabels/labels.go
+++ b/pkg/clusterlabels/labels.go
@@ -1,7 +1,6 @@
 package clusterlabels
 
 import (
-	"fmt"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"strings"
@@ -16,16 +15,16 @@ func Parse(rawLabels []string) (map[string]string, error) {
 	for _, labelSpec := range rawLabels {
 		parts := strings.Split(labelSpec, "=")
 		if len(parts) != 2 {
-			return nil, microerror.Mask(fmt.Errorf("invalid label spec: %v", labelSpec))
+			return nil, microerror.Maskf(invalidLabelSpecError, labelSpec)
 		}
 		if strings.Contains(parts[0], label.ForbiddenLabelKeyPart) {
-			return nil, microerror.Mask(fmt.Errorf("invalid label key: %q: containing forbidden substring '%s'", labelSpec, label.ForbiddenLabelKeyPart))
+			return nil, microerror.Maskf(invalidLabelKeyError, "%q: containing forbidden substring '%s'", labelSpec, label.ForbiddenLabelKeyPart)
 		}
 		if errs := validation.IsQualifiedName(parts[0]); len(errs) != 0 {
-			return nil, microerror.Mask(fmt.Errorf("invalid label key: %q: %s", labelSpec, strings.Join(errs, ";")))
+			return nil, microerror.Maskf(invalidLabelKeyError, "%q: %s", labelSpec, strings.Join(errs, ";"))
 		}
 		if errs := validation.IsValidLabelValue(parts[1]); len(errs) != 0 {
-			return nil, microerror.Mask(fmt.Errorf("invalid label value: %q: %s", labelSpec, strings.Join(errs, ";")))
+			return nil, microerror.Maskf(invalidLabelValueError, "%q: %s", labelSpec, strings.Join(errs, ";"))
 		}
 		labels[parts[0]] = parts[1]
 	}

--- a/pkg/clusterlabels/labels.go
+++ b/pkg/clusterlabels/labels.go
@@ -1,0 +1,36 @@
+package clusterlabels
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"strings"
+
+	"github.com/giantswarm/kubectl-gs/internal/label"
+)
+
+// Logic partially lifted from https://github.com/kubernetes/kubectl/blob/445ad13/pkg/cmd/label/label.go#L400-L425
+// Licensed under Apache-2.0
+func Parse(rawLabels []string) (map[string]string, error) {
+	labels := map[string]string{}
+	for _, labelSpec := range rawLabels {
+		if strings.Contains(labelSpec, "=") {
+			parts := strings.Split(labelSpec, "=")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid label spec: %v", labelSpec)
+			}
+			if strings.Contains(parts[0], label.ForbiddenLabelKeyPart) {
+				return nil, fmt.Errorf("invalid label key: %q: containing forbidden substring '%s'", labelSpec, label.ForbiddenLabelKeyPart)
+			}
+			if errs := validation.IsQualifiedName(parts[0]); len(errs) != 0 {
+				return nil, fmt.Errorf("invalid label key: %q: %s", labelSpec, strings.Join(errs, ";"))
+			}
+			if errs := validation.IsValidLabelValue(parts[1]); len(errs) != 0 {
+				return nil, fmt.Errorf("invalid label value: %q: %s", labelSpec, strings.Join(errs, ";"))
+			}
+			labels[parts[0]] = parts[1]
+		} else {
+			return nil, fmt.Errorf("unknown label spec: %v", labelSpec)
+		}
+	}
+	return labels, nil
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#11403

adds a `--label` flag to the `template cluster` command, which allows to set tenant cluster labels added to the `Cluster` CR.