### PR TITLE
Allow using inactive release versions for templating clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [Unreleased]
 
 ### Changed
-- Allow using inactive release versions for templating clusters. This especially useful for testing cluster upgrades.
+- Allow using inactive release versions for templating clusters. This is especially useful for testing cluster upgrades.
 
 ## [0.7.2] - 2020-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- Allow using inactive release versions for templating clusters. This especially useful for testing cluster upgrades.
+
 ## [0.7.2] - 2020-10-12
 
 ### Changed

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -91,7 +91,7 @@ func (r *Release) Validate(version string) bool {
 	}
 
 	for _, release := range r.releases {
-		if release.Metadata.Name == releaseVersion && release.Spec.State == "active" {
+		if release.Metadata.Name == releaseVersion {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13581

This is really useful if you want to test version upgrades.