### PR TITLE
Disallow cluster creation with legacy or non-active release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## Added
+### Added
 - Add the `--version` flag for printing the current version. Run `kgs --version` to check which version you're running.
+
+### Changed
+
+- Disabled templating clusters with legacy or deprecated release versions.
 
 ## [0.6.0] - 2020-08-11
 
@@ -30,7 +34,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Prevent breaking the client's kubeconfig if token renewal fails.
 
 ### Added
-- Add `--use-alike-instance-types` for node pools. 
+- Add `--use-alike-instance-types` for node pools.
 
 ## [0.5.3] - 2020-07-13
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -121,7 +121,7 @@ func readReleases(branch string) ([]ReleaseObject, error) {
 		for _, v := range r.Resources {
 			// skip legacy (< 10)
 			versionParts := strings.Split(strings.TrimPrefix(v, "v"), ".")
-			if i, _ := strconv.Atoi(versionParts[0]); i < firstAWSNodePoolsReleaseMajor {
+			if i, err := strconv.Atoi(versionParts[0]); i < firstAWSNodePoolsReleaseMajor || err != nil {
 				continue
 			}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13186

This PR adds filtering of legacy aws releases for release flag validation & disallowing cluster creation with non-active releases

## Checklist

- [x] Update changelog in CHANGELOG.md.
