### PR TITLE
Adjust krew index manifest for automatic approval

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,15 +10,21 @@ spec:
     Simplifies creating clusters and node pools via Giant Swarm Kubernetes
     control planes, as well as installing app catalogs and apps.
   platforms:
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
-    bin: ./kubectl-gs-{{ .TagName }}-darwin-amd64/kubectl-gs
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
-    bin: ./kubectl-gs-{{ .TagName }}-linux-amd64/kubectl-gs
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
+      files:
+        - from: ./kubectl-gs-*/*
+          to: .
+      bin: ./kubectl-gs
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
+      files:
+        - from: ./kubectl-gs-*/*
+          to: .
+      bin: ./kubectl-gs


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12197

The way we had before was preventing the [automated PR](https://github.com/kubernetes-sigs/krew-index/pull/701) from being approved automatically