### PR TITLE
Removed the `--domain` flag on `Azure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Removed availability zones for `GermanyWestCentral` in `Azure`.
+- Removed the `--domain` flag on `Azure`.
 
 ## [0.9.0] - 2020-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
 - Removed availability zones for `GermanyWestCentral` in `Azure`.
 - Removed the `--domain` flag on `Azure`.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -45,10 +45,10 @@ type flag struct {
 	ExternalSNAT bool
 	PodsCIDR     string
 	Credential   string
+	Domain       string
 
 	// Common.
 	ClusterID     string
-	Domain        string
 	MasterAZ      []string
 	Name          string
 	Output        string
@@ -66,9 +66,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.ExternalSNAT, flagExternalSNAT, false, "AWS CNI configuration.")
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
 	cmd.Flags().StringVar(&f.Credential, flagCredential, "credential-default", "Cloud provider credentials used to spin up the cluster.")
+	cmd.Flags().StringVar(&f.Domain, flagDomain, "", "Installation base domain.")
 
 	// Common.
-	cmd.Flags().StringVar(&f.Domain, flagDomain, "", "Installation base domain.")
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "User-defined cluster ID.")
 	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, []string{}, "Tenant master availability zone.")
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Tenant cluster name.")
@@ -105,8 +105,14 @@ func (f *flag) Validate() error {
 
 		return nil
 	}
-	if f.Domain == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagDomain)
+	{
+		// Validate domain.
+		switch f.Provider {
+		case key.ProviderAWS:
+			if f.Domain == "" {
+				return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagDomain)
+			}
+		}
 	}
 	if f.Name == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagName)

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -24,10 +24,10 @@ const (
 	flagExternalSNAT = "external-snat"
 	flagPodsCIDR     = "pods-cidr"
 	flagCredential   = "credential"
+	flagDomain        = "domain"
 
 	// Common.
 	flagClusterID     = "cluster-id"
-	flagDomain        = "domain"
 	flagMasterAZ      = "master-az"
 	flagName          = "name"
 	flagOutput        = "output"
@@ -112,6 +112,10 @@ func (f *flag) Validate() error {
 			if f.Domain == "" {
 				return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagDomain)
 			}
+		case key.ProviderAzure:
+			if f.Domain != "" {
+			        return microerror.Maskf(invalidFlagError, "--%s is not supported for provider 'azure'", flagDomain)
+		        }
 		}
 	}
 	if f.Name == "" {

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -24,7 +24,7 @@ const (
 	flagExternalSNAT = "external-snat"
 	flagPodsCIDR     = "pods-cidr"
 	flagCredential   = "credential"
-	flagDomain        = "domain"
+	flagDomain       = "domain"
 
 	// Common.
 	flagClusterID     = "cluster-id"

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -114,8 +114,8 @@ func (f *flag) Validate() error {
 			}
 		case key.ProviderAzure:
 			if f.Domain != "" {
-			        return microerror.Maskf(invalidFlagError, "--%s is not supported for provider 'azure'", flagDomain)
-		        }
+				return microerror.Maskf(invalidFlagError, "--%s is not supported for provider 'azure'", flagDomain)
+			}
 		}
 	}
 	if f.Name == "" {

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	serviceNetworkCIDR  = "172.31.0.0/16"
 	defaultMasterVMSize = "Standard_D4s_v3"
 )
 
@@ -90,10 +89,6 @@ func newAzureClusterCR(config ClusterCRsConfig) *capzv1alpha3.AzureCluster {
 			},
 		},
 		Spec: capzv1alpha3.AzureClusterSpec{
-			ControlPlaneEndpoint: capiv1alpha3.APIEndpoint{
-				Host: fmt.Sprintf("api.%s.k8s.%s", config.ClusterID, config.Domain),
-				Port: 443,
-			},
 			Location:      config.Region,
 			ResourceGroup: config.ClusterID,
 		},

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -1,8 +1,6 @@
 package provider
 
 import (
-	"fmt"
-
 	"github.com/giantswarm/apiextensions/v2/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v2/pkg/label"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +29,6 @@ type ClusterCRsConfig struct {
 }
 
 func newCAPIV1Alpha3ClusterCR(config ClusterCRsConfig, infrastructureRef *corev1.ObjectReference) *capiv1alpha3.Cluster {
-	httpsPort := int32(443)
 	cluster := &capiv1alpha3.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Cluster",
@@ -52,19 +49,6 @@ func newCAPIV1Alpha3ClusterCR(config ClusterCRsConfig, infrastructureRef *corev1
 			},
 		},
 		Spec: capiv1alpha3.ClusterSpec{
-			ClusterNetwork: &capiv1alpha3.ClusterNetwork{
-				APIServerPort: &httpsPort,
-				Services: &capiv1alpha3.NetworkRanges{
-					CIDRBlocks: []string{
-						serviceNetworkCIDR,
-					},
-				},
-				ServiceDomain: fmt.Sprintf("%s.k8s.%s", config.ClusterID, config.Domain),
-			},
-			ControlPlaneEndpoint: capiv1alpha3.APIEndpoint{
-				Host: fmt.Sprintf("api.%s.k8s.%s", config.ClusterID, config.Domain),
-				Port: 443,
-			},
 			InfrastructureRef: infrastructureRef,
 		},
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13916

This PR removes the `--domain` flag for the `template` command on `azure only`.
The CR fields that needed that value are left blank and populated using a mutating webhook.

The rationale behind this is that there is no configurability of the `domain` field, so there is no need to add a flag that has no more that one specific option.