### PR TITLE
Remove the mention of the unexistent 'create cluster' command, and suggest 'template cluster' instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Remove the mention of the unexistent 'create cluster' command.
+
 ## [1.19.0] - 2021-01-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Added
+### Removed
 
 - Remove the mention of the unexistent 'create cluster' command.
 

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -58,5 +58,5 @@ func (r *runner) printOutput(resource runtime.Object) error {
 func (r *runner) printNoResourcesOutput() {
 	fmt.Fprintf(r.stdout, "No clusters found.\n")
 	fmt.Fprintf(r.stdout, "To create a cluster, please check\n\n")
-	fmt.Fprintf(r.stdout, "  kgs create cluster --help\n")
+	fmt.Fprintf(r.stdout, "  kgs template cluster --help\n")
 }

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -340,7 +340,7 @@ func Test_printNoResourcesOutput(t *testing.T) {
 	expected := `No clusters found.
 To create a cluster, please check
 
-  kgs create cluster --help
+  kgs template cluster --help
 `
 	out := new(bytes.Buffer)
 	runner := &runner{

--- a/cmd/get/clusters/testdata/run_get_clusters_empty_storage.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters_empty_storage.golden
@@ -1,4 +1,4 @@
 No clusters found.
 To create a cluster, please check
 
-  kgs create cluster --help
+  kgs template cluster --help


### PR DESCRIPTION
If there are no cluster resources to be printed, we suggest creating one using the `create cluster` command, which doesn't exist. Let's suggest `template cluster` instead.