### PR TITLE
Add the '--version' flag for getting the current version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Added
+- Add the `--version` flag for printing the current version. Run `kgs --version` to check which version you're running.
+
 ## [0.6.0] - 2020-08-11
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/kubectl-gs/cmd/get"
 	"github.com/giantswarm/kubectl-gs/cmd/login"
 	"github.com/giantswarm/kubectl-gs/cmd/template"
+	"github.com/giantswarm/kubectl-gs/pkg/project"
 )
 
 const (
@@ -128,6 +129,7 @@ func New(config Config) (*cobra.Command, error) {
 		RunE:          r.Run,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		Version:       project.Version(),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown command %q for %s", args[0], cmd.CommandPath())


### PR DESCRIPTION
Print current version using `cobra`'s built-in version flag.

Before

![image](https://user-images.githubusercontent.com/13508038/90774732-36f4c880-e2f8-11ea-8321-3f08f03d5b27.png)

After

![image](https://user-images.githubusercontent.com/13508038/90774746-3e1bd680-e2f8-11ea-9507-7ab2d4fa3d8c.png)
