### PR TITLE
azure v5: set first node pool version to 13.0.0

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -27,7 +27,7 @@ const (
 	releasesAzureReleaseURLFmt = "https://raw.githubusercontent.com/giantswarm/releases/%s/azure/%s/release.yaml"
 
 	firstAWSNodePoolsRelease   = "10.0.0"
-	firstAzureNodePoolsRelease = "13.0.0"
+	firstAzureNodePoolsRelease = "13.0.0-alpha"
 )
 
 type Config struct {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -27,7 +27,7 @@ const (
 	releasesAzureReleaseURLFmt = "https://raw.githubusercontent.com/giantswarm/releases/%s/azure/%s/release.yaml"
 
 	firstAWSNodePoolsRelease   = "10.0.0"
-	firstAzureNodePoolsRelease = "12.2.0"
+	firstAzureNodePoolsRelease = "13.0.0"
 )
 
 type Config struct {


### PR DESCRIPTION
Analog of https://github.com/giantswarm/api/pull/1123