### PR TITLE
Normalize organization name to match company requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Normalize organization name when used as a namespace, to match company requirements.
+
 ## [0.7.2] - 2020-10-12
 
 ### Changed

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -100,7 +99,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 
 		if r.flag.Provider == key.ProviderAzure {
-			config.Namespace = fmt.Sprintf("org-%s", config.Owner)
+			config.Namespace = key.OrganizationNamespaceFromName(config.Owner)
 		}
 	}
 

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -2,7 +2,6 @@ package nodepool
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -123,7 +122,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		config.ReleaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
 
 		if r.flag.Provider == key.ProviderAzure {
-			config.Namespace = fmt.Sprintf("org-%s", config.Owner)
+			config.Namespace = key.OrganizationNamespaceFromName(config.Owner)
 		}
 	}
 

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -1,6 +1,7 @@
 package key
 
 import (
+	"fmt"
 	"math/rand"
 	"regexp"
 	"strconv"
@@ -18,6 +19,8 @@ const (
 	IDChars = "023456789abcdefghijkmnopqrstuvwxyz"
 	// IDLength represents the number of characters used to create a cluster ID.
 	IDLength = 5
+
+	organizationNamespaceFormat = "org-%s"
 )
 
 func GenerateID() string {
@@ -82,4 +85,11 @@ func ReadSecretYamlFromFile(fs afero.Fs, path string) (map[string][]byte, error)
 	}
 
 	return rawMap, nil
+}
+
+func OrganizationNamespaceFromName(name string) string {
+	name = strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+	name = fmt.Sprintf(organizationNamespaceFormat, name)
+
+	return name
 }

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/giantswarm/kubectl-gs/pkg/normalize"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
+
+	"github.com/giantswarm/kubectl-gs/pkg/normalize"
 )
 
 const (

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -90,7 +90,7 @@ func ReadSecretYamlFromFile(fs afero.Fs, path string) (map[string][]byte, error)
 }
 
 func OrganizationNamespaceFromName(name string) string {
-	name = fmt.Sprintf(organizationNamespaceFormat, normalize.AsDNSLabelName(name))
+	name = normalize.AsDNSLabelName(fmt.Sprintf(organizationNamespaceFormat, name))
 
 	return name
 }

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/giantswarm/kubectl-gs/pkg/normalize"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 )
@@ -88,8 +89,7 @@ func ReadSecretYamlFromFile(fs afero.Fs, path string) (map[string][]byte, error)
 }
 
 func OrganizationNamespaceFromName(name string) string {
-	name = strings.ToLower(strings.ReplaceAll(name, "_", "-"))
-	name = fmt.Sprintf(organizationNamespaceFormat, name)
+	name = fmt.Sprintf(organizationNamespaceFormat, normalize.AsDNSLabelName(name))
 
 	return name
 }

--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -1,0 +1,55 @@
+package normalize
+
+import (
+	"strings"
+	"unicode"
+)
+
+const (
+	maxDNSLabelLength = 63
+)
+
+// AsDNSLabelName normalizes input string to be valid DNS label name so that it
+// can be used as Kubernetes object identifier such as namespace name.
+//
+// NOTE: This function returns an empty string if input string consists of only
+//		 non-allowed characters.
+//
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+//
+// Source: https://github.com/giantswarm/azure-operator/blob/master/pkg/normalize/normalize.go
+func AsDNSLabelName(v string) string {
+	var xs []rune
+
+	for _, x := range strings.ToLower(v) {
+
+		// Is x in whitelisted characters?
+		if x == '-' || unicode.IsDigit(x) || ('a' <= x && x <= 'z') {
+			xs = append(xs, x)
+		} else if len(xs) > 0 && xs[len(xs)-1] != '-' {
+			// If not, append dash and coalesce consecutive ones.
+			xs = append(xs, '-')
+		}
+	}
+
+	// Ensure that the string doesn't start or end with dash.
+	for len(xs) > 0 {
+		if xs[0] == '-' {
+			xs = xs[1:]
+			continue
+		}
+
+		if xs[len(xs)-1] == '-' {
+			xs = xs[:len(xs)-1]
+			continue
+		}
+
+		break
+	}
+
+	if len(xs) > maxDNSLabelLength {
+		xs = xs[:maxDNSLabelLength]
+	}
+
+	return string(xs)
+}

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -1,0 +1,99 @@
+package normalize
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_AsDNSLabelName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "case 0: Uppercase input",
+			input:    "Foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 1: Uppercase input",
+			input:    "FooBar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 2: Uppercase input",
+			input:    "FOOBAR",
+			expected: "foobar",
+		},
+		{
+			name:     "case 3: Lower input",
+			input:    "foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 4: Input with dot",
+			input:    "foo.bar",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 5: Input with consequtive dots",
+			input:    "foo..bar",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 6: Input with different punctuations",
+			input:    "f\"\"oo!;ba_r",
+			expected: "f-oo-ba-r",
+		},
+		{
+			name:     "case 7: Input with dot in the beginning",
+			input:    ".foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 8: Input with dot in the end",
+			input:    "foobar.",
+			expected: "foobar",
+		},
+		{
+			name:     "case 9: Input with dot all over the place",
+			input:    ".foo-bar.",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 10: Input with dot all over the place",
+			input:    "...foo-bar.",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 11: Input with dot all over the place",
+			input:    "...foo-bar.....",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 12: Input without whitelisted characters",
+			input:    ".*/!_*()[]%^\\.",
+			expected: "",
+		},
+		{
+			name:     "case 13: Way too long input",
+			input:    "my.input.string.is.way.too.long.to.be.an.individual.dns.label.name.given.that.there.are.all.these.letters.and.other.punctuations.",
+			expected: "my-input-string-is-way-too-long-to-be-an-individual-dns-label-n",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			output := AsDNSLabelName(tc.input)
+
+			if !cmp.Equal(output, tc.expected) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expected, output))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Analog of https://github.com/giantswarm/api/pull/1146

We actually have some requirements for organization names inside our company. (such as using `_` to separate words, or only having lowercase characters), and this PR makes sure that the namespaces we use for creating clusters and nodepools are formatted properly.