### PR TITLE
Prepare for krew-release-bot

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gs
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/giantswarm/kubectl-gs
+  shortDescription: Handle custom resources with Giant Swarm
+  description: |
+    Simplifies creating clusters and node pools via Giant Swarm Kubernetes
+    control planes, as well as installing app catalogs and apps.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: "386"
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs_{{ .TagName }}_darwin_386.tar.gz" .TagName }}
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: "386"
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs_{{ .TagName }}_linux_386.tar.gz" .TagName }}
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: ./kubectl-gs


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11783

Goal: Automate Krew plugin updates with https://github.com/rajatjindal/krew-release-bot

Changes

- Add a `.krew.yaml` file, which serves as a template for the Krew plugin manifest
