### PR TITLE
[GET NP 1/3]: Add support for computing provider capabilities

### DIFF
--- a/internal/feature/autoscaling.go
+++ b/internal/feature/autoscaling.go
@@ -1,0 +1,14 @@
+package feature
+
+const (
+	Autoscaling = "autoscaling"
+)
+
+var autoscaling = Feature{
+	ProviderAWS: Capability{
+		MinVersion: "10.0.0",
+	},
+	ProviderAzure: Capability{
+		MinVersion: "13.1.0",
+	},
+}

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -1,0 +1,44 @@
+package feature
+
+import (
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// Service is used to compute different provider capabilities.
+type Service struct {
+	provider string
+	features map[string]Feature
+}
+
+func New(provider string) *Service {
+	s := &Service{
+		provider: provider,
+		features: map[string]Feature{
+			Autoscaling:        autoscaling,
+			NodePoolConditions: nodePoolConditions,
+		},
+	}
+
+	return s
+}
+
+// Supports checks if a certain feature is supported or not on a given release version.
+func (s *Service) Supports(featureName string, releaseVersion string) bool {
+	feature, exists := s.features[featureName]
+	if !exists {
+		return false
+	}
+
+	capability, exists := feature[s.provider]
+	if !exists {
+		return false
+	}
+
+	releaseVersion = strings.TrimPrefix(releaseVersion, "v")
+	inputVersion := semver.MustParse(releaseVersion)
+	featureMinVersion := semver.MustParse(capability.MinVersion)
+
+	return inputVersion.GE(featureMinVersion)
+}

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -1,0 +1,93 @@
+package feature
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestService_Supports(t *testing.T) {
+	testCases := []struct {
+		name           string
+		provider       string
+		feature        string
+		version        string
+		expectedResult bool
+	}{
+		{
+			name:           "case 0: autoscaling on aws 10.0.0",
+			provider:       ProviderAWS,
+			feature:        Autoscaling,
+			version:        "10.0.0",
+			expectedResult: true,
+		},
+		{
+			name:           "case 1: autoscaling on aws 11.0.0",
+			provider:       ProviderAWS,
+			feature:        Autoscaling,
+			version:        "13.1.0",
+			expectedResult: true,
+		},
+		{
+			name:           "case 2: autoscaling on azure 13.0.0",
+			provider:       ProviderAzure,
+			feature:        Autoscaling,
+			version:        "13.0.0",
+			expectedResult: false,
+		},
+		{
+			name:           "case 3: autoscaling on azure 13.1.0",
+			provider:       ProviderAzure,
+			feature:        Autoscaling,
+			version:        "13.1.0",
+			expectedResult: true,
+		},
+		{
+			name:           "case 4: autoscaling on azure 13.2.0",
+			provider:       ProviderAzure,
+			feature:        Autoscaling,
+			version:        "13.2.0",
+			expectedResult: true,
+		},
+		{
+			name:           "case 5: autoscaling on kvm 13.0.0",
+			provider:       ProviderKVM,
+			feature:        Autoscaling,
+			version:        "13.0.0",
+			expectedResult: false,
+		},
+		{
+			name:           "case 6: nodepool conditions on aws 10.0.0",
+			provider:       ProviderAWS,
+			feature:        NodePoolConditions,
+			version:        "10.0.0",
+			expectedResult: false,
+		},
+		{
+			name:           "case 7: nodepool conditions on azure 13.0.0",
+			provider:       ProviderAzure,
+			feature:        NodePoolConditions,
+			version:        "13.0.0",
+			expectedResult: true,
+		},
+		{
+			name:           "case 8: nodepool conditions on kvm 13.0.0",
+			provider:       ProviderKVM,
+			feature:        NodePoolConditions,
+			version:        "13.0.0",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			capabilities := New(tc.provider)
+			isSupported := capabilities.Supports(tc.feature, tc.version)
+
+			diff := cmp.Diff(tc.expectedResult, isSupported)
+			if len(diff) > 0 {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
+		})
+	}
+}

--- a/internal/feature/nodepool_conditions.go
+++ b/internal/feature/nodepool_conditions.go
@@ -1,0 +1,11 @@
+package feature
+
+const (
+	NodePoolConditions = "nodepool-conditions"
+)
+
+var nodePoolConditions = Feature{
+	ProviderAzure: Capability{
+		MinVersion: "13.0.0",
+	},
+}

--- a/internal/feature/providers.go
+++ b/internal/feature/providers.go
@@ -1,0 +1,7 @@
+package feature
+
+const (
+	ProviderAWS   = "aws"
+	ProviderAzure = "azure"
+	ProviderKVM   = "kvm"
+)

--- a/internal/feature/spec.go
+++ b/internal/feature/spec.go
@@ -1,0 +1,11 @@
+package feature
+
+// Capability contains a provider's requirements
+// for a feature to be supported.
+type Capability struct {
+	MinVersion string
+}
+
+// Feature is a collection of different requirements
+// for supporting a functionality on different providers.
+type Feature map[string]Capability


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14854

This PR adds support for checking if a specific feature is supported on a cluster, based on its provider and release version. The reason for doing it is so we could have an easy way of hiding and displaying information, based on a feature being supported or not.

For the moment, I only added `Autoscaling` and `Node Pool Conditions` to the list.