### PR TITLE
Fix handling of AZs for azure germanywestcentral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Removed availability zones for `GermanyWestCentral` in `Azure`.
+
 ## [0.9.0] - 2020-10-16
 
 ### Removed

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -210,7 +210,7 @@ func (f *flag) Validate() error {
 			return microerror.Maskf(invalidFlagError, "--%s must be configured with at least 1 AZ", flagAvailabilityZones)
 		}
 		if numOfAZs > numOfAvailableAZs {
-			return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region (%s has %d regions)", flagAvailabilityZones, f.Region, numOfAvailableAZs)
+			return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region (%s region has %d availability zones)", flagAvailabilityZones, f.Region, numOfAvailableAZs)
 		}
 
 		switch f.Provider {

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -91,7 +91,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.NodepoolName, flagNodepoolName, "Unnamed node pool", "NodepoolName or purpose description of the node pool.")
 	cmd.Flags().IntVar(&f.NodesMax, flagNodesMax, 0, fmt.Sprintf("Maximum number of worker nodes for the node pool. (default %d on AWS, or %d on Azure)", maxNodesAWS, maxNodesAzure))
 	cmd.Flags().IntVar(&f.NodesMin, flagNodesMin, 0, fmt.Sprintf("Minimum number of worker nodes for the node pool. (default %d on AWS, or %d on Azure)", minNodesAWS, minNodesAzure))
-	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 1, "Number of availability zones to use. Default is 1.")
+	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 0, "Number of availability zones to use. Default is 1 on AWS and 0 on Azure.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
@@ -179,7 +179,18 @@ func (f *flag) Validate() error {
 				azs = f.AvailabilityZones
 				numOfAZs = len(azs)
 			} else {
-				numOfAZs = f.NumAvailabilityZones
+				if f.NumAvailabilityZones > 0 {
+					numOfAZs = f.NumAvailabilityZones
+				} else {
+					// Customer didn't specify explicit availability zones nor a number of desired AZs.
+					// Default for AWS is 1, for Azure is 0 (automated selection).
+					switch f.Provider {
+					case key.ProviderAWS:
+						numOfAZs = 1
+					case key.ProviderAzure:
+						numOfAZs = 0
+					}
+				}
 			}
 		}
 
@@ -199,7 +210,7 @@ func (f *flag) Validate() error {
 			return microerror.Maskf(invalidFlagError, "--%s must be configured with at least 1 AZ", flagAvailabilityZones)
 		}
 		if numOfAZs > numOfAvailableAZs {
-			return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region", flagAvailabilityZones)
+			return microerror.Maskf(invalidFlagError, "--%s must be less than number of available AZs in selected region (%s has %d regions)", flagAvailabilityZones, f.Region, numOfAvailableAZs)
 		}
 
 		switch f.Provider {

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -11,8 +11,12 @@ func AvailableAZs(region string) int {
 
 func GetAvailabilityZones(num int, region string) []string {
 	var azs []string
+	available := infrastructure[region]
+	if len(available) == 0 {
+		return azs
+	}
 	for i := 0; i < num; i++ {
-		azs = append(azs, infrastructure[region][i])
+		azs = append(azs, available[i%len(available)])
 	}
 
 	return azs

--- a/pkg/azure/infrastructure.go
+++ b/pkg/azure/infrastructure.go
@@ -6,9 +6,5 @@ var infrastructure = map[string][]string{
 		"2",
 		"3",
 	},
-	"germanywestcentral": {
-		"1",
-		"2",
-		"3",
-	},
+	"germanywestcentral": {},
 }


### PR DESCRIPTION
This PR fixes how AZs are handled in Azure.

The new default number of AZs is 0 for azure (meaning the zone gets autoselected) and the case when the location does not support AZs (such as in GermanyWestCentral) is taken into account.

Some samples:

```
$ kubectl-gs template nodepool --cluster-id=a3y33 --owner giantswarm --region westeurope --provider azure --release 13.0.0-alpha3 --num-availability-zones 4
Error: Invalid flag: --availability-zones must be less than number of available AZs in selected region (westeurope has 3 regions)
```

```
$ kubectl-gs template nodepool --cluster-id=a3y33 --owner giantswarm --region germanywestcentral --provider azure --release 13.0.0-alpha3 --num-availability-zones 1
Error: Invalid flag: --availability-zones must be less than number of available AZs in selected region (germanywestcentral has 0 regions)
```