### PR TITLE
Print namespace when getting clusters in all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `cluster-admin` flag to `login` command, which allows full access for Giant Swarm staff.
+- Print namespace when using the `get clusters` command with the `--all-namespaces` flag.
 
 ## [0.13.0] - 2020-11-20
 
@@ -190,7 +191,7 @@ No changes
 This release supports rendering for CRs:
 
 - Tenant cluster control plane:
-  - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`) 
+  - `Cluster` (API version `cluster.x-k8s.io/v1alpha2`)
   - `AWSCluster` (API version `infrastructure.giantswarm.io/v1alpha2`)
 - Node pool:
   - `MachineDeployment` (API version `cluster.x-k8s.io/v1alpha2`)

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -27,7 +27,9 @@ func (r *runner) printOutput(resource runtime.Object) error {
 			resource = provider.GetAzureTable(resource)
 		}
 
-		printOptions := printers.PrintOptions{}
+		printOptions := printers.PrintOptions{
+			WithNamespace: r.flag.AllNamespaces,
+		}
 		printer = printers.NewTablePrinter(printOptions)
 
 	case output.IsOutputName(r.flag.print.OutputFormat):

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -44,6 +44,9 @@ func getAWSClusterRow(res *infrastructurev1alpha2.AWSCluster) metav1.TableRow {
 			res.Labels[label.Organization],
 			res.Spec.Cluster.Description,
 		},
+		Object: runtime.RawExtension{
+			Object: res,
+		},
 	}
 }
 

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -45,6 +45,9 @@ func getAzureClusterRow(res *capiv1alpha3.Cluster) metav1.TableRow {
 			res.Labels[label.Organization],
 			getAzureClusterDescription(res),
 		},
+		Object: runtime.RawExtension{
+			Object: res,
+		},
 	}
 }
 


### PR DESCRIPTION
Making the command behave more like regular `kubectl`.

### Preview

<details>
<summary>Getting clusters in set namespace</summary>

![image](https://user-images.githubusercontent.com/13508038/99998420-eee5b600-2dbe-11eb-8fdd-1e3f2326fe41.png)

</details>

<details>
<summary>Getting clusters in all namespaces</summary>

![image](https://user-images.githubusercontent.com/13508038/99998475-07ee6700-2dbf-11eb-893f-fa52652bca5a.png)

</details>