### PR TITLE
Revert "Revert "Removed the `--release` and `--release-branch` flags""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the `--release` and `--release-branch` version from `kubectl-gs template nodepool` command.
+
 ## [0.12.0] - 2020-11-13
 
 ### Removed

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
-	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
 const (
@@ -94,8 +93,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 }
 
 func (f *flag) Validate() error {
-	var err error
-
 	if f.Provider != key.ProviderAWS && f.Provider != key.ProviderAzure {
 		return microerror.Maskf(invalidFlagError, "--%s must be either aws or azure", flagProvider)
 	}
@@ -193,29 +190,6 @@ func (f *flag) Validate() error {
 			if f.OnDemandBaseCapacity != 0 || f.OnDemandPercentageAboveBaseCapacity != 100 || f.UseAlikeInstanceTypes {
 				return microerror.Maskf(invalidFlagError, "--%s, --%s and --%s spot instances flags are not supported on Azure.", flagOnDemandBaseCapacity, flagOnDemandPercentageAboveBaseCapacity, flagUseAlikeInstanceTypes)
 			}
-		}
-	}
-
-	{
-		if f.Release == "" {
-			return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
-		}
-
-		var r *release.Release
-		{
-			c := release.Config{
-				Provider: f.Provider,
-				Branch:   f.ReleaseBranch,
-			}
-
-			r, err = release.New(c)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-
-		if !r.Validate(f.Release) {
-			return microerror.Maskf(invalidFlagError, "--%s must be a valid release", flagRelease)
 		}
 	}
 

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -25,8 +25,6 @@ func WriteAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		OnDemandBaseCapacity:                config.OnDemandBaseCapacity,
 		OnDemandPercentageAboveBaseCapacity: config.OnDemandPercentageAboveBaseCapacity,
 		Owner:                               config.Owner,
-		ReleaseComponents:                   config.ReleaseComponents,
-		ReleaseVersion:                      config.ReleaseVersion,
 		UseAlikeInstanceTypes:               config.UseAlikeInstanceTypes,
 	}
 

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -33,10 +33,6 @@ func WriteAzureTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		infrastructureRef := newCAPZMachinePoolInfraRef(azureMachinePoolCR)
 
 		machinePoolCR := newCAPIV1Alpha3MachinePoolCR(config, infrastructureRef)
-		{
-			// XXX: azure-operator reconciles Cluster & MachinePool to set OwnerReferences (for now).
-			machinePoolCR.GetLabels()[label.AzureOperatorVersion] = config.ReleaseComponents["azure-operator"]
-		}
 		machinePoolCRYaml, err = yaml.Marshal(machinePoolCR)
 		if err != nil {
 			return microerror.Mask(err)
@@ -80,10 +76,8 @@ func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachi
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
-				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
-				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 		},
 		Spec: expcapzv1alpha3.AzureMachinePoolSpec{

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -46,10 +46,8 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
-				label.ClusterOperatorVersion:  config.ReleaseComponents["cluster-operator"],
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
-				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 			Annotations: map[string]string{
 				annotation.MachinePoolName: config.Description,
@@ -82,7 +80,6 @@ func newSparkCR(config NodePoolCRsConfig) *corev1alpha1.Spark {
 			Namespace: config.Namespace,
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterID,
-				label.ReleaseVersion:          config.ReleaseVersion,
 				capiv1alpha3.ClusterLabelName: config.ClusterID,
 			},
 		},

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
 
@@ -14,8 +13,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
-
-	"github.com/giantswarm/kubectl-gs/pkg/release"
 )
 
 const (
@@ -82,32 +79,15 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			OnDemandPercentageAboveBaseCapacity: r.flag.OnDemandPercentageAboveBaseCapacity,
 			Owner:                               r.flag.Owner,
 			UseAlikeInstanceTypes:               r.flag.UseAlikeInstanceTypes,
-			ReleaseVersion:                      r.flag.Release,
 		}
 
 		if config.NodePoolID == "" {
 			config.NodePoolID = id.Generate()
 		}
 
-		// Remove leading 'v' from release flag input.
-		config.ReleaseVersion = strings.TrimLeft(config.ReleaseVersion, "v")
-
 		if len(r.flag.AvailabilityZones) > 0 {
 			config.AvailabilityZones = r.flag.AvailabilityZones
 		}
-
-		var releaseCollection *release.Release
-		{
-			c := release.Config{
-				Provider: r.flag.Provider,
-				Branch:   r.flag.ReleaseBranch,
-			}
-			releaseCollection, err = release.New(c)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-		config.ReleaseComponents = releaseCollection.ReleaseComponents(r.flag.Release)
 
 		if r.flag.Provider == key.ProviderAzure {
 			config.Namespace = key.OrganizationNamespaceFromName(config.Owner)


### PR DESCRIPTION
Reverts giantswarm/kubectl-gs#224

PR #224 was reverting a merged PR because it was suspected to be the cause of this issue: https://github.com/giantswarm/giantswarm/issues/14429

We confirmed that was not the issue, so we can re-merge the original PR by reverting the revert PR.

Going with a ping as it was already approved.