### PR TITLE
Use 'kubectl gs' as executable name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,11 @@ import (
 )
 
 const (
+	// Hack to set base command name as 'kubectl gs', since
+	// cobra splits all the words in the 'usage' field and
+	// only prints the first word. The splitting is done by
+	// space characters (' '), and we trick it by using a
+	// NBSP character (NBSP) between the 2 words.
 	name        = "kubectl" + string(0xA0) + "gs"
 	description = "Kubectl plugin for Giant Swarm CRs templating"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,14 +4,15 @@ import (
 	"io"
 	"os"
 
-	"github.com/giantswarm/kubectl-gs/cmd/template"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/cmd/template"
 )
 
 const (
-	name        = "kubectl-gs"
+	name        = "kubectl" + string(0xA0) + "gs"
 	description = "Kubectl plugin for Giant Swarm CRs templating"
 )
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/11820

Not pretty. `Cobra` splits the root command's `Use` field by spaces, into multiple words, and only displays the first word.

With this, we're fooling it by using the hex value of a non-breakable space (NBSP char), instead of a regular space character.

## Preview

![image](https://user-images.githubusercontent.com/13508038/86387335-50cc4480-bc93-11ea-8a5b-a118f26073e6.png)
