### PR TITLE
[6/7] get clusters: add commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Implemented support for the `get cluster(s) <id>` command.
+
 ## [0.5.5] - 2020-07-28
 
 ### Fixed

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -20,7 +20,9 @@ const (
 
 	shortDescription = "Display one or many clusters"
 	longDescription  = `Display one or many clusters
+
 Output columns:
+
 - ID: Unique identifier of the cluster.
 - CREATED: Date and time of the Cluster CR creation.
 - CONDITION: Latest condition reported for the cluster. Can be "CREATING", "CREATED", "UPDATING", "UPDATED", "DELETING".

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -32,8 +32,10 @@ Output columns:
 
 	examples = `  # List all clusters you have access to
   kgs get clusters
+  
   # Get one specific cluster by its ID
   kgs get clusters f83ir
+  
   Note: 'kgs' is an alias for 'kubectl gs'.`
 )
 

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -55,7 +55,7 @@ func New(config Config) (*cobra.Command, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
 	}
 	if config.K8sConfigAccess == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigAccess must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
 	}
 	if config.Stderr == nil {
 		config.Stderr = os.Stderr

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -1,0 +1,92 @@
+package clusters
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/giantswarm/kubectl-gs/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
+)
+
+const (
+	name  = "clusters <cluster-id>"
+	alias = "cluster"
+
+	shortDescription = "Display one or many clusters"
+	longDescription  = `Display one or many clusters
+Output columns:
+- ID: Unique identifier of the cluster.
+- CREATED: Date and time of the Cluster CR creation.
+- CONDITION: Latest condition reported for the cluster. Can be "CREATING", "CREATED", "UPDATING", "UPDATED", "DELETING".
+- RELEASE: Release version of the cluster.
+- ORGANIZATION: Organization owning the cluster.
+- DESCRIPTION: User friendly description for the cluster.`
+
+	examples = `  # List all clusters you have access to
+  kgs get clusters
+  # Get one specific cluster by its ID
+  kgs get clusters f83ir
+  Note: 'kgs' is an alias for 'kubectl gs'.`
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	K8sConfigAccess clientcmd.ConfigAccess
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.FileSystem == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
+	}
+	if config.K8sConfigAccess == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigAccess must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		fs:     config.FileSystem,
+
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Short:   shortDescription,
+		Long:    longDescription,
+		Example: examples,
+		Aliases: []string{alias},
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    r.Run,
+		PreRunE: middleware.Compose(
+			renewtoken.Middleware(config.K8sConfigAccess),
+		),
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/get/clusters/error.go
+++ b/cmd/get/clusters/error.go
@@ -1,0 +1,30 @@
+package clusters
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/cmd/get/clusters/flag.go
+++ b/cmd/get/clusters/flag.go
@@ -1,0 +1,25 @@
+package clusters
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type flag struct {
+	config genericclioptions.RESTClientGetter
+	print  *genericclioptions.PrintFlags
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	f.config = genericclioptions.NewConfigFlags(true)
+	f.print = genericclioptions.NewPrintFlags("")
+
+	// Merging current command flags and config flags,
+	// to be able to override kubectl-specific ones.
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+	f.print.AddFlags(cmd)
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -1,0 +1,71 @@
+package clusters
+
+import (
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/giantswarm/kubectl-gs/cmd/get/clusters/provider"
+	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+)
+
+func (r *runner) printOutput(resource runtime.Object) error {
+	var (
+		err     error
+		printer printers.ResourcePrinter
+	)
+
+	switch {
+	case output.IsOutputDefault(r.flag.print.OutputFormat):
+		switch r.provider {
+		case key.ProviderAWS:
+			resource = provider.GetAWSTable(resource)
+		case key.ProviderAzure:
+			resource = provider.GetAzureTable(resource)
+		}
+
+		printOptions := printers.PrintOptions{}
+		printer = printers.NewTablePrinter(printOptions)
+
+	case output.IsOutputName(r.flag.print.OutputFormat):
+		err = output.PrintResourceNames(r.stdout, resource)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+
+	default:
+		printer, err = r.flag.print.ToPrinter()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = printer.PrintObj(resource, r.stdout)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) printNoResourcesOutput() error {
+	_, err := io.WriteString(r.stdout, "No clusters found.\n")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	_, err = io.WriteString(r.stdout, "To create a cluster, please check\n\n")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	_, err = io.WriteString(r.stdout, "  kgs create cluster --help\n")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -1,7 +1,7 @@
 package clusters
 
 import (
-	"io"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,19 +53,8 @@ func (r *runner) printOutput(resource runtime.Object) error {
 	return nil
 }
 
-func (r *runner) printNoResourcesOutput() error {
-	_, err := io.WriteString(r.stdout, "No clusters found.\n")
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	_, err = io.WriteString(r.stdout, "To create a cluster, please check\n\n")
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	_, err = io.WriteString(r.stdout, "  kgs create cluster --help\n")
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
+func (r *runner) printNoResourcesOutput() {
+	fmt.Fprintf(r.stdout, "No clusters found.\n")
+	fmt.Fprintf(r.stdout, "To create a cluster, please check\n\n")
+	fmt.Fprintf(r.stdout, "  kgs create cluster --help\n")
 }

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/kubectl-gs/internal/label"
+)
+
+func GetAWSTable(resource runtime.Object) *metav1.Table {
+	// Creating a custom table resource.
+	table := &metav1.Table{}
+
+	table.ColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "ID", Type: "string"},
+		{Name: "Created", Type: "string", Format: "date-time"},
+		{Name: "Condition", Type: "string"},
+		{Name: "Release", Type: "string"},
+		{Name: "Organization", Type: "string"},
+		{Name: "Description", Type: "string"},
+	}
+
+	switch c := resource.(type) {
+	case *infrastructurev1alpha2.AWSClusterList:
+		for _, cluster := range c.Items {
+			table.Rows = append(table.Rows, getAWSClusterRow(&cluster))
+		}
+
+	case *infrastructurev1alpha2.AWSCluster:
+		table.Rows = append(table.Rows, getAWSClusterRow(c))
+	}
+
+	return table
+}
+
+func getAWSClusterRow(res *infrastructurev1alpha2.AWSCluster) metav1.TableRow {
+	return metav1.TableRow{
+		Cells: []interface{}{
+			res.GetName(),
+			res.CreationTimestamp.UTC(),
+			getLatestAWSCondition(res.Status.Cluster.Conditions),
+			res.Labels[label.ReleaseVersion],
+			res.Labels[label.Organization],
+			res.Spec.Cluster.Description,
+		},
+	}
+}
+
+func getLatestAWSCondition(conditions []infrastructurev1alpha2.CommonClusterStatusCondition) string {
+	if len(conditions) < 1 {
+		return "n/a"
+	}
+
+	condition := conditions[0].Condition
+
+	return formatCondition(condition)
+}

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -52,7 +52,5 @@ func getLatestAWSCondition(conditions []infrastructurev1alpha2.CommonClusterStat
 		return "n/a"
 	}
 
-	condition := conditions[0].Condition
-
-	return formatCondition(condition)
+	return formatCondition(conditions[0].Condition)
 }

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/kubectl-gs/internal/label"
+)
+
+func GetAzureTable(resource runtime.Object) *metav1.Table {
+	// Creating a custom table resource.
+	table := &metav1.Table{}
+
+	table.ColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "ID", Type: "string"},
+		{Name: "Created", Type: "string", Format: "date-time"},
+		{Name: "Condition", Type: "string"},
+		{Name: "Release", Type: "string"},
+		{Name: "Organization", Type: "string"},
+		{Name: "Description", Type: "string"},
+	}
+
+	switch c := resource.(type) {
+	case *capiv1alpha3.ClusterList:
+		for _, cluster := range c.Items {
+			table.Rows = append(table.Rows, getAzureClusterRow(&cluster))
+		}
+
+	case *capiv1alpha3.Cluster:
+		table.Rows = append(table.Rows, getAzureClusterRow(c))
+	}
+
+	return table
+}
+
+func getAzureClusterRow(res *capiv1alpha3.Cluster) metav1.TableRow {
+	return metav1.TableRow{
+		Cells: []interface{}{
+			res.GetName(),
+			res.CreationTimestamp.UTC(),
+			getLatestAzureCondition(res),
+			res.Labels[label.ReleaseVersion],
+			res.Labels[label.Organization],
+			getAzureClusterDescription(res),
+		},
+	}
+}
+
+func getAzureClusterDescription(res *capiv1alpha3.Cluster) string {
+	description := "n/a"
+
+	if desc, exists := res.GetAnnotations()[label.Description]; exists {
+		description = desc
+	}
+
+	return description
+}
+
+func getLatestAzureCondition(res *capiv1alpha3.Cluster) string {
+	condition := ClusterStatusConditionCreating
+
+	if res.Status.InfrastructureReady && res.Status.ControlPlaneInitialized && res.Status.ControlPlaneReady {
+		condition = ClusterStatusConditionCreated
+	}
+
+	return formatCondition(condition)
+}

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/annotation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -51,8 +52,9 @@ func getAzureClusterRow(res *capiv1alpha3.Cluster) metav1.TableRow {
 func getAzureClusterDescription(res *capiv1alpha3.Cluster) string {
 	description := "n/a"
 
-	if desc, exists := res.GetAnnotations()[label.Description]; exists {
-		description = desc
+	annotations := res.GetAnnotations()
+	if annotations != nil && annotations[annotation.ClusterDescription] != "" {
+		description = annotations[annotation.ClusterDescription]
 	}
 
 	return description

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
+	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/internal/label"
 )
 
@@ -58,10 +59,10 @@ func getAzureClusterDescription(res *capiv1alpha3.Cluster) string {
 }
 
 func getLatestAzureCondition(res *capiv1alpha3.Cluster) string {
-	condition := ClusterStatusConditionCreating
+	condition := key.ClusterStatusConditionCreating
 
 	if res.Status.InfrastructureReady && res.Status.ControlPlaneInitialized && res.Status.ControlPlaneReady {
-		condition = ClusterStatusConditionCreated
+		condition = key.ClusterStatusConditionCreated
 	}
 
 	return formatCondition(condition)

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -1,0 +1,20 @@
+package provider
+
+import (
+	"strings"
+)
+
+const (
+	ClusterStatusConditionCreated  = "Created"
+	ClusterStatusConditionCreating = "Creating"
+
+	ClusterStatusConditionDeleted  = "Deleted"
+	ClusterStatusConditionDeleting = "Deleting"
+
+	ClusterStatusConditionUpdated  = "Updated"
+	ClusterStatusConditionUpdating = "Updating"
+)
+
+func formatCondition(condition string) string {
+	return strings.ToUpper(condition)
+}

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -4,17 +4,6 @@ import (
 	"strings"
 )
 
-const (
-	ClusterStatusConditionCreated  = "Created"
-	ClusterStatusConditionCreating = "Creating"
-
-	ClusterStatusConditionDeleted  = "Deleted"
-	ClusterStatusConditionDeleting = "Deleting"
-
-	ClusterStatusConditionUpdated  = "Updated"
-	ClusterStatusConditionUpdating = "Updating"
-)
-
 func formatCondition(condition string) string {
 	return strings.ToUpper(condition)
 }

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -1,0 +1,123 @@
+package clusters
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	fs     afero.Fs
+
+	provider string
+	service  cluster.Interface
+
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	config := commonconfig.New(r.flag.config)
+	{
+		if r.provider == "" {
+			r.provider, err = config.GetProvider()
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		err = r.getService(config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var resource runtime.Object
+	{
+		options := cluster.GetOptions{
+			Provider: r.provider,
+		}
+		{
+			if len(args) > 0 {
+				options.ID = strings.ToLower(args[0])
+			}
+			if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
+				options.Namespace = *cf.Namespace
+			}
+		}
+
+		resource, err = r.service.Get(ctx, options)
+		if cluster.IsNotFound(err) {
+			return microerror.Maskf(notFoundError, fmt.Sprintf("A cluster with ID '%s' cannot be found.\n", options.ID))
+		} else if cluster.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
+			pErr := r.printNoResourcesOutput()
+			if pErr != nil {
+				return microerror.Mask(err)
+			}
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = r.printOutput(resource)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) getService(config *commonconfig.CommonConfig) error {
+	if r.service != nil {
+		return nil
+	}
+
+	client, err := config.GetClient(r.logger)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	serviceConfig := cluster.Config{
+		Client: client,
+	}
+	r.service, err = cluster.New(serviceConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -82,10 +82,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if cluster.IsNotFound(err) {
 			return microerror.Maskf(notFoundError, fmt.Sprintf("A cluster with ID '%s' cannot be found.\n", options.ID))
 		} else if cluster.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
-			pErr := r.printNoResourcesOutput()
-			if pErr != nil {
-				return microerror.Mask(err)
-			}
+			r.printNoResourcesOutput()
 
 			return nil
 		} else if err != nil {

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -36,7 +36,7 @@ func New(config Config) (*cobra.Command, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
 	}
 	if config.K8sConfigAccess == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigAccess must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
 	}
 	if config.Stderr == nil {
 		config.Stderr = os.Stderr

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -1,0 +1,89 @@
+package get
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/giantswarm/kubectl-gs/cmd/get/clusters"
+)
+
+const (
+	name        = "get"
+	description = "Get various types of resources."
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	K8sConfigAccess clientcmd.ConfigAccess
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.FileSystem == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
+	}
+	if config.K8sConfigAccess == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigAccess must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	var err error
+
+	var clustersCmd *cobra.Command
+	{
+		c := clusters.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			K8sConfigAccess: config.K8sConfigAccess,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		clustersCmd, err = clusters.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:   name,
+		Short: description,
+		Long:  description,
+		RunE:  r.Run,
+	}
+
+	f.Init(c)
+
+	c.AddCommand(clustersCmd)
+
+	return c, nil
+}

--- a/cmd/get/error.go
+++ b/cmd/get/error.go
@@ -1,0 +1,21 @@
+package get
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/get/flag.go
+++ b/cmd/get/flag.go
@@ -1,0 +1,13 @@
+package get
+
+import "github.com/spf13/cobra"
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/get/runner.go
+++ b/cmd/get/runner.go
@@ -1,0 +1,42 @@
+package get
+
+import (
+	"context"
+	"io"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	err := cmd.Help()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/giantswarm/kubectl-gs/cmd/get"
 	"github.com/giantswarm/kubectl-gs/cmd/login"
 	"github.com/giantswarm/kubectl-gs/cmd/template"
 )
@@ -93,6 +94,24 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var getCmd *cobra.Command
+	{
+		c := get.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			K8sConfigAccess: config.K8sConfigAccess,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		getCmd, err = get.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -121,6 +140,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	c.AddCommand(loginCmd)
 	c.AddCommand(templateCmd)
+	c.AddCommand(getCmd)
 
 	return c, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/fatih/color v1.9.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/giantswarm/apiextensions v0.4.18
+	github.com/giantswarm/apiextensions v0.4.19
 	github.com/giantswarm/k8sclient/v3 v3.1.2
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/micrologger v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions v0.4.15/go.mod h1:iMZLjyvqRIVPTAQGbjwTSqifwrGB41a4mW8MwC45mYI=
-github.com/giantswarm/apiextensions v0.4.18 h1:a7/EVxZvEDTfegWBZk5+TR3y8txRkleRkr0wz59PEPI=
-github.com/giantswarm/apiextensions v0.4.18/go.mod h1:dOiXE5ZQDN1vDpZjcCgKhPN/Id8BQKlI7mqYyn+mCJk=
+github.com/giantswarm/apiextensions v0.4.19 h1:NLkjdZWTlkatvzT6H9HHdsRfWiifzctVwrNpBkRmUrM=
+github.com/giantswarm/apiextensions v0.4.19/go.mod h1:dOiXE5ZQDN1vDpZjcCgKhPN/Id8BQKlI7mqYyn+mCJk=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/k8sclient/v3 v3.1.2 h1:/X1OqiWDm+4IjZn3HYkTJbNkqH6/T9j+lJfZRQ4R30A=

--- a/internal/key/conditions.go
+++ b/internal/key/conditions.go
@@ -1,0 +1,12 @@
+package key
+
+const (
+	ClusterStatusConditionCreated  = "Created"
+	ClusterStatusConditionCreating = "Creating"
+
+	ClusterStatusConditionDeleted  = "Deleted"
+	ClusterStatusConditionDeleting = "Deleting"
+
+	ClusterStatusConditionUpdated  = "Updated"
+	ClusterStatusConditionUpdating = "Updating"
+)

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -11,7 +11,6 @@ const (
 	Organization      = "giantswarm.io/organization"
 	Provider          = "giantswarm.io/provider"
 	VersionBundle     = "giantswarm.io/version-bundle"
-	Description       = "cluster.giantswarm.io/description"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/giantswarm/kubectl-gs/cmd"
 	"github.com/giantswarm/kubectl-gs/pkg/errorprinter"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func main() {

--- a/pkg/data/domain/cluster/azure.go
+++ b/pkg/data/domain/cluster/azure.go
@@ -2,15 +2,11 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/giantswarm/kubectl-gs/internal/label"
 )
 
 func (s *Service) getAllAzure(ctx context.Context, namespace string) (*capiv1alpha3.ClusterList, error) {
@@ -27,30 +23,6 @@ func (s *Service) getAllAzure(ctx context.Context, namespace string) (*capiv1alp
 			return nil, microerror.Mask(err)
 		} else if len(clusterList.Items) == 0 {
 			return nil, microerror.Mask(noResourcesError)
-		}
-	}
-
-	var objKey runtimeClient.ObjectKey
-	for _, cluster := range clusterList.Items {
-		// FIXME(axbarsan): Remove once the name is stored in
-		// an annotation, rather than a config map.
-		var config corev1.ConfigMap
-		{
-			objKey = runtimeClient.ObjectKey{
-				Name:      fmt.Sprintf("%s-cluster-user-values", cluster.Name),
-				Namespace: cluster.Namespace,
-			}
-			err = s.client.K8sClient.CtrlClient().Get(ctx, objKey, &config)
-			if errors.IsNotFound(err) {
-				// Fall through.
-			} else if err != nil {
-				return nil, microerror.Mask(err)
-			} else {
-				if cluster.Annotations == nil {
-					cluster.Annotations = make(map[string]string)
-				}
-				cluster.Annotations[label.Description] = config.Data["cluster.description"]
-			}
 		}
 	}
 
@@ -78,27 +50,6 @@ func (s *Service) getByIdAzure(ctx context.Context, id, namespace string) (*capi
 		return nil, microerror.Mask(notFoundError)
 	} else if err != nil {
 		return nil, microerror.Mask(err)
-	}
-
-	// FIXME(axbarsan): Remove once the name is stored in
-	// an annotation, rather than a config map.
-	var config corev1.ConfigMap
-	{
-		objKey = runtimeClient.ObjectKey{
-			Name:      fmt.Sprintf("%s-cluster-user-values", id),
-			Namespace: namespace,
-		}
-		err = s.client.K8sClient.CtrlClient().Get(ctx, objKey, &config)
-		if errors.IsNotFound(err) {
-			// Fall through.
-		} else if err != nil {
-			return nil, microerror.Mask(err)
-		} else {
-			if cluster.Annotations == nil {
-				cluster.Annotations = make(map[string]string)
-			}
-			cluster.Annotations[label.Description] = config.Data["cluster.description"]
-		}
 	}
 
 	{


### PR DESCRIPTION
Part of the huge `get clusters` [PR](https://github.com/giantswarm/kubectl-gs/pull/100)

This PR:
* adds the main `get *` command
* adds the `get cluster(s)` command
* azure v5: use annotations for cluster descriptions (thanks to https://github.com/giantswarm/giantswarm/issues/12363)

Tests are coming in PR 7/7.


## Preview (taken from original PR)

<details><summary>Get clusters</summary>

![image](https://user-images.githubusercontent.com/13508038/87782006-040b7080-c832-11ea-9221-2060eb9078f8.png)

</details>

<details><summary>Get cluster by ID</summary>

![image](https://user-images.githubusercontent.com/13508038/87782044-1685aa00-c832-11ea-9d33-cbd484fd5d1d.png)

</details>

<details><summary>Get clusters, no clusters available</summary>

![image](https://user-images.githubusercontent.com/13508038/87782090-28674d00-c832-11ea-8e46-c0414baedc9f.png)

</details>

<details><summary>Get clusters by ID, no cluster found</summary>

![image](https://user-images.githubusercontent.com/13508038/87782276-8300a900-c832-11ea-9da7-e5c158dde710.png)

</details>

<details><summary>Help</summary>

![image](https://user-images.githubusercontent.com/13508038/87782330-9b70c380-c832-11ea-8299-0f44e2ee6d98.png)

</details>