### PR TITLE
[GET NP 2/3]: Add data domain for node pools

### DIFF
--- a/pkg/data/client/client.go
+++ b/pkg/data/client/client.go
@@ -14,8 +14,10 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/rest"
+	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexpv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 )
 
 type Config struct {
@@ -42,6 +44,8 @@ func New(config Config) (*Client, error) {
 			SchemeBuilder: k8sclient.SchemeBuilder{
 				capiv1alpha2.AddToScheme,
 				capiv1alpha3.AddToScheme,
+				capiexpv1alpha3.AddToScheme,
+				capzexpv1alpha3.AddToScheme,
 				applicationv1alpha1.AddToScheme,
 				backupv1alpha1.AddToScheme,
 				corev1alpha1.AddToScheme,

--- a/pkg/data/client/k8sclient_fake.go
+++ b/pkg/data/client/k8sclient_fake.go
@@ -19,8 +19,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexpv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -37,6 +39,8 @@ func NewFakeK8sClient() k8sclient.Interface {
 		schemeBuilder := runtime.SchemeBuilder(k8sclient.SchemeBuilder{
 			capiv1alpha2.AddToScheme,
 			capiv1alpha3.AddToScheme,
+			capiexpv1alpha3.AddToScheme,
+			capzexpv1alpha3.AddToScheme,
 			applicationv1alpha1.AddToScheme,
 			backupv1alpha1.AddToScheme,
 			corev1alpha1.AddToScheme,

--- a/pkg/data/domain/nodepool/aws.go
+++ b/pkg/data/domain/nodepool/aws.go
@@ -1,0 +1,121 @@
+package nodepool
+
+import (
+	"context"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (s *Service) getAllAWS(ctx context.Context, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{}
+	if len(clusterID) > 0 {
+		labelSelector[label.Cluster] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	var awsMDs map[string]*infrastructurev1alpha2.AWSMachineDeployment
+	{
+		mdCollection := &infrastructurev1alpha2.AWSMachineDeploymentList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, mdCollection, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else if len(mdCollection.Items) == 0 {
+			return nil, microerror.Mask(noResourcesError)
+		}
+
+		awsMDs = make(map[string]*infrastructurev1alpha2.AWSMachineDeployment, len(mdCollection.Items))
+		for _, machineDeployment := range mdCollection.Items {
+			md := machineDeployment
+			awsMDs[machineDeployment.GetName()] = &md
+		}
+	}
+
+	machineDeployments := &capiv1alpha2.MachineDeploymentList{}
+	{
+		err = s.client.K8sClient.CtrlClient().List(ctx, machineDeployments, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else if len(machineDeployments.Items) == 0 {
+			return nil, microerror.Mask(noResourcesError)
+		}
+	}
+
+	npCollection := &Collection{}
+	{
+		for _, cr := range machineDeployments.Items {
+			o := cr
+
+			if awsMD, exists := awsMDs[cr.GetName()]; exists {
+				cr.TypeMeta = metav1.TypeMeta{
+					APIVersion: "cluster.x-k8s.io/v1alpha2",
+					Kind:       "MachineDeployment",
+				}
+				awsMD.TypeMeta = infrastructurev1alpha2.NewAWSMachineDeploymentTypeMeta()
+
+				np := Nodepool{
+					MachineDeployment:    &o,
+					AWSMachineDeployment: awsMD,
+				}
+				npCollection.Items = append(npCollection.Items, np)
+			}
+		}
+	}
+
+	return npCollection, nil
+}
+
+func (s *Service) getByIdAWS(ctx context.Context, id, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{
+		label.MachineDeployment: id,
+	}
+	if len(clusterID) > 0 {
+		labelSelector[label.Cluster] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	np := &Nodepool{}
+
+	{
+		crs := &capiv1alpha2.MachineDeploymentList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(crs.Items) < 1 {
+			return nil, microerror.Mask(notFoundError)
+		}
+		np.MachineDeployment = &crs.Items[0]
+
+		np.MachineDeployment.TypeMeta = metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1alpha2",
+			Kind:       "MachineDeployment",
+		}
+	}
+
+	{
+		crs := &infrastructurev1alpha2.AWSMachineDeploymentList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(crs.Items) < 1 {
+			return nil, microerror.Mask(notFoundError)
+		}
+		np.AWSMachineDeployment = &crs.Items[0]
+
+		np.AWSMachineDeployment.TypeMeta = infrastructurev1alpha2.NewAWSMachineDeploymentTypeMeta()
+	}
+
+	return np, nil
+}

--- a/pkg/data/domain/nodepool/azure.go
+++ b/pkg/data/domain/nodepool/azure.go
@@ -1,0 +1,128 @@
+package nodepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexpv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (s *Service) getAllAzure(ctx context.Context, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{}
+	if len(clusterID) > 0 {
+		labelSelector[capiv1alpha3.ClusterLabelName] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	var azureMPs map[string]*capzexpv1alpha3.AzureMachinePool
+	{
+		mpCollection := &capzexpv1alpha3.AzureMachinePoolList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, mpCollection, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else if len(mpCollection.Items) == 0 {
+			return nil, microerror.Mask(noResourcesError)
+		}
+
+		azureMPs = make(map[string]*capzexpv1alpha3.AzureMachinePool, len(mpCollection.Items))
+		for _, machineDeployment := range mpCollection.Items {
+			md := machineDeployment
+			azureMPs[machineDeployment.GetName()] = &md
+		}
+	}
+
+	machinePools := &capiexpv1alpha3.MachinePoolList{}
+	{
+		err = s.client.K8sClient.CtrlClient().List(ctx, machinePools, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else if len(machinePools.Items) == 0 {
+			return nil, microerror.Mask(noResourcesError)
+		}
+	}
+
+	npCollection := &Collection{}
+	{
+		for _, cr := range machinePools.Items {
+			o := cr
+
+			if azureMP, exists := azureMPs[cr.GetName()]; exists {
+				cr.TypeMeta = metav1.TypeMeta{
+					APIVersion: "exp.cluster.x-k8s.io/v1alpha3",
+					Kind:       "MachinePool",
+				}
+				azureMP.TypeMeta = metav1.TypeMeta{
+					APIVersion: "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
+					Kind:       "AzureMachinePool",
+				}
+
+				np := Nodepool{
+					MachinePool:      &o,
+					AzureMachinePool: azureMP,
+				}
+				npCollection.Items = append(npCollection.Items, np)
+			}
+		}
+	}
+
+	return npCollection, nil
+}
+
+func (s *Service) getByIdAzure(ctx context.Context, id, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{
+		label.MachinePool: id,
+	}
+	if len(clusterID) > 0 {
+		labelSelector[capiv1alpha3.ClusterLabelName] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	np := &Nodepool{}
+
+	{
+		crs := &capiexpv1alpha3.MachinePoolList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(crs.Items) < 1 {
+			return nil, microerror.Mask(notFoundError)
+		}
+		np.MachinePool = &crs.Items[0]
+
+		np.MachinePool.TypeMeta = metav1.TypeMeta{
+			APIVersion: "exp.cluster.x-k8s.io/v1alpha3",
+			Kind:       "MachinePool",
+		}
+	}
+
+	{
+		crs := &capzexpv1alpha3.AzureMachinePoolList{}
+		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(crs.Items) < 1 {
+			return nil, microerror.Mask(notFoundError)
+		}
+		np.AzureMachinePool = &crs.Items[0]
+
+		np.AzureMachinePool.TypeMeta = metav1.TypeMeta{
+			APIVersion: "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
+			Kind:       "AzureMachinePool",
+		}
+	}
+
+	return np, nil
+}

--- a/pkg/data/domain/nodepool/common.go
+++ b/pkg/data/domain/nodepool/common.go
@@ -1,0 +1,79 @@
+package nodepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/kubectl-gs/internal/key"
+)
+
+func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {
+	var resource Resource
+	var err error
+
+	if len(options.ID) > 0 {
+		resource, err = s.getById(ctx, options.Provider, options.ID, options.Namespace, options.ClusterID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else {
+		resource, err = s.getAll(ctx, options.Provider, options.Namespace, options.ClusterID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resource, nil
+}
+
+func (s *Service) getById(ctx context.Context, provider, id, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	var np Resource
+	{
+		switch provider {
+		case key.ProviderAWS:
+			np, err = s.getByIdAWS(ctx, id, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		case key.ProviderAzure:
+			np, err = s.getByIdAzure(ctx, id, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		default:
+			return nil, microerror.Mask(invalidProviderError)
+		}
+
+	}
+
+	return np, nil
+}
+
+func (s *Service) getAll(ctx context.Context, provider, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	var npCollection Resource
+	{
+		switch provider {
+		case key.ProviderAWS:
+			npCollection, err = s.getAllAWS(ctx, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+		case key.ProviderAzure:
+			npCollection, err = s.getAllAzure(ctx, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+		default:
+			return nil, microerror.Mask(invalidProviderError)
+		}
+	}
+
+	return npCollection, nil
+}

--- a/pkg/data/domain/nodepool/error.go
+++ b/pkg/data/domain/nodepool/error.go
@@ -1,0 +1,41 @@
+package nodepool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var noResourcesError = &microerror.Error{
+	Kind: "noResourcesError",
+}
+
+// IsNoResources asserts noResourcesError.
+func IsNoResources(err error) bool {
+	return microerror.Cause(err) == noResourcesError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var invalidProviderError = &microerror.Error{
+	Kind: "invalidProviderError",
+}
+
+// IsInvalidProvider asserts invalidProviderError.
+func IsInvalidProvider(err error) bool {
+	return microerror.Cause(err) == invalidProviderError
+}

--- a/pkg/data/domain/nodepool/service.go
+++ b/pkg/data/domain/nodepool/service.go
@@ -1,0 +1,29 @@
+package nodepool
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/client"
+)
+
+var _ Interface = &Service{}
+
+type Config struct {
+	Client *client.Client
+}
+
+type Service struct {
+	client *client.Client
+}
+
+func New(config Config) (Interface, error) {
+	if config.Client == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
+	}
+
+	s := &Service{
+		client: config.Client,
+	}
+
+	return s, nil
+}

--- a/pkg/data/domain/nodepool/service_fake.go
+++ b/pkg/data/domain/nodepool/service_fake.go
@@ -1,0 +1,53 @@
+package nodepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/client"
+)
+
+var _ Interface = &FakeService{}
+
+type FakeService struct {
+	service *Service
+	storage []runtime.Object
+}
+
+func NewFakeService(storage []runtime.Object) *FakeService {
+	clientConfig := client.Config{
+		Logger: microloggertest.New(),
+	}
+	fakeClient, _ := client.NewFakeClient(clientConfig)
+
+	underlyingService := &Service{
+		client: fakeClient,
+	}
+
+	ms := &FakeService{
+		service: underlyingService,
+		storage: storage,
+	}
+
+	return ms
+}
+
+func (ms *FakeService) Get(ctx context.Context, options GetOptions) (Resource, error) {
+	var err error
+	for _, res := range ms.storage {
+		err = ms.service.client.K8sClient.CtrlClient().Create(ctx, res)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	result, err := ms.service.Get(ctx, options)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return result, nil
+}

--- a/pkg/data/domain/nodepool/spec.go
+++ b/pkg/data/domain/nodepool/spec.go
@@ -1,0 +1,76 @@
+package nodepool
+
+import (
+	"context"
+
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	capiexpv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+)
+
+type GetOptions struct {
+	ID        string
+	ClusterID string
+	Provider  string
+	Namespace string
+}
+
+type Interface interface {
+	Get(context.Context, GetOptions) (Resource, error)
+}
+
+type Resource interface {
+	Object() runtime.Object
+}
+
+// Nodepool abstracts away provider-specific
+// node pool resources.
+type Nodepool struct {
+	MachineDeployment *capiv1alpha2.MachineDeployment
+	MachinePool       *capiexpv1alpha3.MachinePool
+
+	AWSMachineDeployment *infrastructurev1alpha2.AWSMachineDeployment
+	AzureMachinePool     *capzexpv1alpha3.AzureMachinePool
+}
+
+func (n *Nodepool) Object() runtime.Object {
+	if n.MachineDeployment != nil {
+		return n.MachineDeployment
+	} else if n.MachinePool != nil {
+		return n.MachinePool
+	}
+
+	return nil
+}
+
+// Collection wraps a list of nodepools.
+type Collection struct {
+	Items []Nodepool
+}
+
+func (nc *Collection) Object() runtime.Object {
+	list := &metav1.List{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+	}
+
+	for _, item := range nc.Items {
+		obj := item.Object()
+		if obj == nil {
+			continue
+		}
+
+		raw := runtime.RawExtension{
+			Object: obj,
+		}
+		list.Items = append(list.Items, raw)
+	}
+
+	return list
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14854

This PR adds the K8s API logic for the `get nodepools` command.

What's different compared to the clusters logic is that we'll use a wrapper around node pool resources. This allows us to easily get all the required information from multiple resources (such as the CAPI `MachinePool`, and the CAPZ `AzureMachinePool`), but still be able to easily print a singe resource as YAML or JSON.

Hopefully the comments below do a good job in explaining this.