### PR TITLE
Add container image building to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.10.0
+  architect: giantswarm/architect@0.13.0
 
 jobs:
   debug-tag:
@@ -40,6 +40,18 @@ workflows:
           name: go-build
           binary: kubectl-gs
           filters:
+            tags:
+              only: /^v.*/
+      - architect/push-to-docker:
+          name: push-kgs-to-quay
+          context: architect
+          image: "quay.io/giantswarm/kubectl-gs"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          requires:
+            - go-build
+          filters:
+            # Needed to trigger job also on git tag.
             tags:
               only: /^v.*/
   update-krew:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [Unreleased]
 
 ### Added
-- Publish a container image of kubectl-gs as quay.io/giantswarm/kubectl-gs
+- Start publishing a container image of kubectl-gs as giantswarm/kubectl-gs
 
 ### Changed
 - Allow using inactive release versions for templating clusters. This is especially useful for testing cluster upgrades.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Publish a container image of kubectl-gs as quay.io/giantswarm/kubectl-gs
+
 ### Changed
 - Allow using inactive release versions for templating clusters. This is especially useful for testing cluster upgrades.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM quay.io/giantswarm/alpine:3.12 AS binaries
+
+ARG KUBECTL_VERSION=1.18.9
+
+RUN apk add --no-cache ca-certificates curl \
+    && mkdir -p /binaries \
+    && curl -SL https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /binaries/kubectl \
+    && chmod +x /binaries/*
+
+FROM quay.io/giantswarm/alpine:3.12
+
+COPY --from=binaries /binaries/* /usr/bin/
+COPY ./kubectl-gs /usr/bin/kubectl-gs
+RUN ln -s /usr/bin/kubectl-gs /usr/bin/kgs
+
+ENTRYPOINT ["kgs"]
+


### PR DESCRIPTION
This PR

- updates CI configuration to use `architect-orb` to 0.13.0
- adds container image publishing at [`quay.io/giantswarm/kubectl-gs`](https://quay.io/repository/giantswarm/kubectl-gs)