### PR TITLE
Prevent breaking client's kubeconfig if token renewal fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+- Prevent breaking the client's kubeconfig if token renewal fails.
+
 ## [0.5.3] - 2020-07-13
 
 ## [0.5.2] - 2020-07-03

--- a/pkg/middleware/renewtoken/renewtoken.go
+++ b/pkg/middleware/renewtoken/renewtoken.go
@@ -39,7 +39,10 @@ func Middleware(k8sConfigAccess clientcmd.ConfigAccess) middleware.Middleware {
 		}
 
 		{
-			idToken, rToken, _ := auther.RenewToken(ctx, authProvider.Config["refresh-token"])
+			idToken, rToken, err := auther.RenewToken(ctx, authProvider.Config["refresh-token"])
+			if err != nil {
+				return nil
+			}
 			authProvider.Config["refresh-token"] = rToken
 			authProvider.Config["id-token"] = idToken
 		}


### PR DESCRIPTION
Previously, if the renewal failed, the token will just be replaced with an empty string.