### PR TITLE
Remove validation of the GS `release` when creating a `Cluster` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `cluster-admin` flag to `login` command, which allows full access for Giant Swarm staff.
 
+### Removed
+
+- Remove client-side validation of the GS `release` when creating a `Cluster`'s template. 
+
+
 ## [0.13.0] - 2020-11-20
 
 ### Removed

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
-	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
 const (
@@ -24,14 +23,13 @@ const (
 	flagDomain       = "domain"
 
 	// Common.
-	flagClusterID     = "cluster-id"
-	flagMasterAZ      = "master-az"
-	flagName          = "name"
-	flagOutput        = "output"
-	flagOwner         = "owner"
-	flagRelease       = "release"
-	flagLabel         = "label"
-	flagReleaseBranch = "release-branch"
+	flagClusterID = "cluster-id"
+	flagMasterAZ  = "master-az"
+	flagName      = "name"
+	flagOutput    = "output"
+	flagOwner     = "owner"
+	flagRelease   = "release"
+	flagLabel     = "label"
 )
 
 type flag struct {
@@ -44,14 +42,13 @@ type flag struct {
 	Domain       string
 
 	// Common.
-	ClusterID     string
-	MasterAZ      []string
-	Name          string
-	Output        string
-	Owner         string
-	Release       string
-	Label         []string
-	ReleaseBranch string
+	ClusterID string
+	MasterAZ  []string
+	Name      string
+	Output    string
+	Owner     string
+	Release   string
+	Label     []string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -71,7 +68,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Tenant cluster label.")
-	cmd.Flags().StringVar(&f.ReleaseBranch, flagReleaseBranch, "master", "Release branch to use.")
 }
 
 func (f *flag) Validate() error {
@@ -141,27 +137,9 @@ func (f *flag) Validate() error {
 		}
 	}
 
-	{
-		// Validate release version.
-		if f.Release == "" {
-			return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
-		}
-
-		var r *release.Release
-		{
-			c := release.Config{
-				Provider: f.Provider,
-				Branch:   f.ReleaseBranch,
-			}
-			r, err = release.New(c)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-
-		if !r.Validate(f.Release) {
-			return microerror.Maskf(invalidFlagError, "--%s must be a valid release", flagRelease)
-		}
+	// Validate release version.
+	if f.Release == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
 	}
 
 	_, err = clusterlabels.Parse(f.Label)

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -15,17 +15,16 @@ func WriteAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
 	crsConfig := v1alpha2.ClusterCRsConfig{
-		ClusterID:         config.ClusterID,
-		Credential:        config.Credential,
-		Domain:            config.Domain,
-		ExternalSNAT:      config.ExternalSNAT,
-		MasterAZ:          config.MasterAZ,
-		Description:       config.Description,
-		PodsCIDR:          config.PodsCIDR,
-		Owner:             config.Owner,
-		ReleaseComponents: config.ReleaseComponents,
-		ReleaseVersion:    config.ReleaseVersion,
-		Labels:            config.Labels,
+		ClusterID:      config.ClusterID,
+		Credential:     config.Credential,
+		Domain:         config.Domain,
+		ExternalSNAT:   config.ExternalSNAT,
+		MasterAZ:       config.MasterAZ,
+		Description:    config.Description,
+		PodsCIDR:       config.PodsCIDR,
+		Owner:          config.Owner,
+		ReleaseVersion: config.ReleaseVersion,
+		Labels:         config.Labels,
 	}
 
 	crs, err := v1alpha2.NewClusterCRs(crsConfig)

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -36,10 +36,6 @@ func WriteAzureTemplate(out io.Writer, config ClusterCRsConfig) error {
 		infrastructureRef := newCAPZClusterInfraRef(azureClusterCR)
 
 		clusterCR := newCAPIV1Alpha3ClusterCR(config, infrastructureRef)
-		{
-			// XXX: azure-operator reconciles Cluster & MachinePool to set OwnerReferences (for now).
-			clusterCR.GetLabels()[label.AzureOperatorVersion] = config.ReleaseComponents["azure-operator"]
-		}
 		clusterCRYaml, err = yaml.Marshal(clusterCR)
 		if err != nil {
 			return microerror.Mask(err)
@@ -81,7 +77,6 @@ func newAzureClusterCR(config ClusterCRsConfig) *capzv1alpha3.AzureCluster {
 			Name:      config.ClusterID,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
 				label.Organization:            config.Owner,
@@ -111,7 +106,6 @@ func newAzureMasterMachineCR(config ClusterCRsConfig) *capzv1alpha3.AzureMachine
 			Name:      fmt.Sprintf("%s-master-%d", config.ClusterID, 0),
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.AzureOperatorVersion:                config.ReleaseComponents["azure-operator"],
 				label.Cluster:                             config.ClusterID,
 				capiv1alpha3.ClusterLabelName:             config.ClusterID,
 				capiv1alpha3.MachineControlPlaneLabelName: "true",

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -15,16 +15,15 @@ type ClusterCRsConfig struct {
 	Credential   string
 
 	// Common.
-	FileName          string
-	ClusterID         string
-	Domain            string
-	MasterAZ          []string
-	Description       string
-	Owner             string
-	ReleaseComponents map[string]string
-	ReleaseVersion    string
-	Labels            map[string]string
-	Namespace         string
+	FileName       string
+	ClusterID      string
+	Domain         string
+	MasterAZ       []string
+	Description    string
+	Owner          string
+	ReleaseVersion string
+	Labels         map[string]string
+	Namespace      string
 }
 
 func newCAPIV1Alpha3ClusterCR(config ClusterCRsConfig, infrastructureRef *corev1.ObjectReference) *capiv1alpha3.Cluster {
@@ -37,7 +36,6 @@ func newCAPIV1Alpha3ClusterCR(config ClusterCRsConfig, infrastructureRef *corev1
 			Name:      config.ClusterID,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.ClusterOperatorVersion:  config.ReleaseComponents["cluster-operator"],
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
 				label.Organization:            config.Owner,

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -10,13 +10,12 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
-	"github.com/giantswarm/kubectl-gs/pkg/release"
-
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
@@ -77,19 +76,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 		// Remove leading 'v' from release flag input.
 		config.ReleaseVersion = strings.TrimLeft(config.ReleaseVersion, "v")
-
-		var releaseCollection *release.Release
-		{
-			c := release.Config{
-				Provider: r.flag.Provider,
-				Branch:   r.flag.ReleaseBranch,
-			}
-			releaseCollection, err = release.New(c)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-		config.ReleaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
 
 		config.Labels, err = clusterlabels.Parse(r.flag.Label)
 		if err != nil {


### PR DESCRIPTION
When creating a cluster template with `kubectl-gs template cluster`, the --release flag is used to specify the GS release desired to be used for the cluster.
This is currently validated on the client side by looking at the `releases` git repository (optionally specifying a custom branch with --releases-branch).

The only reason why we did this was to populate some labels in the CRs with the version of the provider operator that should reconcile this CRs.

This can and should be done on the server side by the provider admission controllers.

This PR hence removes the `--releases-branch` flag and only validates the presence of the `--release` flag. It also avoid setting the provider operator version label in the CRs.

This requires support in the provider admission controller, already implemented in azure.

Will wait for @giantswarm/team-firecracker-engineers to release the feature in `AWS` before I merge.