### PR TITLE
Add flag for toggling debug mode

### DIFF
--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -4,10 +4,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	flagDebugMode = "debug"
+)
+
 type flag struct {
+	debugMode *bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(f.debugMode, flagDebugMode, false, "Toggle debug mode, for seeing full error output.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -5,16 +5,15 @@ import (
 )
 
 const (
-	flagDebugMode = "debug"
+	flagDebug = "debug"
 )
 
 type flag struct {
-	debugMode bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	// This value is ignored. The real value is handled inside 'main.go'.
-	cmd.PersistentFlags().BoolVar(&f.debugMode, flagDebugMode, false, "Toggle debug mode, for seeing full error output.")
+	cmd.PersistentFlags().Bool(flagDebug, false, "Toggle debug mode, for seeing full error output.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -9,11 +9,12 @@ const (
 )
 
 type flag struct {
-	debugMode *bool
+	debugMode bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVar(f.debugMode, flagDebugMode, false, "Toggle debug mode, for seeing full error output.")
+	// This value is ignored. The real value is handled inside 'main.go'.
+	cmd.PersistentFlags().BoolVar(&f.debugMode, flagDebugMode, false, "Toggle debug mode, for seeing full error output.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ type Config struct {
 	Logger     micrologger.Logger
 	FileSystem afero.Fs
 
+	DebugModePtr    *bool
 	K8sConfigAccess clientcmd.ConfigAccess
 
 	Stderr io.Writer
@@ -93,7 +94,9 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
-	f := &flag{}
+	f := &flag{
+		debugMode: config.DebugModePtr,
+	}
 
 	r := &runner{
 		flag:   f,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,6 @@ type Config struct {
 	Logger     micrologger.Logger
 	FileSystem afero.Fs
 
-	DebugModePtr    *bool
 	K8sConfigAccess clientcmd.ConfigAccess
 
 	Stderr io.Writer
@@ -94,9 +93,7 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
-	f := &flag{
-		debugMode: config.DebugModePtr,
-	}
+	f := &flag{}
 
 	r := &runner{
 		flag:   f,

--- a/main.go
+++ b/main.go
@@ -15,14 +15,10 @@ import (
 	"github.com/giantswarm/kubectl-gs/pkg/errorprinter"
 )
 
-var (
-	DebugMode = false
-)
-
 func main() {
 	err := mainE(context.Background())
 	if err != nil {
-		if DebugMode {
+		if isDebugMode() {
 			panic(microerror.JSON(err))
 		} else {
 			ep := errorprinter.New()
@@ -55,8 +51,6 @@ func mainE(ctx context.Context) error {
 			Logger:     logger,
 			FileSystem: fs,
 
-			DebugModePtr: &DebugMode,
-
 			K8sConfigAccess: k8sConfigAccess,
 		}
 
@@ -72,4 +66,14 @@ func mainE(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func isDebugMode() bool {
+	for _, arg := range os.Args {
+		if arg == "--debug" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/main.go
+++ b/main.go
@@ -15,12 +15,20 @@ import (
 	"github.com/giantswarm/kubectl-gs/pkg/errorprinter"
 )
 
+var (
+	DebugMode = false
+)
+
 func main() {
 	err := mainE(context.Background())
 	if err != nil {
-		ep := errorprinter.New()
-		fmt.Print(ep.Format(err))
-		os.Exit(1)
+		if DebugMode {
+			panic(err)
+		} else {
+			ep := errorprinter.New()
+			fmt.Print(ep.Format(err))
+			os.Exit(1)
+		}
 	}
 }
 
@@ -46,6 +54,8 @@ func mainE(ctx context.Context) error {
 		c := cmd.Config{
 			Logger:     logger,
 			FileSystem: fs,
+
+			DebugModePtr: &DebugMode,
 
 			K8sConfigAccess: k8sConfigAccess,
 		}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	err := mainE(context.Background())
 	if err != nil {
 		if DebugMode {
-			panic(err)
+			panic(microerror.JSON(err))
 		} else {
 			ep := errorprinter.New()
 			fmt.Print(ep.Format(err))


### PR DESCRIPTION
Adds a new persistent `--debug` flag. This flag can be used for enabling full error output.

**Debug mode off:**

![image](https://user-images.githubusercontent.com/13508038/87313477-38291d80-c522-11ea-8c66-561c6ece3ae8.png)

**Debug mode on:**

![image](https://user-images.githubusercontent.com/13508038/87313622-70c8f700-c522-11ea-9382-a6d43c7ea4d1.png)
