### PR TITLE
Remove --domain flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Removed
+
+- Removed the `--domain` flag since it is managed by admission controller.
+
 ## [0.16.0] - 2020-12-09
 
 - In the `template nodepool` command, the flags `--nodex-min` and `--nodex-max` have been renamed to `--nodes-min` and `--nodes-max`.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -19,7 +19,6 @@ const (
 	// AWS only.
 	flagExternalSNAT = "external-snat"
 	flagPodsCIDR     = "pods-cidr"
-	flagDomain       = "domain"
 
 	// Common.
 	flagClusterID = "cluster-id"
@@ -37,7 +36,6 @@ type flag struct {
 	// AWS only.
 	ExternalSNAT bool
 	PodsCIDR     string
-	Domain       string
 
 	// Common.
 	ClusterID string
@@ -55,7 +53,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// AWS only.
 	cmd.Flags().BoolVar(&f.ExternalSNAT, flagExternalSNAT, false, "AWS CNI configuration.")
 	cmd.Flags().StringVar(&f.PodsCIDR, flagPodsCIDR, "", "CIDR used for the pods.")
-	cmd.Flags().StringVar(&f.Domain, flagDomain, "", "Installation base domain.")
 
 	// Common.
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "User-defined cluster ID.")
@@ -91,19 +88,6 @@ func (f *flag) Validate() error {
 		}
 
 		return nil
-	}
-	{
-		// Validate domain.
-		switch f.Provider {
-		case key.ProviderAWS:
-			if f.Domain == "" {
-				return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagDomain)
-			}
-		case key.ProviderAzure:
-			if f.Domain != "" {
-				return microerror.Maskf(invalidFlagError, "--%s is not supported for provider 'azure'", flagDomain)
-			}
-		}
 	}
 	if f.Name == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagName)

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -16,7 +16,6 @@ func WriteAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 
 	crsConfig := v1alpha2.ClusterCRsConfig{
 		ClusterID:      config.ClusterID,
-		Domain:         config.Domain,
 		ExternalSNAT:   config.ExternalSNAT,
 		MasterAZ:       config.MasterAZ,
 		Description:    config.Description,

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -16,7 +16,6 @@ type ClusterCRsConfig struct {
 	// Common.
 	FileName       string
 	ClusterID      string
-	Domain         string
 	MasterAZ       []string
 	Description    string
 	Owner          string

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -61,7 +61,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			FileName:       clusterCRFileName,
 			ClusterID:      r.flag.ClusterID,
 			ExternalSNAT:   r.flag.ExternalSNAT,
-			Domain:         r.flag.Domain,
 			MasterAZ:       r.flag.MasterAZ,
 			Description:    r.flag.Name,
 			Owner:          r.flag.Owner,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/198
We do not need the `--domain` flag anymore as this attribute is managed by the admission-controller.