### PR TITLE
Terminology change: "tenant cluster" to "worload cluster", "control plane" to "management cluster"

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -7,8 +7,8 @@ spec:
   homepage: https://github.com/giantswarm/kubectl-gs
   shortDescription: Handle custom resources with Giant Swarm
   description: |
-    Simplifies creating clusters and node pools via Giant Swarm Kubernetes
-    control planes, as well as installing app catalogs and apps.
+    Simplifies creating clusters and node pools via Giant Swarm
+    management clusters, as well as installing app catalogs and apps.
   platforms:
   - selector:
       matchLabels:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Removed
 
-- Removed the `--region` flag from the `kubectl-gs template` commands. Region gets set automatically according to the control plane the cluster is created in.
+- Removed the `--region` flag from the `kubectl-gs template` commands. Region gets set automatically according to the installation the cluster is created in.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Check the [installation docs](https://docs.giantswarm.io/reference/kubectl-gs/in
   - App catalogs
   - Apps
 - **SSO login**: with the `login` command you can quickly set up a `kubectl context` with
-  OIDC authentication for a Giant Swarm control plane.
+  OIDC authentication for a Giant Swarm management cluster.
 
 ## Documentation
 

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -87,16 +87,16 @@ func (r *runner) tryToReuseExistingContext() error {
 	currentContext, isLoggedInWithKubeContext := isLoggedWithGSContext(r.k8sConfigAccess)
 	if isLoggedInWithKubeContext {
 		codeName := kubeconfig.GetCodeNameFromKubeContext(currentContext)
-		fmt.Fprint(r.stdout, color.GreenString("You are logged in to the control plane of installation '%s'.\n", codeName))
+		fmt.Fprint(r.stdout, color.GreenString("You are logged in to the management cluster of installation '%s'.\n", codeName))
 
 		return nil
 	}
 
 	if currentContext != "" {
-		return microerror.Maskf(selectedContextNonCompatibleError, "The current context '%s' does not seem to belong to a Giant Swarm control plane.\nPlease run 'kgs login --help' to find out how to log in to a particular control plane.", currentContext)
+		return microerror.Maskf(selectedContextNonCompatibleError, "The current context '%s' does not seem to belong to a Giant Swarm management cluster.\nPlease run 'kgs login --help' to find out how to log in to a particular management cluster.", currentContext)
 	}
 
-	return microerror.Maskf(selectedContextNonCompatibleError, "The current context does not seem to belong to a Giant Swarm control plane.\nPlease run 'kgs login --help' to find out how to log in to a particular control plane.")
+	return microerror.Maskf(selectedContextNonCompatibleError, "The current context does not seem to belong to a Giant Swarm management cluster.\nPlease run 'kgs login --help' to find out how to log in to a particular management cluster.")
 }
 
 // loginWithKubeContextName switches the active kubernetes context to
@@ -120,7 +120,7 @@ func (r *runner) loginWithKubeContextName(ctx context.Context, contextName strin
 		fmt.Fprintf(r.stdout, "Switched to context '%s'.\n", contextName)
 	}
 
-	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the control plane of installation '%s'.\n", codeName))
+	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the management cluster of installation '%s'.\n", codeName))
 
 	return nil
 }
@@ -144,7 +144,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 		fmt.Fprintf(r.stdout, "Switched to context '%s'.\n", contextName)
 	}
 
-	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the control plane of installation '%s'.\n", codeName))
+	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the management cluster of installation '%s'.\n", codeName))
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ const (
 	// space characters (' '), and we trick it by using a
 	// NBSP character (NBSP) between the 2 words.
 	name        = "kubectl\u00a0gs"
-	description = `Your user-friendly kubectl plug-in for the Giant Swarm control plane.
+	description = `Your user-friendly kubectl plug-in for the Giant Swarm management cluster.
 
 Get more information at https://github.com/giantswarm/kubectl-gs
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -56,12 +56,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Common.
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "User-defined cluster ID.")
-	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, []string{}, "Tenant master availability zone.")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "Tenant cluster name.")
+	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, []string{}, "Workload master node availability zone.")
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Workload cluster name.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
-	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
-	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Tenant cluster release.")
-	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Tenant cluster label.")
+	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
+	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
+	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Workload cluster label.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/networkpool/flag.go
+++ b/cmd/template/networkpool/flag.go
@@ -27,7 +27,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.NetworkPoolName, flagNetworkPoolName, "", "NetworkPool identifier.")
 	cmd.Flags().StringVar(&f.CIDRBlock, flagCIDRBlock, "", "Installation infrastructure provider.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
-	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
+	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -84,13 +84,13 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Common.
 	cmd.Flags().StringSliceVar(&f.AvailabilityZones, flagAvailabilityZones, []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")
-	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "Tenant cluster ID.")
+	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "Workload cluster ID.")
 	cmd.Flags().StringVar(&f.NodepoolName, flagNodepoolName, "Unnamed node pool", "NodepoolName or purpose description of the node pool.")
 	cmd.Flags().IntVar(&f.NodesMax, flagNodesMax, 0, fmt.Sprintf("Maximum number of worker nodes for the node pool. (default %d on AWS, or %d on Azure)", maxNodesAWS, maxNodesAzure))
 	cmd.Flags().IntVar(&f.NodesMin, flagNodesMin, 0, fmt.Sprintf("Minimum number of worker nodes for the node pool. (default %d on AWS, or %d on Azure)", minNodesAWS, minNodesAzure))
 	cmd.Flags().IntVar(&f.NumAvailabilityZones, flagNumAvailabilityZones, 0, "Number of availability zones to use. Default is 1 on AWS and 0 on Azure.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
-	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Tenant cluster owner organization.")
+	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
 
 	// This can be removed in a future version around March 2021 or later.
 	cmd.Flags().IntVar(&f.NodexMax, flagNodexMax, 0, "")

--- a/cmd/validate/apps/command.go
+++ b/cmd/validate/apps/command.go
@@ -45,7 +45,7 @@ Output columns:
 
   kubectl gs validate apps
 
-  # Narrow down by namespace to validate apps on a specific tenant cluster
+  # Narrow down by namespace to validate apps on a specific workload cluster
 
     kubectl gs validate apps \
       -n oby63
@@ -57,7 +57,7 @@ Output columns:
       -n oby63 \
       -o report
 
-  # Get a detailed validation report of a specific app across all tenant clusters
+  # Get a detailed validation report of a specific app across all workload clusters
   # the "app" label contains the name of the app in the App Catalog, so we can use --selector for that.
 
     kubectl gs validate apps \

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,7 +1,7 @@
 package project
 
 var (
-	description = "Kubectl plugin to render CRs for Giant Swarm tenant clusters."
+	description = "Kubectl plugin to render CRs for Giant Swarm workload clusters."
 	gitSHA      = "n/a"
 	name        = "kubectl-gs"
 	source      = "https://github.com/giantswarm/kubectl-gs"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14961

This PR changes the terms

- "tenant cluster" to "workload cluster"
- "control plane" to "management cluster" (where appropriate)