### PR TITLE
refactor release management

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -21,7 +21,6 @@ const (
 	flagDomain       = "domain"
 	flagMasterAZ     = "master-az"
 	flagName         = "name"
-	flagNoCache      = "no-cache"
 	flagPodsCIDR     = "pods-cidr"
 	flagExternalSNAT = "external-snat"
 	flagOutput       = "output"
@@ -37,7 +36,6 @@ type flag struct {
 	Domain       string
 	MasterAZ     []string
 	Name         string
-	NoCache      bool
 	PodsCIDR     string
 	ExternalSNAT bool
 	Output       string
@@ -54,7 +52,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.ExternalSNAT, flagExternalSNAT, false, "AWS CNI configuration.")
 	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, []string{}, "Tenant master availability zone.")
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Tenant cluster name.")
-	cmd.Flags().BoolVar(&f.NoCache, flagNoCache, false, "Force updating release folder.")
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
@@ -127,9 +124,7 @@ func (f *flag) Validate() error {
 
 	var release *gsrelease.GSRelease
 	{
-		c := gsrelease.Config{
-			NoCache: f.NoCache,
-		}
+		c := gsrelease.Config{}
 
 		release, err = gsrelease.New(c)
 		if err != nil {

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -51,9 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var release *gsrelease.GSRelease
 	{
-		c := gsrelease.Config{
-			NoCache: r.flag.NoCache,
-		}
+		c := gsrelease.Config{}
 
 		release, err = gsrelease.New(c)
 		if err != nil {

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -15,7 +15,6 @@ const (
 	flagAWSInstanceType                     = "aws-instance-type"
 	flagClusterID                           = "cluster-id"
 	flagNodepoolName                        = "nodepool-name"
-	flagNoCache                             = "no-cache"
 	flagNodesMax                            = "nodex-max"
 	flagNodesMin                            = "nodex-min"
 	flagNumAvailabilityZones                = "num-availability-zones"
@@ -32,7 +31,6 @@ type flag struct {
 	AWSInstanceType                     string
 	ClusterID                           string
 	NodepoolName                        string
-	NoCache                             bool
 	NodesMax                            int
 	NodesMin                            int
 	NumAvailabilityZones                int
@@ -49,7 +47,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AWSInstanceType, flagAWSInstanceType, "m5.xlarge", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'.")
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "Tenant cluster ID.")
 	cmd.Flags().StringVar(&f.NodepoolName, flagNodepoolName, "Unnamed node pool", "NodepoolName or purpose description of the node pool.")
-	cmd.Flags().BoolVar(&f.NoCache, flagNoCache, false, "Force updating release folder.")
 	cmd.Flags().IntVar(&f.NodesMax, flagNodesMax, 10, "Maximum number of worker nodes for the node pool.")
 	cmd.Flags().IntVar(&f.NodesMin, flagNodesMin, 3, "Minimum number of worker nodes for the node pool.")
 	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 1, "Number of availability zones to use. Default is 1.")
@@ -132,9 +129,7 @@ func (f *flag) Validate() error {
 
 	var release *gsrelease.GSRelease
 	{
-		c := gsrelease.Config{
-			NoCache: f.NoCache,
-		}
+		c := gsrelease.Config{}
 
 		release, err = gsrelease.New(c)
 		if err != nil {

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -55,9 +55,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var release *gsrelease.GSRelease
 	{
-		c := gsrelease.Config{
-			NoCache: r.flag.NoCache,
-		}
+		c := gsrelease.Config{}
 
 		release, err = gsrelease.New(c)
 		if err != nil {

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -1,7 +1,7 @@
 package key
 
 const AppCRTemplate = `
-{{ .UserConfigConfigMapCR -}}
+{{- .UserConfigConfigMapCR -}}
 ---
 {{ .UserConfigSecretCR -}}
 ---
@@ -9,7 +9,7 @@ const AppCRTemplate = `
 `
 
 const AppCatalogCRTemplate = `
-{{ .ConfigmapCR -}}
+{{- .ConfigmapCR -}}
 ---
 {{ .SecretCR -}}
 ---
@@ -17,7 +17,7 @@ const AppCatalogCRTemplate = `
 `
 
 const ClusterCRsTemplate = `
-{{ .ClusterCR -}}
+{{- .ClusterCR -}}
 ---
 {{ .AWSClusterCR -}}
 ---
@@ -27,7 +27,7 @@ const ClusterCRsTemplate = `
 `
 
 const MachineDeploymentCRsTemplate = `
-{{ .MachineDeploymentCR -}}
+{{- .MachineDeploymentCR -}}
 ---
 {{ .AWSMachineDeploymentCR -}}
 `

--- a/pkg/gsrelease/release.go
+++ b/pkg/gsrelease/release.go
@@ -2,12 +2,8 @@ package gsrelease
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"os/user"
-	"path"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -16,80 +12,40 @@ import (
 )
 
 const (
-	configRelativePath         = ".kube/gs"
-	releasesConfigRelativePath = ".kube/gs/aws.yaml"
-	releasesAWSBaseURL         = "https://raw.githubusercontent.com/giantswarm/releases/master/aws/"
-	releasesConfigURL          = "https://raw.githubusercontent.com/giantswarm/releases/master/aws/kustomization.yaml"
+	defaultBranch = "master"
+)
+
+const (
+	releasesAWSBaseURLFmt   = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/"
+	releasesAWSConfigURLFmt = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/kustomization.yaml"
 )
 
 type Config struct {
-	NoCache bool
-}
-
-type ReleaseListResource struct {
-	ReleaseList []string `yaml:"resources"`
+	Branch string
 }
 
 type GSRelease struct {
 	releases []Release
 }
 
-type Release struct {
-	Kind     string          `json:"kind"`
-	Metadata ReleaseMetadata `json:"metadata"`
-	Spec     ReleaseSpec     `json:"spec"`
-	Version  string          `json:"apiVersion"`
-}
+func New(config Config) (*GSRelease, error) {
+	if config.Branch == "" {
+		config.Branch = defaultBranch
+	}
 
-type ReleaseMetadata struct {
-	Name        string            `json:"name"`
-	Annotations map[string]string `json:"annotations"`
-}
-
-type ReleaseSpec struct {
-	Date       string       `json:"date"`
-	Apps       []Apps       `json:"apps"`
-	Components []Components `json:"components"`
-	State      string       `json:"state"`
-	Version    string       `json:"version"`
-}
-
-type Components struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
-type Apps struct {
-	ComponentVersion string `json:"componentVersion"`
-	Name             string `json:"name"`
-	Version          string `json:"version"`
-}
-
-func New(c Config) (*GSRelease, error) {
-
-	err := ensureConfigDirExists()
+	releases, err := readReleases(config.Branch)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	err = ensureReleasesConfigExists(c.NoCache)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	releases, err := readReleases()
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	newReleases := &GSRelease{
+	g := &GSRelease{
 		releases: releases,
 	}
 
-	return newReleases, nil
+	return g, nil
 }
 
-func (r *GSRelease) ReleaseComponents(version string) map[string]string {
+func (g *GSRelease) ReleaseComponents(version string) map[string]string {
 	var releaseVersion string
 	{
 		if strings.HasPrefix(version, "v") {
@@ -97,12 +53,11 @@ func (r *GSRelease) ReleaseComponents(version string) map[string]string {
 		} else {
 			releaseVersion = fmt.Sprintf("v%s", version)
 		}
-
 	}
 
 	releaseComponents := make(map[string]string)
 
-	for _, release := range r.releases {
+	for _, release := range g.releases {
 		if release.Metadata.Name == releaseVersion {
 			for _, component := range release.Spec.Components {
 				releaseComponents[component.Name] = component.Version
@@ -113,7 +68,7 @@ func (r *GSRelease) ReleaseComponents(version string) map[string]string {
 	return releaseComponents
 }
 
-func (r *GSRelease) Validate(version string) bool {
+func (g *GSRelease) Validate(version string) bool {
 	var releaseVersion string
 	{
 		if strings.HasPrefix(version, "v") {
@@ -124,7 +79,7 @@ func (r *GSRelease) Validate(version string) bool {
 
 	}
 
-	for _, release := range r.releases {
+	for _, release := range g.releases {
 		if release.Metadata.Name == releaseVersion {
 			return true
 		}
@@ -133,80 +88,35 @@ func (r *GSRelease) Validate(version string) bool {
 	return false
 }
 
-func ensureConfigDirExists() error {
-	usr, err := user.Current()
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	configPath := path.Join(usr.HomeDir, configRelativePath)
-
-	_, err = os.Stat(configPath)
-	if os.IsNotExist(err) {
-		err = os.Mkdir(configPath, 0700)
+func readReleases(branch string) ([]Release, error) {
+	var b []byte
+	{
+		resp, err := http.Get(fmt.Sprintf(releasesAWSConfigURLFmt, branch))
 		if err != nil {
-			return microerror.Mask(err)
-		}
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-func ensureReleasesConfigExists(noCache bool) error {
-	usr, err := user.Current()
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	releasesConfigPath := path.Join(usr.HomeDir, releasesConfigRelativePath)
-
-	_, err = os.Stat(releasesConfigPath)
-	if os.IsNotExist(err) || noCache {
-		resp, err := http.Get(releasesConfigURL)
-		if err != nil {
-			return microerror.Mask(err)
+			return nil, microerror.Mask(err)
 		}
 		defer resp.Body.Close()
 
-		out, err := os.Create(releasesConfigPath)
+		b, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return microerror.Mask(err)
+			return nil, microerror.Mask(err)
 		}
-		defer out.Close()
+	}
 
-		_, err = io.Copy(out, resp.Body)
+	r := struct {
+		Resources []string `yaml:"resources"`
+	}{}
+	{
+		err := yaml.Unmarshal(b, &r)
 		if err != nil {
-			return microerror.Mask(err)
+			return nil, microerror.Mask(err)
 		}
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-func readReleases() ([]Release, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	releasesConfigPath := path.Join(usr.HomeDir, releasesConfigRelativePath)
-
-	data, err := ioutil.ReadFile(releasesConfigPath)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	rl := ReleaseListResource{}
-	err = yaml.Unmarshal(data, &rl)
-	if err != nil {
-		return nil, microerror.Mask(err)
 	}
 
 	var releases []Release
 	{
-		for _, rv := range rl.ReleaseList {
-			resp, err := http.Get(releasesAWSBaseURL + rv + "/release.yaml")
+		for _, v := range r.Resources {
+			resp, err := http.Get(fmt.Sprintf(releasesAWSBaseURLFmt, branch) + v + "/release.yaml")
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/pkg/gsrelease/release.go
+++ b/pkg/gsrelease/release.go
@@ -16,8 +16,8 @@ const (
 )
 
 const (
-	releasesAWSBaseURLFmt   = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/"
-	releasesAWSConfigURLFmt = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/kustomization.yaml"
+	releasesAWSIndexURLFmt   = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/kustomization.yaml"
+	releasesAWSReleaseURLFmt = "https://raw.githubusercontent.com/giantswarm/releases/%s/aws/%s/release.yaml"
 )
 
 type Config struct {
@@ -91,7 +91,7 @@ func (g *GSRelease) Validate(version string) bool {
 func readReleases(branch string) ([]Release, error) {
 	var b []byte
 	{
-		resp, err := http.Get(fmt.Sprintf(releasesAWSConfigURLFmt, branch))
+		resp, err := http.Get(fmt.Sprintf(releasesAWSIndexURLFmt, branch))
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -116,7 +116,7 @@ func readReleases(branch string) ([]Release, error) {
 	var releases []Release
 	{
 		for _, v := range r.Resources {
-			resp, err := http.Get(fmt.Sprintf(releasesAWSBaseURLFmt, branch) + v + "/release.yaml")
+			resp, err := http.Get(fmt.Sprintf(releasesAWSReleaseURLFmt, branch, v))
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/pkg/gsrelease/type.go
+++ b/pkg/gsrelease/type.go
@@ -1,0 +1,32 @@
+package gsrelease
+
+type Release struct {
+	Kind     string
+	Metadata ReleaseMetadata
+	Spec     ReleaseSpec
+	Version  string
+}
+
+type ReleaseMetadata struct {
+	Name        string
+	Annotations map[string]string
+}
+
+type ReleaseSpec struct {
+	Date       string
+	Apps       []ReleaseSpecApp
+	Components []ReleaseSpecComponent
+	State      string
+	Version    string
+}
+
+type ReleaseSpecApp struct {
+	ComponentVersion string
+	Name             string
+	Version          string
+}
+
+type ReleaseSpecComponent struct {
+	Name    string
+	Version string
+}


### PR DESCRIPTION
This PR tries to improve the internal Giant Swarm releases management. 

```
$ kubectl-gs template cluster --domain="gauss.eu-central-1.aws.gigantic.io" --master-az="eu-central-1a" --name="xh3b4sd" --owner="giantswarm" --region="eu-central-1" --release="v11.4.1"
apiVersion: cluster.x-k8s.io/v1alpha2
kind: Cluster
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.3.0
    giantswarm.io/cluster: bku53
    giantswarm.io/organization: giantswarm
    release.giantswarm.io/version: v11.4.1
  name: bku53
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSCluster
    name: bku53
    namespace: default
status:
  controlPlaneInitialized: false
  infrastructureReady: false
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSCluster
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.7.1
    giantswarm.io/cluster: bku53
    giantswarm.io/organization: giantswarm
    release.giantswarm.io/version: v11.4.1
  name: bku53
  namespace: default
spec:
  cluster:
    description: xh3b4sd
    dns:
      domain: gauss.eu-central-1.aws.gigantic.io
    kubeProxy: {}
    oidc:
      claims: {}
  provider:
    credentialSecret:
      name: credential-default
      namespace: giantswarm
    master:
      availabilityZone: eu-central-1a
      instanceType: m5.xlarge
    pods:
      externalSNAT: false
    region: eu-central-1
status:
  cluster: {}
  provider:
    network: {}
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: G8sControlPlane
metadata:
  creationTimestamp: null
  labels:
    cluster-operator.giantswarm.io/version: 2.3.0
    giantswarm.io/cluster: bku53
    giantswarm.io/control-plane: 0nzjg
    giantswarm.io/organization: giantswarm
    release.giantswarm.io/version: v11.4.1
  name: 0nzjg
  namespace: default
spec:
  infrastructureRef:
    apiVersion: infrastructure.giantswarm.io/v1alpha2
    kind: AWSControlPlane
    name: 0nzjg
    namespace: default
  replicas: 1
status: {}
---
apiVersion: infrastructure.giantswarm.io/v1alpha2
kind: AWSControlPlane
metadata:
  creationTimestamp: null
  labels:
    aws-operator.giantswarm.io/version: 8.7.1
    giantswarm.io/cluster: bku53
    giantswarm.io/control-plane: 0nzjg
    giantswarm.io/organization: giantswarm
    release.giantswarm.io/version: v11.4.1
  name: 0nzjg
  namespace: default
spec:
  availabilityZones:
  - eu-central-1a
  instanceType: m5.xlarge
```