### PR TITLE
drop Docker updates for Dependabot due to lack of Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,3 @@ updates:
   - dependency-name: k8s.io/*
     versions:
     - ">=0.17.0"
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  target-branch: master
-  reviewers:
-  - axbarsan
-  - giantswarm/team-firecracker-engineers


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

> Dependabot couldn't update this dependency

https://github.com/giantswarm/kubectl-gs/network/updates/34589830