### PR TITLE
Store Azure node pool resources in the organization namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [Unreleased]
 
 ### Changed
+- Store Azure node pools resources in the organization-specific namespace.
 - Display full error output when getting installation info fails or when the OIDC configuration is incorrect, while running the `login` command fails.
 
 ### Fixed

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -2,6 +2,7 @@ package nodepool
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -100,6 +101,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			}
 		}
 		config.ReleaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
+
+		if r.flag.Provider == key.ProviderAzure {
+			config.Namespace = fmt.Sprintf("org-%s", config.Owner)
+		}
 	}
 
 	var output *os.File


### PR DESCRIPTION
Same as for clusters, but I thought for some reason that node pools are different