### PR TITLE
Store all Azure resources in organization namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 - Add the `--version` flag for printing the current version. Run `kgs --version` to check which version you're running.
 
+### Fixed
+- Store all Azure resources in the organization-specific namespace.
+
 ### Changed
 - Disabled templating clusters with legacy or deprecated release versions.
 - Allow specifying the `--release` flag for templating clusters and node pools with leading `v`.

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -19,9 +19,8 @@ import (
 )
 
 const (
-	serviceNetworkCIDR       = "172.31.0.0/16"
-	defaultMasterVMSize      = "Standard_D4_v3"
-	organizationNamespaceFmt = "org-%s"
+	serviceNetworkCIDR  = "172.31.0.0/16"
+	defaultMasterVMSize = "Standard_D4_v3"
 )
 
 func WriteAzureTemplate(out io.Writer, config ClusterCRsConfig) error {
@@ -81,7 +80,7 @@ func newAzureClusterCR(config ClusterCRsConfig) *capzv1alpha3.AzureCluster {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.ClusterID,
-			Namespace: fmt.Sprintf(organizationNamespaceFmt, config.Owner),
+			Namespace: config.Namespace,
 			Labels: map[string]string{
 				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
 				label.Cluster:                 config.ClusterID,

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	clusterCRFileName        = "clusterCR"
-	organizationNamespaceFmt = "org-%s"
 )
 
 type runner struct {

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -22,7 +23,8 @@ import (
 )
 
 const (
-	clusterCRFileName = "clusterCR"
+	clusterCRFileName        = "clusterCR"
+	organizationNamespaceFmt = "org-%s"
 )
 
 type runner struct {
@@ -95,6 +97,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		config.Labels, err = clusterlabels.Parse(r.flag.Label)
 		if err != nil {
 			return microerror.Mask(err)
+		}
+
+		if r.flag.Provider == key.ProviderAzure {
+			config.Namespace = fmt.Sprintf(organizationNamespaceFmt, config.Owner)
 		}
 	}
 

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	clusterCRFileName        = "clusterCR"
+	clusterCRFileName = "clusterCR"
 )
 
 type runner struct {

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -99,7 +99,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 
 		if r.flag.Provider == key.ProviderAzure {
-			config.Namespace = fmt.Sprintf(organizationNamespaceFmt, config.Owner)
+			config.Namespace = fmt.Sprintf("org-%s", config.Owner)
 		}
 	}
 


### PR DESCRIPTION
Looks like I understood it incorrectly the first time around. I thought that just the `AzureCluster` resource needs to be stored in the organization-specific namespace, but it turns out that all resources must be stored in that namespace. This PR addresses that.