### PR TITLE
Add support for listing clusters in all namespaces, or using a namespace from the current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Added support for using a custom namespace set for a specific Kubernetes context in the Kubeconfig file.
+- Add support for using a custom namespace set for a specific Kubernetes context in the Kubeconfig file.
+- Add support for using the `--all-namespaces, -A` flag for listing resources in all namespaces.
 
 ## [0.10.0] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added support for using a custom namespace set for a specific Kubernetes context in the Kubeconfig file.
+
 ## [0.10.0] - 2020-10-23
 
 ### Removed
@@ -23,6 +27,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.8.0] - 2020-10-14
 
 ### Added
+
 - Start publishing a container image of kubectl-gs as giantswarm/kubectl-gs
 
 ### Changed
@@ -33,60 +38,73 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ## [0.7.2] - 2020-10-12
 
 ### Changed
+
 - Store Azure node pools resources in the organization-specific namespace.
 - Display full error output when getting installation info fails or when the OIDC configuration is incorrect, while running the `login` command fails.
 - Use proper CAPI conditions to determine Azure Cluster status.
 
 ### Fixed
+
 - Use the custom releases branch when fetching release components.
 
 ## [0.7.1] - 2020-09-30
 
 ### Added
+
 - Add support for using a custom release branch when templating clusters or node pools.
 
 ### Changed
+
 - Change the default Azure VM size to `Standard_D4s_v3`
 
 ### Fixed
+
 - Store all Azure resources in the organization-specific namespace.
 - Use correct K8s API version for Cluster API Machine Pools.
 
 ## [0.7.0] - 2020-09-30
 
 ### Added
+
 - Add support for templating clusters and node pools on Azure.
 - Add support for templating NetworkPools.
 
 ## [0.6.1] - 2020-09-14
 
 ### Added
+
 - Add the `--version` flag for printing the current version. Run `kgs --version` to check which version you're running.
 
 ### Changed
+
 - Disabled templating clusters with legacy or deprecated release versions.
 - Allow specifying the `--release` flag for templating clusters and node pools with leading `v`.
 
 ## [0.6.0] - 2020-08-11
 
 ### Added
+
 - Implemented support for the `get cluster(s) <id>` command.
 - Improved error printing formatting.
 
 ### Changed
+
 - Running the `template` command without any arguments how displays the command help output.
 
 ## [0.5.5] - 2020-07-28
 
 ### Fixed
+
 - Make executable work on lightweight linux distributions, such as `alpine`.
 
 ## [0.5.4] - 2020-07-24
 
 ### Fixed
+
 - Prevent breaking the client's kubeconfig if token renewal fails.
 
 ### Added
+
 - Add `--use-alike-instance-types` for node pools.
 
 ## [0.5.3] - 2020-07-13
@@ -95,41 +113,29 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [0.5.1] - 2020-07-03
 
-
 ## [0.5.0] 2020-06-10
-
 
 ## [0.4.0] 2020-06-09
 
-
 ## [0.3.5] 2020-06-04
-
 
 ## [0.3.4] 2020-05-27
 
-
 ## [0.3.3] 2020-05-21
-
 
 ## [0.3.2] 2020-05-08
 
-
 ## [0.3.1] 2020-05-06
-
 
 ## [0.3.0] 2020-05-06
 
-
 ## [0.2.0] 2020-03-26
-
 
 ## [0.1.0] 2020-03-26
 
-
 ## [0.2.0] 2020-04-23
 
-
-[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.7.2...v0.8.0

--- a/cmd/get/clusters/flag.go
+++ b/cmd/get/clusters/flag.go
@@ -5,12 +5,20 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	flagAllNamespaces = "all-namespaces"
+)
+
 type flag struct {
+	AllNamespaces bool
+
 	config genericclioptions.RESTClientGetter
 	print  *genericclioptions.PrintFlags
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&f.AllNamespaces, flagAllNamespaces, "A", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+
 	f.config = genericclioptions.NewConfigFlags(true)
 	f.print = genericclioptions.NewPrintFlags("")
 

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -68,7 +68,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	{
 		options := cluster.GetOptions{
 			Provider:  r.provider,
-			Namespace: metav1.NamespaceDefault,
 		}
 		{
 			if len(args) > 0 {

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -68,7 +68,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var resource runtime.Object
 	{
 		options := cluster.GetOptions{
-			Provider: r.provider,
+			Provider:  r.provider,
 			Namespace: metav1.NamespaceDefault,
 		}
 		{
@@ -76,7 +76,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				options.ID = strings.ToLower(args[0])
 			}
 
-			if (r.flag.AllNamespaces) {
+			if r.flag.AllNamespaces {
 				options.Namespace = metav1.NamespaceAll
 			} else if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
 				options.Namespace, _, err = cf.ToRawKubeConfigLoader().Namespace()

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
@@ -78,8 +77,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 			if r.flag.AllNamespaces {
 				options.Namespace = metav1.NamespaceAll
-			} else if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
-				options.Namespace, _, err = cf.ToRawKubeConfigLoader().Namespace()
+			} else {
+				options.Namespace, _, err = r.flag.config.ToRawKubeConfigLoader().Namespace()
 				if err != nil {
 					return microerror.Mask(err)
 				}

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -74,7 +74,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				options.ID = strings.ToLower(args[0])
 			}
 			if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
-				options.Namespace = *cf.Namespace
+				n, _, err := cf.ToRawKubeConfigLoader().Namespace()
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				options.Namespace = n
 			}
 		}
 

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -68,17 +69,20 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	{
 		options := cluster.GetOptions{
 			Provider: r.provider,
+			Namespace: metav1.NamespaceDefault,
 		}
 		{
 			if len(args) > 0 {
 				options.ID = strings.ToLower(args[0])
 			}
-			if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
-				n, _, err := cf.ToRawKubeConfigLoader().Namespace()
+
+			if (r.flag.AllNamespaces) {
+				options.Namespace = metav1.NamespaceAll
+			} else if cf, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok {
+				options.Namespace, _, err = cf.ToRawKubeConfigLoader().Namespace()
 				if err != nil {
 					return microerror.Mask(err)
 				}
-				options.Namespace = n
 			}
 		}
 

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -67,7 +67,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var resource runtime.Object
 	{
 		options := cluster.GetOptions{
-			Provider:  r.provider,
+			Provider: r.provider,
 		}
 		{
 			if len(args) > 0 {

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -9,26 +9,17 @@ import (
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
-const (
-	defaultNamespace = "default"
-)
-
 func (s *Service) Get(ctx context.Context, options GetOptions) (runtime.Object, error) {
 	var err error
 
-	namespace := options.Namespace
-	if namespace == "" {
-		namespace = defaultNamespace
-	}
-
 	var resource runtime.Object
 	if options.ID != "" {
-		resource, err = s.getById(ctx, options.Provider, options.ID, namespace)
+		resource, err = s.getById(ctx, options.Provider, options.ID, options.Namespace)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	} else {
-		resource, err = s.getAll(ctx, options.Provider, namespace)
+		resource, err = s.getAll(ctx, options.Provider, options.Namespace)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
2 things:

* Add support for using a specific namespace defined for a kubectl context (you can define that using `kubectl config set-context --current --namespace=<insert-namespace-name-here>`)
* Add support for the `--all-namespaces` flag, which allows listing clusters in all namespaces (aka all organizations)