### PR TITLE
Removed ssh key parameter for azure

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"encoding/base64"
 	"net"
 	"regexp"
 
@@ -26,9 +25,6 @@ const (
 	flagPodsCIDR     = "pods-cidr"
 	flagCredential   = "credential"
 
-	// Azure only.
-	flagAzurePublicSSHKey = "azure-public-ssh-key"
-
 	// Common.
 	flagClusterID     = "cluster-id"
 	flagDomain        = "domain"
@@ -50,9 +46,6 @@ type flag struct {
 	PodsCIDR     string
 	Credential   string
 
-	// Azure only.
-	AzurePublicSSHKey string
-
 	// Common.
 	ClusterID     string
 	Domain        string
@@ -73,9 +66,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.ExternalSNAT, flagExternalSNAT, false, "AWS CNI configuration.")
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
 	cmd.Flags().StringVar(&f.Credential, flagCredential, "credential-default", "Cloud provider credentials used to spin up the cluster.")
-
-	// Azure only.
-	cmd.Flags().StringVar(&f.AzurePublicSSHKey, flagAzurePublicSSHKey, "", "Base64-encoded Azure machine public SSH key.")
 
 	// Common.
 	cmd.Flags().StringVar(&f.Domain, flagDomain, "", "Installation base domain.")
@@ -144,19 +134,6 @@ func (f *flag) Validate() error {
 		case key.ProviderAzure:
 			if !azure.ValidateRegion(f.Region) {
 				return microerror.Maskf(invalidFlagError, "--%s must be valid region name", flagRegion)
-			}
-		}
-	}
-
-	{
-		if f.Provider == key.ProviderAzure {
-			if len(f.AzurePublicSSHKey) < 1 {
-				return microerror.Maskf(invalidFlagError, "--%s must not be empty on Azure", flagAzurePublicSSHKey)
-			} else {
-				_, err := base64.StdEncoding.DecodeString(f.AzurePublicSSHKey)
-				if err != nil {
-					return microerror.Maskf(invalidFlagError, "--%s must be Base64-encoded", flagAzurePublicSSHKey)
-				}
 			}
 		}
 	}

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -139,7 +139,7 @@ func newAzureMasterMachineCR(config ClusterCRsConfig) *capzv1alpha3.AzureMachine
 				},
 			},
 			Location:     config.Region,
-			SSHPublicKey: config.PublicSSHKey,
+			SSHPublicKey: "",
 		},
 	}
 

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -16,9 +16,6 @@ type ClusterCRsConfig struct {
 	PodsCIDR     string
 	Credential   string
 
-	// Azure only.
-	PublicSSHKey string
-
 	// Common.
 	FileName          string
 	ClusterID         string

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -69,7 +69,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Owner:          r.flag.Owner,
 			Region:         r.flag.Region,
 			ReleaseVersion: r.flag.Release,
-			PublicSSHKey:   r.flag.AzurePublicSSHKey,
 			Namespace:      metav1.NamespaceDefault,
 		}
 

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -1,7 +1,6 @@
 package nodepool
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/giantswarm/microerror"
@@ -24,8 +23,7 @@ const (
 	flagUseAlikeInstanceTypes               = "use-alike-instance-types"
 
 	// Azure only.
-	flagAzurePublicSSHKey = "azure-public-ssh-key"
-	flagAzureVMSize       = "azure-vm-size"
+	flagAzureVMSize = "azure-vm-size"
 
 	// Common.
 	flagAvailabilityZones    = "availability-zones"
@@ -59,8 +57,7 @@ type flag struct {
 	UseAlikeInstanceTypes               bool
 
 	// Azure only.
-	AzurePublicSSHKey string
-	AzureVMSize       string
+	AzureVMSize string
 
 	// Common.
 	AvailabilityZones    []string
@@ -86,7 +83,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.UseAlikeInstanceTypes, flagUseAlikeInstanceTypes, false, "Whether to use similar instances types as a fallback.")
 
 	// Azure only.
-	cmd.Flags().StringVar(&f.AzurePublicSSHKey, flagAzurePublicSSHKey, "", "Base64-encoded Azure machine public SSH key.")
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")
 
 	// Common.
@@ -170,19 +166,6 @@ func (f *flag) Validate() error {
 		case key.ProviderAzure:
 			if !azure.ValidateRegion(f.Region) {
 				return microerror.Maskf(invalidFlagError, "--%s must be valid region name", flagRegion)
-			}
-		}
-	}
-
-	{
-		if f.Provider == key.ProviderAzure {
-			if len(f.AzurePublicSSHKey) < 1 {
-				return microerror.Maskf(invalidFlagError, "--%s must not be empty on Azure", flagAzurePublicSSHKey)
-			} else {
-				_, err = base64.StdEncoding.DecodeString(f.AzurePublicSSHKey)
-				if err != nil {
-					return microerror.Maskf(invalidFlagError, "--%s must be Base64-encoded", flagAzurePublicSSHKey)
-				}
 			}
 		}
 	}

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -89,7 +89,7 @@ func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachi
 		Spec: expcapzv1alpha3.AzureMachinePoolSpec{
 			Location: config.Region,
 			Template: expcapzv1alpha3.AzureMachineTemplate{
-				SSHPublicKey: config.PublicSSHKey,
+				SSHPublicKey: "",
 				VMSize:       config.VMSize,
 			},
 		},

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -18,8 +18,7 @@ type NodePoolCRsConfig struct {
 	UseAlikeInstanceTypes               bool
 
 	// Azure only.
-	PublicSSHKey string
-	VMSize       string
+	VMSize string
 
 	// Common.
 	FileName          string

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -84,7 +84,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			OnDemandBaseCapacity:                r.flag.OnDemandBaseCapacity,
 			OnDemandPercentageAboveBaseCapacity: r.flag.OnDemandPercentageAboveBaseCapacity,
 			Owner:                               r.flag.Owner,
-			PublicSSHKey:                        r.flag.AzurePublicSSHKey,
 			Region:                              r.flag.Region,
 			UseAlikeInstanceTypes:               r.flag.UseAlikeInstanceTypes,
 			ReleaseVersion:                      r.flag.Release,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13783

This PR remove the `public ssh key` parameter that was mandatory on azure.
This is not used any more.