### PR TITLE
Strip leading v from --release input for template cluster and template nodepool commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Add the `--version` flag for printing the current version. Run `kgs --version` to check which version you're running.
 
 ### Changed
-
 - Disabled templating clusters with legacy or deprecated release versions.
+- Allow specifying the `--release` flag for templating clusters and node pools with leading `v`.
 
 ## [0.6.0] - 2020-08-11
 

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"text/template"
 
 	"github.com/ghodss/yaml"
@@ -69,6 +70,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
+	// remove leading v from release flag input
+	sanitizedRelease := strings.TrimLeft(r.flag.Release, "v")
+
 	config := v1alpha2.ClusterCRsConfig{
 		ClusterID:         r.flag.ClusterID,
 		Credential:        r.flag.Credential,
@@ -80,7 +84,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		Owner:             r.flag.Owner,
 		Region:            r.flag.Region,
 		ReleaseComponents: releaseComponents,
-		ReleaseVersion:    r.flag.Release,
+		ReleaseVersion:    sanitizedRelease,
 		Labels:            userLabels,
 	}
 

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -65,6 +65,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		releaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
 	}
 
+	// remove leading v from release flag input
+	sanitizedRelease := strings.TrimLeft(r.flag.Release, "v")
+
 	config := v1alpha2.NodePoolCRsConfig{
 		AvailabilityZones:                   availabilityZones,
 		AWSInstanceType:                     r.flag.AWSInstanceType,
@@ -76,7 +79,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		OnDemandPercentageAboveBaseCapacity: r.flag.OnDemandPercentageAboveBaseCapacity,
 		Owner:                               r.flag.Owner,
 		ReleaseComponents:                   releaseComponents,
-		ReleaseVersion:                      r.flag.Release,
+		ReleaseVersion:                      sanitizedRelease,
 		UseAlikeInstanceTypes:               r.flag.UseAlikeInstanceTypes,
 	}
 


### PR DESCRIPTION
This PR removes leading `v` from `--release` flag inputs for `template cluster` and `template nodepool` commands

## Checklist

- [x] Update changelog in CHANGELOG.md.
