### PR TITLE
Allow for empty master-az  flag in AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow for empty `--master-az` flag in AWS since it is defaulted in the admission controller.
+
 ## [0.16.0] - 2020-12-09
 
 - In the `template nodepool` command, the flags `--nodex-min` and `--nodex-max` have been renamed to `--nodes-min` and `--nodes-max`.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -121,7 +121,7 @@ func (f *flag) Validate() error {
 		// Validate Master AZs.
 		switch f.Provider {
 		case key.ProviderAWS:
-			if len(f.MasterAZ) != 1 && len(f.MasterAZ) != 3 {
+			if len(f.MasterAZ) != 0 && len(f.MasterAZ) != 1 && len(f.MasterAZ) != 3 {
 				return microerror.Maskf(invalidFlagError, "--%s must be set to either one or three availability zone names", flagMasterAZ)
 			}
 			if !unique.StringsAreUnique(f.MasterAZ) {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/198
Allow for empty `--master-az` flag in AWS since it is defaulted in the admission controller.