### PR TITLE
Remove credential flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Removed the `--credential` flag, now it is managed by admission controller.
+
 ## [0.14.0] - 2020-11-24
 
 ### Added

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -19,7 +19,6 @@ const (
 	// AWS only.
 	flagExternalSNAT = "external-snat"
 	flagPodsCIDR     = "pods-cidr"
-	flagCredential   = "credential"
 	flagDomain       = "domain"
 
 	// Common.
@@ -38,7 +37,6 @@ type flag struct {
 	// AWS only.
 	ExternalSNAT bool
 	PodsCIDR     string
-	Credential   string
 	Domain       string
 
 	// Common.
@@ -57,7 +55,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// AWS only.
 	cmd.Flags().BoolVar(&f.ExternalSNAT, flagExternalSNAT, false, "AWS CNI configuration.")
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
-	cmd.Flags().StringVar(&f.Credential, flagCredential, "credential-default", "Cloud provider credentials used to spin up the cluster.")
 	cmd.Flags().StringVar(&f.Domain, flagDomain, "", "Installation base domain.")
 
 	// Common.

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -16,7 +16,6 @@ func WriteAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 
 	crsConfig := v1alpha2.ClusterCRsConfig{
 		ClusterID:      config.ClusterID,
-		Credential:     config.Credential,
 		Domain:         config.Domain,
 		ExternalSNAT:   config.ExternalSNAT,
 		MasterAZ:       config.MasterAZ,

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -12,7 +12,6 @@ type ClusterCRsConfig struct {
 	// AWS only.
 	ExternalSNAT bool
 	PodsCIDR     string
-	Credential   string
 
 	// Common.
 	FileName       string

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -60,7 +60,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		config = provider.ClusterCRsConfig{
 			FileName:       clusterCRFileName,
 			ClusterID:      r.flag.ClusterID,
-			Credential:     r.flag.Credential,
 			ExternalSNAT:   r.flag.ExternalSNAT,
 			Domain:         r.flag.Domain,
 			MasterAZ:       r.flag.MasterAZ,


### PR DESCRIPTION
Since it defaults to credential secret name based on org, now we should not set `credential` anymore as it could be error prone. @whites11 is azure defaulting credential too? if not we need to wait till it does

towards https://github.com/giantswarm/roadmap/issues/198