### PR TITLE
Add support for non-standard GS API URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for fetching installation information using non-standard Giant Swarm API URLs.
+
 ## [0.14.0] - 2020-11-24
 
 ### Added
@@ -16,7 +20,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Removed
 
-- Remove client-side validation of the GS `release` when creating a `Cluster`'s template. 
+- Remove client-side validation of the GS `release` when creating a `Cluster`'s template.
 
 
 ## [0.13.0] - 2020-11-20

--- a/pkg/installation/error.go
+++ b/pkg/installation/error.go
@@ -13,13 +13,13 @@ func IsCannotParseCertificate(err error) bool {
 	return microerror.Cause(err) == cannotParseCertificateError
 }
 
-var cannotGetInstallationInfo = &microerror.Error{
-	Kind: "cannotGetInstallationInfo",
+var cannotGetInstallationInfoError = &microerror.Error{
+	Kind: "cannotGetInstallationInfoError",
 }
 
-// IsCannotGetInstallationInfo asserts cannotGetInstallationInfo.
+// IsCannotGetInstallationInfo asserts cannotGetInstallationInfoError.
 func IsCannotGetInstallationInfo(err error) bool {
-	return microerror.Cause(err) == cannotGetInstallationInfo
+	return microerror.Cause(err) == cannotGetInstallationInfoError
 }
 
 var unknownUrlTypeError = &microerror.Error{

--- a/pkg/installation/info.go
+++ b/pkg/installation/info.go
@@ -20,10 +20,10 @@ type installationInfo struct {
 func getInstallationInfo(httpClient *http.Client, apiUrl string) (installationInfo, error) {
 	res, err := httpClient.Get(apiUrl) // #nosec G107
 	if err != nil {
-		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfo, "make sure you're connected to the internet and that the Giant Swarm API is up and running\n%v", err.Error())
+		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfoError, "make sure you're connected to the internet and that the Giant Swarm API is up and running\n%s", err.Error())
 	}
 	if res.StatusCode != http.StatusOK {
-		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfo, "make sure you're behind the correct VPN")
+		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfoError, "make sure you're behind the correct VPN")
 	}
 
 	defer res.Body.Close()
@@ -32,7 +32,7 @@ func getInstallationInfo(httpClient *http.Client, apiUrl string) (installationIn
 	{
 		err = json.NewDecoder(res.Body).Decode(&result)
 		if err != nil {
-			return installationInfo{}, microerror.Maskf(cannotGetInstallationInfo, "API response has invalid format")
+			return installationInfo{}, microerror.Maskf(cannotGetInstallationInfoError, "API response has invalid format")
 		}
 
 		result.Installation.K8sCaCert, err = parseCertificate(result.Installation.K8sCaCert)

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -21,11 +21,11 @@ func New(fromUrl string) (*Installation, error) {
 	}
 
 	k8sApiUrl := getK8sApiUrl(basePath)
-	apiUrl := getGiantSwarmApiUrl(basePath)
+	apiUrls := getGiantSwarmApiUrls(basePath)
 	authUrl := getAuthUrl(basePath)
 
 	client := http.DefaultClient
-	installationInfo, err := getInstallationInfo(client, apiUrl)
+	installationInfo, err := getInstallationInfo(client, apiUrls[0])
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	apiUrlPrefix    = "api"
 	k8sApiUrlPrefix = "g8s"
 	happaUrlPrefix  = "happa"
 	authUrlPrefix   = "dex"
@@ -21,6 +20,14 @@ const (
 	UrlTypeK8sApi
 	UrlTypeHappa
 )
+
+// This list contains the most common GS API prefixes out there.
+// We need this hacky approach because some installations have
+// different prefixes.
+var gsApiUrlPrefixes = [...]string{
+	"api",
+	"gs-api",
+}
 
 func GetUrlType(u string) int {
 	switch {
@@ -67,7 +74,14 @@ func getBasePath(u string) (string, error) {
 }
 
 func getGiantSwarmApiUrls(basePath string) []string {
-	return []string{fmt.Sprintf("https://%s.%s", apiUrlPrefix, basePath)}
+	var urls []string
+	{
+		for _, prefix := range gsApiUrlPrefixes {
+			urls = append(urls, fmt.Sprintf("https://%s.%s", prefix, basePath))
+		}
+	}
+
+	return urls
 }
 
 func getK8sApiUrl(basePath string) string {

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -66,8 +66,8 @@ func getBasePath(u string) (string, error) {
 	}
 }
 
-func getGiantSwarmApiUrl(basePath string) string {
-	return fmt.Sprintf("https://%s.%s", apiUrlPrefix, basePath)
+func getGiantSwarmApiUrls(basePath string) []string {
+	return []string{fmt.Sprintf("https://%s.%s", apiUrlPrefix, basePath)}
 }
 
 func getK8sApiUrl(basePath string) string {

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -3,6 +3,7 @@ package installation
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 )
 
@@ -70,12 +71,15 @@ func Test_getBasePath(t *testing.T) {
 	}
 }
 
-func Test_getGiantSwarmApiUrl(t *testing.T) {
+func Test_getGiantSwarmApiUrls(t *testing.T) {
 	basePath := "g8s.test.eu-west-1.aws.coolio.com" // nolint:goconst
-	expectedResult := "https://api.g8s.test.eu-west-1.aws.coolio.com"
+	expectedResult := []string{
+		"https://api.g8s.test.eu-west-1.aws.coolio.com",
+		"https://gs-api.g8s.test.eu-west-1.aws.coolio.com",
+	}
 
-	if result := getGiantSwarmApiUrl(basePath); result != expectedResult {
-		t.Fatalf("url not expected, got: %s", result)
+	if result := getGiantSwarmApiUrls(basePath); len(cmp.Diff(result, expectedResult)) > 0 {
+		t.Fatalf("urls not expected, got: %s", result)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/14545

Because some installations have non-standard GS API URLs, we need to somehow support logging in for all of them.
This PR includes a solution that'a bit hacky, trying out multiple common API URLs and seeing if it works.

I don't consider it a big issue for now, since we want to have a different service providing installation information in the future, instead of the GS API.