### PR TITLE
[7/7] get clusters: add command tests

### DIFF
--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -336,6 +336,7 @@ func newAzureCluster(id, created, release, org, description string, conditions [
 func Test_printNoResourcesOutput(t *testing.T) {
 	expected := `No clusters found.
 To create a cluster, please check
+
   kgs create cluster --help
 `
 	out := new(bytes.Buffer)

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -1,0 +1,350 @@
+package clusters
+
+import (
+	"bytes"
+	goflag "flag"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/annotation"
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/internal/label"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+)
+
+var update = goflag.Bool("update", false, "update .golden reference test files")
+
+// Test_printOutput uses golden files.
+//
+//  go test ./cmd/get/clusters -run Test_printOutput -update
+//
+func Test_printOutput(t *testing.T) {
+	testCases := []struct {
+		name               string
+		cr                 runtime.Object
+		provider           string
+		outputType         string
+		expectedGoldenFile string
+	}{
+		{
+			name: "case 0: print list of AWS clusters, with table output",
+			cr: newAWSClusterList(
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_list_of_aws_clusters_table_output.golden",
+		},
+		{
+			name: "case 1: print list of AWS clusters, with JSON output",
+			cr: newAWSClusterList(
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_list_of_aws_clusters_json_output.golden",
+		},
+		{
+			name: "case 2: print list of AWS clusters, with YAML output",
+			cr: newAWSClusterList(
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_list_of_aws_clusters_yaml_output.golden",
+		},
+		{
+			name: "case 3: print list of AWS clusters, with name output",
+			cr: newAWSClusterList(
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_list_of_aws_clusters_name_output.golden",
+		},
+		{
+			name:               "case 4: print single AWS cluster, with table output",
+			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_single_aws_cluster_table_output.golden",
+		},
+		{
+			name:               "case 5: print single AWS cluster, with JSON output",
+			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_single_aws_cluster_json_output.golden",
+		},
+		{
+			name:               "case 6: print single AWS cluster, with YAML output",
+			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_single_aws_cluster_yaml_output.golden",
+		},
+		{
+			name:               "case 7: print single AWS cluster, with name output",
+			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAWS,
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_single_aws_cluster_name_output.golden",
+		},
+		{
+			name: "case 8: print list of Azure clusters, with table output",
+			cr: newAzureClusterList(
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_list_of_azure_clusters_table_output.golden",
+		},
+		{
+			name: "case 9: print list of Azure clusters, with JSON output",
+			cr: newAzureClusterList(
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_list_of_azure_clusters_json_output.golden",
+		},
+		{
+			name: "case 10: print list of Azure clusters, with YAML output",
+			cr: newAzureClusterList(
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_list_of_azure_clusters_yaml_output.golden",
+		},
+		{
+			name: "case 11: print list of Azure clusters, with name output",
+			cr: newAzureClusterList(
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha2.ClusterStatusConditionDeleting, infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_list_of_azure_clusters_name_output.golden",
+		},
+		{
+			name:               "case 12: print single Azure cluster, with table output",
+			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_single_azure_cluster_table_output.golden",
+		},
+		{
+			name:               "case 13: print single Azure cluster, with JSON output",
+			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_single_azure_cluster_json_output.golden",
+		},
+		{
+			name:               "case 14: print single Azure cluster, with YAML output",
+			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_single_azure_cluster_yaml_output.golden",
+		},
+		{
+			name:               "case 15: print single Azure cluster, with name output",
+			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			provider:           key.ProviderAzure,
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_single_azure_cluster_name_output.golden",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := &flag{
+				print: genericclioptions.NewPrintFlags("").WithDefaultOutput(tc.outputType),
+			}
+			out := new(bytes.Buffer)
+			runner := &runner{
+				flag:     flag,
+				stdout:   out,
+				provider: tc.provider,
+			}
+
+			err := runner.printOutput(tc.cr)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			var expectedResult []byte
+			{
+				gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+				if *update {
+					err = gf.Update(out.Bytes())
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+					expectedResult = out.Bytes()
+				} else {
+					expectedResult, err = gf.Read()
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+				}
+			}
+
+			diff := cmp.Diff(string(expectedResult), out.String())
+			if diff != "" {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
+		})
+	}
+}
+
+func newAWSClusterList(clusters ...infrastructurev1alpha2.AWSCluster) *infrastructurev1alpha2.AWSClusterList {
+	clusterList := &infrastructurev1alpha2.AWSClusterList{}
+
+	clusterList.Items = clusters
+	clusterList.APIVersion = "v1"
+	clusterList.Kind = "List"
+
+	return clusterList
+}
+
+func newAWSCluster(id, created, release, org, description string, conditions []string) *infrastructurev1alpha2.AWSCluster {
+	location, _ := time.LoadLocation("UTC")
+	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
+	c := &infrastructurev1alpha2.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              id,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(parsedCreationDate),
+			Labels: map[string]string{
+				label.ReleaseVersion: release,
+				label.Organization:   org,
+			},
+		},
+		Spec: infrastructurev1alpha2.AWSClusterSpec{
+			Cluster: infrastructurev1alpha2.AWSClusterSpecCluster{
+				Description: description,
+			},
+		},
+	}
+	for _, condition := range conditions {
+		c.Status.Cluster.Conditions = append(c.Status.Cluster.Conditions, infrastructurev1alpha2.CommonClusterStatusCondition{
+			Condition: condition,
+		})
+	}
+
+	c.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   infrastructurev1alpha2.SchemeGroupVersion.Group,
+		Version: infrastructurev1alpha2.SchemeGroupVersion.Version,
+		Kind:    infrastructurev1alpha2.NewAWSClusterTypeMeta().Kind,
+	})
+
+	return c
+}
+
+func newAzureClusterList(clusters ...capiv1alpha3.Cluster) *capiv1alpha3.ClusterList {
+	clusterList := &capiv1alpha3.ClusterList{}
+
+	clusterList.Items = clusters
+	clusterList.APIVersion = "v1"
+	clusterList.Kind = "List"
+
+	return clusterList
+}
+
+func newAzureCluster(id, created, release, org, description string, conditions []string) *capiv1alpha3.Cluster {
+	location, _ := time.LoadLocation("UTC")
+	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
+	c := &capiv1alpha3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              id,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(parsedCreationDate),
+			Labels: map[string]string{
+				label.ReleaseVersion: release,
+				label.Organization:   org,
+			},
+			Annotations: map[string]string{
+				annotation.ClusterDescription: description,
+			},
+		},
+	}
+
+	if len(conditions) > 0 && conditions[0] == "Created" {
+		c.Status.InfrastructureReady = true
+		c.Status.ControlPlaneInitialized = true
+		c.Status.ControlPlaneReady = true
+	}
+
+	{
+		c.APIVersion = "v1alpha3"
+		c.Kind = "Cluster"
+	}
+
+	return c
+}
+
+func Test_printNoResourcesOutput(t *testing.T) {
+	expected := `No clusters found.
+To create a cluster, please check
+  kgs create cluster --help
+`
+	out := new(bytes.Buffer)
+	runner := &runner{
+		stdout: out,
+	}
+	runner.printNoResourcesOutput()
+
+	if out.String() != expected {
+		t.Fatalf("value not expected, got:\n %s", out.String())
+	}
+}

--- a/cmd/get/clusters/runner_test.go
+++ b/cmd/get/clusters/runner_test.go
@@ -1,0 +1,121 @@
+package clusters
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
+)
+
+// Test_run uses golden files.
+//
+//  go test ./cmd/get/clusters -run Test_run -update
+//
+func Test_run(t *testing.T) {
+	testCases := []struct {
+		name               string
+		storage            []runtime.Object
+		args               []string
+		expectedGoldenFile string
+		errorMatcher       func(error) bool
+	}{
+		{
+			name: "case 0: get clusters",
+			storage: []runtime.Object{
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
+				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
+				newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+			},
+			args:               nil,
+			expectedGoldenFile: "run_get_clusters.golden",
+		},
+		{
+			name:               "case 1: get clusters, with empty storage",
+			storage:            nil,
+			args:               nil,
+			expectedGoldenFile: "run_get_clusters_empty_storage.golden",
+		},
+		{
+			name: "case 2: get cluster by id",
+			storage: []runtime.Object{
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
+				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
+				newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+			},
+			args:               []string{"f930q"},
+			expectedGoldenFile: "run_get_cluster_by_id.golden",
+		},
+		{
+			name:         "case 3: get cluster by id, with empty storage",
+			storage:      nil,
+			args:         []string{"f930q"},
+			errorMatcher: IsNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			fakeKubeConfig := kubeconfig.CreateFakeKubeConfig()
+			flag := &flag{
+				print:  genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault),
+				config: genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig),
+			}
+			out := new(bytes.Buffer)
+			runner := &runner{
+				service:  cluster.NewFakeService(tc.storage),
+				flag:     flag,
+				stdout:   out,
+				provider: key.ProviderAWS,
+			}
+
+			err := runner.run(ctx, nil, tc.args)
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
+				}
+
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			var expectedResult []byte
+			{
+				gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+				if *update {
+					err = gf.Update(out.Bytes())
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+					expectedResult = out.Bytes()
+				} else {
+					expectedResult, err = gf.Read()
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+				}
+			}
+
+			diff := cmp.Diff(string(expectedResult), out.String())
+			if diff != "" {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/get/clusters/runner_test.go
+++ b/cmd/get/clusters/runner_test.go
@@ -65,6 +65,16 @@ func Test_run(t *testing.T) {
 			args:         []string{"f930q"},
 			errorMatcher: IsNotFound,
 		},
+		{
+			name: "case 4: get cluster by id, with no infrastructure cluster",
+			storage: []runtime.Object{
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
+				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
+			},
+			args:         []string{"f930q"},
+			errorMatcher: IsNotFound,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
@@ -1,0 +1,301 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "1sad2",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "12.0.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 1",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {},
+                "provider": {
+                    "network": {}
+                }
+            }
+        },
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "2a03f",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "11.0.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 2",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {
+                    "conditions": [
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Created"
+                        }
+                    ]
+                },
+                "provider": {
+                    "network": {}
+                }
+            }
+        },
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "asd29",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "10.5.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 3",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {
+                    "conditions": [
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Created"
+                        },
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Creating"
+                        }
+                    ]
+                },
+                "provider": {
+                    "network": {}
+                }
+            }
+        },
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "f930q",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "some-other",
+                    "release.giantswarm.io/version": "11.0.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 4",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {},
+                "provider": {
+                    "network": {}
+                }
+            }
+        },
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "9f012",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "9.0.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 5",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {
+                    "conditions": [
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Deleting"
+                        }
+                    ]
+                },
+                "provider": {
+                    "network": {}
+                }
+            }
+        },
+        {
+            "kind": "AWSCluster",
+            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "metadata": {
+                "name": "2f0as",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "random",
+                    "release.giantswarm.io/version": "10.5.0"
+                }
+            },
+            "spec": {
+                "cluster": {
+                    "description": "test cluster 6",
+                    "dns": {
+                        "domain": ""
+                    },
+                    "kubeProxy": {},
+                    "oidc": {
+                        "claims": {}
+                    }
+                },
+                "provider": {
+                    "credentialSecret": {
+                        "name": "",
+                        "namespace": ""
+                    },
+                    "master": {
+                        "availabilityZone": "",
+                        "instanceType": ""
+                    },
+                    "pods": {},
+                    "region": ""
+                }
+            },
+            "status": {
+                "cluster": {
+                    "conditions": [
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Deleting"
+                        },
+                        {
+                            "lastTransitionTime": null,
+                            "condition": "Created"
+                        }
+                    ]
+                },
+                "provider": {
+                    "network": {}
+                }
+            }
+        }
+    ]
+}

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_name_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_name_output.golden
@@ -1,0 +1,6 @@
+awscluster.infrastructure.giantswarm.io/1sad2
+awscluster.infrastructure.giantswarm.io/2a03f
+awscluster.infrastructure.giantswarm.io/asd29
+awscluster.infrastructure.giantswarm.io/f930q
+awscluster.infrastructure.giantswarm.io/9f012
+awscluster.infrastructure.giantswarm.io/2f0as

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
@@ -1,0 +1,7 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+1sad2   2021-01-02 15:04:32 +0000 UTC   n/a         12.0.0    test           test cluster 1
+2a03f   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    test           test cluster 2
+asd29   2021-01-02 15:04:32 +0000 UTC   CREATED     10.5.0    test           test cluster 3
+f930q   2021-01-02 15:04:32 +0000 UTC   n/a         11.0.0    some-other     test cluster 4
+9f012   2021-01-02 15:04:32 +0000 UTC   DELETING    9.0.0     test           test cluster 5
+2f0as   2021-01-02 15:04:32 +0000 UTC   DELETING    10.5.0    random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
@@ -1,0 +1,200 @@
+apiVersion: v1
+items:
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 12.0.0
+    name: 1sad2
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 1
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster: {}
+    provider:
+      network: {}
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 11.0.0
+    name: 2a03f
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 2
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster:
+      conditions:
+      - condition: Created
+        lastTransitionTime: null
+    provider:
+      network: {}
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 10.5.0
+    name: asd29
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 3
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster:
+      conditions:
+      - condition: Created
+        lastTransitionTime: null
+      - condition: Creating
+        lastTransitionTime: null
+    provider:
+      network: {}
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: some-other
+      release.giantswarm.io/version: 11.0.0
+    name: f930q
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 4
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster: {}
+    provider:
+      network: {}
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 9.0.0
+    name: 9f012
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 5
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster:
+      conditions:
+      - condition: Deleting
+        lastTransitionTime: null
+    provider:
+      network: {}
+- apiVersion: infrastructure.giantswarm.io/v1alpha2
+  kind: AWSCluster
+  metadata:
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: random
+      release.giantswarm.io/version: 10.5.0
+    name: 2f0as
+    namespace: default
+  spec:
+    cluster:
+      description: test cluster 6
+      dns:
+        domain: ""
+      kubeProxy: {}
+      oidc:
+        claims: {}
+    provider:
+      credentialSecret:
+        name: ""
+        namespace: ""
+      master:
+        availabilityZone: ""
+        instanceType: ""
+      pods: {}
+      region: ""
+  status:
+    cluster:
+      conditions:
+      - condition: Deleting
+        lastTransitionTime: null
+      - condition: Created
+        lastTransitionTime: null
+    provider:
+      network: {}
+kind: List
+metadata: {}

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
@@ -1,0 +1,165 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "1sad2",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "12.0.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 1"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
+            }
+        },
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "2a03f",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "11.0.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 2"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": true,
+                "controlPlaneInitialized": true,
+                "controlPlaneReady": true
+            }
+        },
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "asd29",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "10.5.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 3"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": true,
+                "controlPlaneInitialized": true,
+                "controlPlaneReady": true
+            }
+        },
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "f930q",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "some-other",
+                    "release.giantswarm.io/version": "11.0.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 4"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
+            }
+        },
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "9f012",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "test",
+                    "release.giantswarm.io/version": "9.0.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 5"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
+            }
+        },
+        {
+            "kind": "Cluster",
+            "apiVersion": "v1alpha3",
+            "metadata": {
+                "name": "2f0as",
+                "namespace": "default",
+                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "labels": {
+                    "giantswarm.io/organization": "random",
+                    "release.giantswarm.io/version": "10.5.0"
+                },
+                "annotations": {
+                    "cluster.giantswarm.io/description": "test cluster 6"
+                }
+            },
+            "spec": {
+                "controlPlaneEndpoint": {
+                    "host": "",
+                    "port": 0
+                }
+            },
+            "status": {
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
+            }
+        }
+    ]
+}

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_name_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_name_output.golden
@@ -1,0 +1,6 @@
+cluster/1sad2
+cluster/2a03f
+cluster/asd29
+cluster/f930q
+cluster/9f012
+cluster/2f0as

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
@@ -1,0 +1,7 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+1sad2   2021-01-02 15:04:32 +0000 UTC   CREATING    12.0.0    test           test cluster 1
+2a03f   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    test           test cluster 2
+asd29   2021-01-02 15:04:32 +0000 UTC   CREATED     10.5.0    test           test cluster 3
+f930q   2021-01-02 15:04:32 +0000 UTC   CREATING    11.0.0    some-other     test cluster 4
+9f012   2021-01-02 15:04:32 +0000 UTC   CREATING    9.0.0     test           test cluster 5
+2f0as   2021-01-02 15:04:32 +0000 UTC   CREATING    10.5.0    random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
@@ -1,0 +1,114 @@
+apiVersion: v1
+items:
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 1
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 12.0.0
+    name: 1sad2
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 2
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 11.0.0
+    name: 2a03f
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: true
+    controlPlaneReady: true
+    infrastructureReady: true
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 3
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 10.5.0
+    name: asd29
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: true
+    controlPlaneReady: true
+    infrastructureReady: true
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 4
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: some-other
+      release.giantswarm.io/version: 11.0.0
+    name: f930q
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 5
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: test
+      release.giantswarm.io/version: 9.0.0
+    name: 9f012
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: v1alpha3
+  kind: Cluster
+  metadata:
+    annotations:
+      cluster.giantswarm.io/description: test cluster 6
+    creationTimestamp: "2021-01-02T15:04:32Z"
+    labels:
+      giantswarm.io/organization: random
+      release.giantswarm.io/version: 10.5.0
+    name: 2f0as
+    namespace: default
+  spec:
+    controlPlaneEndpoint:
+      host: ""
+      port: 0
+  status:
+    controlPlaneInitialized: false
+    infrastructureReady: false
+kind: List
+metadata: {}

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
@@ -1,0 +1,50 @@
+{
+    "kind": "AWSCluster",
+    "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+    "metadata": {
+        "name": "f930q",
+        "namespace": "default",
+        "creationTimestamp": "2021-01-02T15:04:32Z",
+        "labels": {
+            "giantswarm.io/organization": "some-other",
+            "release.giantswarm.io/version": "11.0.0"
+        }
+    },
+    "spec": {
+        "cluster": {
+            "description": "test cluster 4",
+            "dns": {
+                "domain": ""
+            },
+            "kubeProxy": {},
+            "oidc": {
+                "claims": {}
+            }
+        },
+        "provider": {
+            "credentialSecret": {
+                "name": "",
+                "namespace": ""
+            },
+            "master": {
+                "availabilityZone": "",
+                "instanceType": ""
+            },
+            "pods": {},
+            "region": ""
+        }
+    },
+    "status": {
+        "cluster": {
+            "conditions": [
+                {
+                    "lastTransitionTime": null,
+                    "condition": "Created"
+                }
+            ]
+        },
+        "provider": {
+            "network": {}
+        }
+    }
+}

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_name_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_name_output.golden
@@ -1,0 +1,1 @@
+awscluster.infrastructure.giantswarm.io/f930q

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
@@ -1,0 +1,2 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+f930q   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
@@ -1,0 +1,33 @@
+apiVersion: infrastructure.giantswarm.io/v1alpha2
+kind: AWSCluster
+metadata:
+  creationTimestamp: "2021-01-02T15:04:32Z"
+  labels:
+    giantswarm.io/organization: some-other
+    release.giantswarm.io/version: 11.0.0
+  name: f930q
+  namespace: default
+spec:
+  cluster:
+    description: test cluster 4
+    dns:
+      domain: ""
+    kubeProxy: {}
+    oidc:
+      claims: {}
+  provider:
+    credentialSecret:
+      name: ""
+      namespace: ""
+    master:
+      availabilityZone: ""
+      instanceType: ""
+    pods: {}
+    region: ""
+status:
+  cluster:
+    conditions:
+    - condition: Created
+      lastTransitionTime: null
+  provider:
+    network: {}

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
@@ -1,0 +1,27 @@
+{
+    "kind": "Cluster",
+    "apiVersion": "v1alpha3",
+    "metadata": {
+        "name": "f930q",
+        "namespace": "default",
+        "creationTimestamp": "2021-01-02T15:04:32Z",
+        "labels": {
+            "giantswarm.io/organization": "some-other",
+            "release.giantswarm.io/version": "11.0.0"
+        },
+        "annotations": {
+            "cluster.giantswarm.io/description": "test cluster 4"
+        }
+    },
+    "spec": {
+        "controlPlaneEndpoint": {
+            "host": "",
+            "port": 0
+        }
+    },
+    "status": {
+        "infrastructureReady": true,
+        "controlPlaneInitialized": true,
+        "controlPlaneReady": true
+    }
+}

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_name_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_name_output.golden
@@ -1,0 +1,1 @@
+cluster/f930q

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
@@ -1,0 +1,2 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+f930q   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
@@ -1,0 +1,19 @@
+apiVersion: v1alpha3
+kind: Cluster
+metadata:
+  annotations:
+    cluster.giantswarm.io/description: test cluster 4
+  creationTimestamp: "2021-01-02T15:04:32Z"
+  labels:
+    giantswarm.io/organization: some-other
+    release.giantswarm.io/version: 11.0.0
+  name: f930q
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+status:
+  controlPlaneInitialized: true
+  controlPlaneReady: true
+  infrastructureReady: true

--- a/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
+++ b/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
@@ -1,0 +1,2 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+f930q   2021-01-02 15:04:32 +0000 UTC   n/a         11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_clusters.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters.golden
@@ -1,0 +1,3 @@
+ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+1sad2   2021-01-01 15:04:32 +0000 UTC   n/a         10.5.0    some-org       test cluster 3
+f930q   2021-01-02 15:04:32 +0000 UTC   n/a         11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_clusters_empty_storage.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters_empty_storage.golden
@@ -1,0 +1,4 @@
+No clusters found.
+To create a cluster, please check
+
+  kgs create cluster --help


### PR DESCRIPTION
Part of the huge `get clusters` [PR](https://github.com/giantswarm/kubectl-gs/pull/100)

This adds goldenfile tests for the output printing, and the runner.
