### PR TITLE
Allow for empty release flag in AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow for empty `--release` flag in AWS since it is defaulted in the admission controller.
+
 ## [0.16.0] - 2020-12-09
 
 - In the `template nodepool` command, the flags `--nodex-min` and `--nodex-max` have been renamed to `--nodes-min` and `--nodes-max`.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -134,8 +134,8 @@ func (f *flag) Validate() error {
 		}
 	}
 
-	// Validate release version.
-	if f.Release == "" {
+	// Validate release version for non-aws clusters.
+	if f.Provider != key.ProviderAWS && f.Release == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
 	}
 


### PR DESCRIPTION
Towards: giantswarm/roadmap#198
Allow for empty `--release` flag in AWS since it is defaulted in the admission controller.