### PR TITLE
Clean up go.mod

### DIFF
--- a/cmd/login/command.go
+++ b/cmd/login/command.go
@@ -39,8 +39,7 @@ You can use as an argument:
   # Or even shorter
   kgs login test
 
-  Note: 'kgs' is an alias for 'kubectl gs'.
-`
+  Note: 'kgs' is an alias for 'kubectl gs'.`
 )
 
 type Config struct {

--- a/go.mod
+++ b/go.mod
@@ -23,28 +23,3 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
 )
-
-replace (
-	k8s.io/api v0.0.0 => k8s.io/api v0.16.6
-	k8s.io/apiextensions-apiserver v0.0.0 => k8s.io/apiextensions-apiserver v0.16.6
-	k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.16.6
-	k8s.io/apiserver v0.0.0 => k8s.io/apiserver v0.16.6
-	k8s.io/cli-runtime v0.0.0 => k8s.io/cli-runtime v0.16.6
-	k8s.io/client-go v0.0.0 => k8s.io/client-go v0.16.6
-	k8s.io/cloud-provider v0.0.0 => k8s.io/cloud-provider v0.16.6
-	k8s.io/cluster-bootstrap v0.0.0 => k8s.io/cluster-bootstrap v0.16.6
-	k8s.io/code-generator v0.0.0 => k8s.io/code-generator v0.16.6
-	k8s.io/component-base v0.0.0 => k8s.io/component-base v0.16.6
-	k8s.io/cri-api v0.0.0 => k8s.io/cri-api v0.16.6
-	k8s.io/csi-translation-lib v0.0.0 => k8s.io/csi-translation-lib v0.16.6
-	k8s.io/kube-aggregator v0.0.0 => k8s.io/kube-aggregator v0.16.6
-	k8s.io/kube-controller-manager v0.0.0 => k8s.io/kube-controller-manager v0.16.6
-	k8s.io/kube-proxy v0.0.0 => k8s.io/kube-proxy v0.16.6
-	k8s.io/kube-scheduler v0.0.0 => k8s.io/kube-scheduler v0.16.6
-	k8s.io/kubectl v0.0.0 => k8s.io/kubectl v0.16.6
-	k8s.io/kubelet v0.0.0 => k8s.io/kubelet v0.16.6
-	k8s.io/legacy-cloud-providers v0.0.0 => k8s.io/legacy-cloud-providers v0.16.6
-	k8s.io/metrics v0.0.0 => k8s.io/metrics v0.16.6
-	k8s.io/sample-apiserver v0.0.0 => k8s.io/sample-apiserver v0.16.6
-
-)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/kubectl-gs
 
-go 1.13
+go 1.14
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible


### PR DESCRIPTION
What's in the box:

* Remove the `replace()` directive from `go.mod`, as we don't need to override any module version (just the fact that `go.sum` is identical after the change proves that)
* Update to `go1.14`
* Remove a newline from the `kgs login` command description.