### PR TITLE
Add support for using custom releases branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Add support for using a custom release branch when templating clusters or node pools.
+
 ## [0.7.0] - 2020-09-30
 
 ### Added

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -30,15 +30,16 @@ const (
 	flagAzurePublicSSHKey = "azure-public-ssh-key"
 
 	// Common.
-	flagClusterID = "cluster-id"
-	flagDomain    = "domain"
-	flagMasterAZ  = "master-az"
-	flagName      = "name"
-	flagOutput    = "output"
-	flagOwner     = "owner"
-	flagRegion    = "region"
-	flagRelease   = "release"
-	flagLabel     = "label"
+	flagClusterID     = "cluster-id"
+	flagDomain        = "domain"
+	flagMasterAZ      = "master-az"
+	flagName          = "name"
+	flagOutput        = "output"
+	flagOwner         = "owner"
+	flagRegion        = "region"
+	flagRelease       = "release"
+	flagLabel         = "label"
+	flagReleaseBranch = "release-branch"
 )
 
 type flag struct {
@@ -53,15 +54,16 @@ type flag struct {
 	AzurePublicSSHKey string
 
 	// Common.
-	ClusterID string
-	Domain    string
-	MasterAZ  []string
-	Name      string
-	Output    string
-	Owner     string
-	Region    string
-	Release   string
-	Label     []string
+	ClusterID     string
+	Domain        string
+	MasterAZ      []string
+	Name          string
+	Output        string
+	Owner         string
+	Region        string
+	Release       string
+	Label         []string
+	ReleaseBranch string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -85,6 +87,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1 or westeurope).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Tenant cluster label.")
+	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "", "Release branch to use.")
 }
 
 func (f *flag) Validate() error {
@@ -196,6 +199,7 @@ func (f *flag) Validate() error {
 		{
 			c := release.Config{
 				Provider: f.Provider,
+				Branch:   f.ReleaseBranch,
 			}
 			r, err = release.New(c)
 			if err != nil {

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -87,7 +87,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1 or westeurope).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Tenant cluster label.")
-	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "", "Release branch to use.")
+	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "master", "Release branch to use.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -37,6 +37,7 @@ const (
 	flagOwner                = "owner"
 	flagRegion               = "region"
 	flagRelease              = "release"
+	flagReleaseBranch        = "release-branch"
 )
 
 type flag struct {
@@ -63,6 +64,7 @@ type flag struct {
 	Owner                string
 	Region               string
 	Release              string
+	ReleaseBranch        string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -89,6 +91,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
+	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "", "Release branch to use.")
 }
 
 func (f *flag) Validate() error {
@@ -239,6 +242,7 @@ func (f *flag) Validate() error {
 		{
 			c := release.Config{
 				Provider: f.Provider,
+				Branch:   f.ReleaseBranch,
 			}
 
 			r, err = release.New(c)

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -91,7 +91,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
-	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "", "Release branch to use.")
+	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "master", "Release branch to use.")
 }
 
 func (f *flag) Validate() error {

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -36,7 +36,7 @@ It supports the following flags:
   Can be retrieved with `gsctl list releases` for your installation. Only versions above *10.x.x*+ support cluster CRs.
 - `--label` - tenant cluster label in the form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
 - `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
-- `--release-branch` - The Giant Swarm releases repository branch to use.
+- `--release-branch` - The Giant Swarm releases repository branch to use. (default *master*)
 
 **Note:** The CRs generated won't trigger the creation of any worker nodes. Please see [node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions on how to create worker node pools.
 

--- a/docs/template-cluster-cr.md
+++ b/docs/template-cluster-cr.md
@@ -36,6 +36,7 @@ It supports the following flags:
   Can be retrieved with `gsctl list releases` for your installation. Only versions above *10.x.x*+ support cluster CRs.
 - `--label` - tenant cluster label in the form of `key=value`. Can be specified multiple times. Only clusters with release version above *10.x.x*+ support tenant cluster labels.
 - `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
+- `--release-branch` - The Giant Swarm releases repository branch to use.
 
 **Note:** The CRs generated won't trigger the creation of any worker nodes. Please see [node pools](https://github.com/giantswarm/kubectl-gs/blob/master/docs/template-nodepool-cr.md) for instructions on how to create worker node pools.
 

--- a/docs/template-nodepool-cr.md
+++ b/docs/template-nodepool-cr.md
@@ -33,7 +33,7 @@ Here are the supported flags:
     Can be retrieved with `gsctl list releases` for your installation. Only versions *10.x.x*+ support cluster CRs.
   - `--azure-vm-size` - Azure VM size to use for workers (e.g. *Standard_D4_v3*).
   - `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
-  - `--release-branch` - The Giant Swarm releases repository branch to use.
+  - `--release-branch` - The Giant Swarm releases repository branch to use. (default *master*)
 
 ```yaml
 ---

--- a/docs/template-nodepool-cr.md
+++ b/docs/template-nodepool-cr.md
@@ -33,6 +33,7 @@ Here are the supported flags:
     Can be retrieved with `gsctl list releases` for your installation. Only versions *10.x.x*+ support cluster CRs.
   - `--azure-vm-size` - Azure VM size to use for workers (e.g. *Standard_D4_v3*).
   - `--azure-public-ssh-key` - Azure master machines Base64-encoded public key used for SSH.
+  - `--release-branch` - The Giant Swarm releases repository branch to use.
 
 ```yaml
 ---


### PR DESCRIPTION
Currently, you can only use releases that are in the `master` branch of `giantswarm/releases`. This PR adds a new flag which lets you specify whichever branch you want to use. This is very useful for testing.