### PR TITLE
Fix yaml formatting in krew index

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,21 +10,21 @@ spec:
     Simplifies creating clusters and node pools via Giant Swarm Kubernetes
     control planes, as well as installing app catalogs and apps.
   platforms:
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
-      files:
-        - from: ./kubectl-gs-*/*
-          to: .
-      bin: ./kubectl-gs
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
-      files:
-        - from: ./kubectl-gs-*/*
-          to: .
-      bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
+    files:
+    - from: ./kubectl-gs-*/*
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
+    files:
+    - from: ./kubectl-gs-*/*
+      to: .
+    bin: ./kubectl-gs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [0.5.4] - 2020-07-24
-
 ### Fixed
 - Prevent breaking the client's kubeconfig if token renewal fails.
 
@@ -55,8 +53,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.2.0] 2020-04-23
 
 
-[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.4...HEAD
-[0.5.4]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.3...v0.5.4
+[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.3...HEAD
 [0.5.3]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/giantswarm/kubectl-gs/compare/v0.5.0...v0.5.1

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "kubectl-gs"
 	source      = "https://github.com/giantswarm/kubectl-gs"
-	version     = "0.5.5-dev"
+	version     = "0.5.4-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Apparently the previous way of formatting broke the generator

Also undoes the changes made to the changelog and project.go, so we could release the same version again