### PR TITLE
Show full error output when oidc client creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- Show full error output when the OIDC configuration is incorrect while running the `login` command.
+
 ### Fixed
 - Use the custom releases branch when fetching release components.
 

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -229,7 +229,7 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 		}
 		auther, err = oidc.New(ctx, oidcConfig)
 		if err != nil {
-			return microerror.Mask(incorrectConfigurationError)
+			return microerror.Maskf(incorrectConfigurationError, "\n%v", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12816

This makes the whole error be displayed when you have an incorrect OIDC configuration, so you can know what's wrong.

### Preview

![image](https://user-images.githubusercontent.com/13508038/94804721-99f37800-03eb-11eb-9494-25f945fe4999.png)
