### PR TITLE
Use the correct binary name in the architect build CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
     jobs:
       - architect/go-build:
           name: go-build
-          binary: kubectl-gigantic
+          binary: kubectl-gs
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
Copy pasta magic 🤦 