### PR TITLE
Removed the `--release` and `--release-branch` flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,33 +126,74 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [0.5.3] - 2020-07-13
 
+- Add `kubectl gs login` command (#85, #86, #87)
+
 ## [0.5.2] - 2020-07-03
+
+No changes
 
 ## [0.5.1] - 2020-07-03
 
+- Several changes regarding the use as a kubectl plugin
+- Remove non-existing AZ cn-north-1c (#54)
+- Allow specifying tenant cluster labels through --label flags (#55)
+- Update main README, Installation docs for Krew (#56)
+
 ## [0.5.0] 2020-06-10
+
+- Add support for organization credentials
 
 ## [0.4.0] 2020-06-09
 
+- Add support for new release info structure
+
 ## [0.3.5] 2020-06-04
+
+- Add goreleaser github action
+- Add instance distribution (#48)
+- Remove default node pool creation (#49)
 
 ## [0.3.4] 2020-05-27
 
+- Add support for AWS China https://github.com/giantswarm/kubectl-gs/pull/47
+- add AWS availability zone `ap-southeast-1a` https://github.com/giantswarm/kubectl-gs/pull/46
+
 ## [0.3.3] 2020-05-21
+
+- Add External SNAT option
 
 ## [0.3.2] 2020-05-08
 
+- Allow user to create cluster with cluster ID containing `[a-z0-9]`
+
 ## [0.3.1] 2020-05-06
+
+- Fix mixed namespace/cluster namespaces usage in App CR
 
 ## [0.3.0] 2020-05-06
 
+- Allow user to specify Cluster ID
+
 ## [0.2.0] 2020-03-26
+
+- Added `pods-cidr` flag to generate pods CIDR in Cluster CRs
+- Added support for new Release CR
 
 ## [0.1.0] 2020-03-26
 
-## [0.2.0] 2020-04-23
+This release supports rendering for CRs:
 
-[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.11.0...HEAD
+- Tenant cluster control plane:
+  - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`) 
+  - `AWSCluster` (API version `infrastructure.giantswarm.io/v1alpha2`)
+- Node pool:
+  - `MachineDeployment` (API version `cluster.x-k8s.io/v1alpha2`)
+  - `AWSMachineDeployment` (API version `infrastructure.giantswarm.io/v1alpha2`)
+- `AppCatalog`
+- `App`
+
+[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the `--release` and `--release-branch` version from `kubectl-gs template nodepool` command.
+
 ## [0.12.0] - 2020-11-13
 
 ### Removed
@@ -122,74 +126,33 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [0.5.3] - 2020-07-13
 
-- Add `kubectl gs login` command (#85, #86, #87)
-
 ## [0.5.2] - 2020-07-03
-
-No changes
 
 ## [0.5.1] - 2020-07-03
 
-- Several changes regarding the use as a kubectl plugin
-- Remove non-existing AZ cn-north-1c (#54)
-- Allow specifying tenant cluster labels through --label flags (#55)
-- Update main README, Installation docs for Krew (#56)
-
 ## [0.5.0] 2020-06-10
-
-- Add support for organization credentials
 
 ## [0.4.0] 2020-06-09
 
-- Add support for new release info structure
-
 ## [0.3.5] 2020-06-04
-
-- Add goreleaser github action
-- Add instance distribution (#48)
-- Remove default node pool creation (#49)
 
 ## [0.3.4] 2020-05-27
 
-- Add support for AWS China https://github.com/giantswarm/kubectl-gs/pull/47
-- add AWS availability zone `ap-southeast-1a` https://github.com/giantswarm/kubectl-gs/pull/46
-
 ## [0.3.3] 2020-05-21
-
-- Add External SNAT option
 
 ## [0.3.2] 2020-05-08
 
-- Allow user to create cluster with cluster ID containing `[a-z0-9]`
-
 ## [0.3.1] 2020-05-06
-
-- Fix mixed namespace/cluster namespaces usage in App CR
 
 ## [0.3.0] 2020-05-06
 
-- Allow user to specify Cluster ID
-
 ## [0.2.0] 2020-03-26
-
-- Added `pods-cidr` flag to generate pods CIDR in Cluster CRs
-- Added support for new Release CR
 
 ## [0.1.0] 2020-03-26
 
-This release supports rendering for CRs:
+## [0.2.0] 2020-04-23
 
-- Tenant cluster control plane:
-  - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`) 
-  - `AWSCluster` (API version `infrastructure.giantswarm.io/v1alpha2`)
-- Node pool:
-  - `MachineDeployment` (API version `cluster.x-k8s.io/v1alpha2`)
-  - `AWSMachineDeployment` (API version `infrastructure.giantswarm.io/v1alpha2`)
-- `AppCatalog`
-- `App`
-
-[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.12.0...HEAD
-[0.12.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.11.0...v0.12.0
+[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/giantswarm/kubectl-gs/compare/v0.8.0...v0.9.0

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -7,9 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
-	"github.com/giantswarm/kubectl-gs/pkg/aws"
-	"github.com/giantswarm/kubectl-gs/pkg/azure"
-	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
 const (
@@ -33,7 +30,6 @@ const (
 	flagNumAvailabilityZones = "num-availability-zones"
 	flagOutput               = "output"
 	flagOwner                = "owner"
-	flagRegion               = "region"
 	flagRelease              = "release"
 	flagReleaseBranch        = "release-branch"
 )
@@ -67,7 +63,6 @@ type flag struct {
 	NumAvailabilityZones int
 	Output               string
 	Owner                string
-	Region               string
 	Release              string
 	ReleaseBranch        string
 }
@@ -93,7 +88,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 0, "Number of availability zones to use. Default is 1 on AWS and 0 on Azure.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
-	cmd.Flags().StringVar(&f.Region, flagRegion, "", "Installation region (e.g. eu-central-1).")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
 	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "master", "Release branch to use.")
 }

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -25,8 +25,6 @@ func WriteAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		OnDemandBaseCapacity:                config.OnDemandBaseCapacity,
 		OnDemandPercentageAboveBaseCapacity: config.OnDemandPercentageAboveBaseCapacity,
 		Owner:                               config.Owner,
-		ReleaseComponents:                   config.ReleaseComponents,
-		ReleaseVersion:                      config.ReleaseVersion,
 		UseAlikeInstanceTypes:               config.UseAlikeInstanceTypes,
 	}
 

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -33,10 +33,6 @@ func WriteAzureTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		infrastructureRef := newCAPZMachinePoolInfraRef(azureMachinePoolCR)
 
 		machinePoolCR := newCAPIV1Alpha3MachinePoolCR(config, infrastructureRef)
-		{
-			// XXX: azure-operator reconciles Cluster & MachinePool to set OwnerReferences (for now).
-			machinePoolCR.GetLabels()[label.AzureOperatorVersion] = config.ReleaseComponents["azure-operator"]
-		}
 		machinePoolCRYaml, err = yaml.Marshal(machinePoolCR)
 		if err != nil {
 			return microerror.Mask(err)
@@ -80,10 +76,8 @@ func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachi
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
-				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
-				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 		},
 		Spec: expcapzv1alpha3.AzureMachinePoolSpec{

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -29,6 +29,7 @@ type NodePoolCRsConfig struct {
 	NodesMax          int
 	NodesMin          int
 	Owner             string
+	Region            string
 	ReleaseComponents map[string]string
 	ReleaseVersion    string
 	Namespace         string
@@ -46,10 +47,8 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
-				label.ClusterOperatorVersion:  config.ReleaseComponents["cluster-operator"],
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
-				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 			Annotations: map[string]string{
 				annotation.MachinePoolName: config.Description,
@@ -82,7 +81,6 @@ func newSparkCR(config NodePoolCRsConfig) *corev1alpha1.Spark {
 			Namespace: config.Namespace,
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
-				label.ReleaseVersion:          config.ReleaseVersion,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
 			},
 		},

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -29,7 +29,6 @@ type NodePoolCRsConfig struct {
 	NodesMax          int
 	NodesMin          int
 	Owner             string
-	Region            string
 	ReleaseComponents map[string]string
 	ReleaseVersion    string
 	Namespace         string

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/kubectl-gs/pkg/aws"
 	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
@@ -82,32 +82,15 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			OnDemandPercentageAboveBaseCapacity: r.flag.OnDemandPercentageAboveBaseCapacity,
 			Owner:                               r.flag.Owner,
 			UseAlikeInstanceTypes:               r.flag.UseAlikeInstanceTypes,
-			ReleaseVersion:                      r.flag.Release,
 		}
 
 		if config.NodePoolID == "" {
 			config.NodePoolID = id.Generate()
 		}
 
-		// Remove leading 'v' from release flag input.
-		config.ReleaseVersion = strings.TrimLeft(config.ReleaseVersion, "v")
-
 		if len(r.flag.AvailabilityZones) > 0 {
 			config.AvailabilityZones = r.flag.AvailabilityZones
 		}
-
-		var releaseCollection *release.Release
-		{
-			c := release.Config{
-				Provider: r.flag.Provider,
-				Branch:   r.flag.ReleaseBranch,
-			}
-			releaseCollection, err = release.New(c)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-		config.ReleaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
 
 		if r.flag.Provider == key.ProviderAzure {
 			config.Namespace = key.OrganizationNamespaceFromName(config.Owner)

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -13,9 +13,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
-
-	"github.com/giantswarm/kubectl-gs/pkg/aws"
-	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
 const (


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14156

When creating a node pool, there is no need to specify the release version to be used.
That value has to match the cluster's and it can be defaulted on the server side with an admission controller.

Azure already does this, will wait until @giantswarm/team-firecracker confirms they are ready as well before I merge this PR.