### PR TITLE
Allow for empty name flag in AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow for empty `--name` flag in AWS since it is defaulted in the admission controller.
+
 ## [0.16.0] - 2020-12-09
 
 - In the `template nodepool` command, the flags `--nodex-min` and `--nodex-max` have been renamed to `--nodes-min` and `--nodes-max`.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -105,7 +105,8 @@ func (f *flag) Validate() error {
 			}
 		}
 	}
-	if f.Name == "" {
+	// Validate name for non-aws clusters.
+	if f.Provider != key.ProviderAWS && f.Name == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagName)
 	}
 	if f.PodsCIDR != "" {


### PR DESCRIPTION
Towards: giantswarm/roadmap#198
Allow for empty `--name` flag in AWS since it is defaulted in the admission controller.