### PR TITLE
Validate context before considering the user logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make the `login` command validate the current context before considering it good to go.
+
 ## [1.20.0] - 2021-01-18
 
 ### Added

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -235,9 +235,9 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 	var auther *oidc.Authenticator
 	{
 		oidcConfig := oidc.Config{
-			Issuer:       authProvider.Config["idp-issuer-url"],
-			ClientID:     authProvider.Config["client-id"],
-			ClientSecret: authProvider.Config["client-secret"],
+			Issuer:       authProvider.Config[Issuer],
+			ClientID:     authProvider.Config[ClientID],
+			ClientSecret: authProvider.Config[ClientSecret],
 		}
 		auther, err = oidc.New(ctx, oidcConfig)
 		if err != nil {
@@ -247,12 +247,12 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 
 	// Renew authentication token.
 	{
-		idToken, rToken, err := auther.RenewToken(ctx, authProvider.Config["refresh-token"])
+		idToken, rToken, err := auther.RenewToken(ctx, authProvider.Config[RefreshToken])
 		if err != nil {
 			return microerror.Mask(tokenRenewalFailedError)
 		}
-		authProvider.Config["refresh-token"] = rToken
-		authProvider.Config["id-token"] = idToken
+		authProvider.Config[RefreshToken] = rToken
+		authProvider.Config[IDToken] = idToken
 	}
 
 	config.CurrentContext = newContextName

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -219,10 +219,6 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 		return microerror.Mask(err)
 	}
 
-	if newContextName == config.CurrentContext {
-		return microerror.Mask(contextAlreadySelectedError)
-	}
-
 	// Check if the context exists.
 	if _, exists := config.Contexts[newContextName]; !exists {
 		return microerror.Maskf(contextDoesNotExistError, "There is no context named '%s'. Please make sure you spelled the installation handle correctly.\nIf not sure, pass the Control Plane API URL or the web UI URL of the installation as an argument.", newContextName)
@@ -236,6 +232,10 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 	err = validateAuthProvider(authProvider)
 	if err != nil {
 		return microerror.Maskf(incorrectConfigurationError, "The authentication configuration is corrupted, please log in again.")
+	}
+
+	if newContextName == config.CurrentContext {
+		return microerror.Mask(contextAlreadySelectedError)
 	}
 
 	var auther *oidc.Authenticator

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -153,11 +153,11 @@ func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.In
 		initialUser.AuthProvider = &clientcmdapi.AuthProviderConfig{
 			Name: "oidc",
 			Config: map[string]string{
-				"client-id":      authResult.ClientID,
-				"client-secret":  authResult.ClientSecret,
-				"id-token":       authResult.IDToken,
-				"idp-issuer-url": i.AuthURL,
-				"refresh-token":  authResult.RefreshToken,
+				ClientID:     authResult.ClientID,
+				ClientSecret: authResult.ClientSecret,
+				IDToken:      authResult.IDToken,
+				Issuer:       i.AuthURL,
+				RefreshToken: authResult.RefreshToken,
 			},
 		}
 

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -282,17 +282,17 @@ func isLoggedWithGSContext(k8sConfig *clientcmdapi.Config) (string, bool) {
 func validateAuthProvider(provider *clientcmdapi.AuthProviderConfig) error {
 	var err error
 
-	switch {
-	case len(provider.Config[ClientID]) == 0:
-		fallthrough
-	case len(provider.Config[ClientSecret]) == 0:
-		fallthrough
-	case len(provider.Config[IDToken]) == 0:
-		fallthrough
-	case len(provider.Config[Issuer]) == 0:
-		fallthrough
-	case len(provider.Config[RefreshToken]) == 0:
-		return microerror.Mask(invalidAuthConfigurationError)
+	keys := []string{
+		ClientID,
+		ClientSecret,
+		IDToken,
+		Issuer,
+		RefreshToken,
+	}
+	for _, k := range keys {
+		if len(provider.Config[k]) == 0 {
+			return microerror.Mask(invalidAuthConfigurationError)
+		}
 	}
 
 	if _, err = url.ParseRequestURI(provider.Config[Issuer]); err != nil {

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -271,17 +271,12 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 	return nil
 }
 
-func isLoggedWithGSContext(k8sConfigAccess clientcmd.ConfigAccess) (string, bool) {
-	config, err := k8sConfigAccess.GetStartingConfig()
-	if err != nil {
-		return "", false
+func isLoggedWithGSContext(k8sConfig *clientcmdapi.Config) (string, bool) {
+	if !kubeconfig.IsKubeContext(k8sConfig.CurrentContext) {
+		return k8sConfig.CurrentContext, false
 	}
 
-	if !kubeconfig.IsKubeContext(config.CurrentContext) {
-		return config.CurrentContext, false
-	}
-
-	return config.CurrentContext, true
+	return k8sConfig.CurrentContext, true
 }
 
 func validateAuthProvider(provider *clientcmdapi.AuthProviderConfig) error {

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -280,8 +280,6 @@ func isLoggedWithGSContext(k8sConfig *clientcmdapi.Config) (string, bool) {
 }
 
 func validateAuthProvider(provider *clientcmdapi.AuthProviderConfig) error {
-	var err error
-
 	keys := []string{
 		ClientID,
 		ClientSecret,
@@ -295,7 +293,8 @@ func validateAuthProvider(provider *clientcmdapi.AuthProviderConfig) error {
 		}
 	}
 
-	if _, err = url.ParseRequestURI(provider.Config[Issuer]); err != nil {
+	_, err := url.ParseRequestURI(provider.Config[Issuer])
+	if err != nil {
 		return microerror.Mask(invalidAuthConfigurationError)
 	}
 

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -231,7 +231,7 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 
 	err = validateAuthProvider(authProvider)
 	if err != nil {
-		return microerror.Maskf(incorrectConfigurationError, "The authentication configuration is corrupted, please log in again.")
+		return microerror.Maskf(incorrectConfigurationError, "The authentication configuration is corrupted, please log in again using a URL.")
 	}
 
 	if newContextName == config.CurrentContext {

--- a/cmd/login/config.go
+++ b/cmd/login/config.go
@@ -1,0 +1,9 @@
+package login
+
+const (
+	ClientID     = "client-id"
+	ClientSecret = "client-secret"
+	Issuer       = "issuer"
+	IDToken      = "id-token"
+	RefreshToken = "refresh-token"
+)

--- a/cmd/login/config.go
+++ b/cmd/login/config.go
@@ -3,7 +3,7 @@ package login
 const (
 	ClientID     = "client-id"
 	ClientSecret = "client-secret"
-	Issuer       = "issuer"
+	Issuer       = "idp-issuer-url"
 	IDToken      = "id-token"
 	RefreshToken = "refresh-token"
 )

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -82,3 +82,12 @@ var contextAlreadySelectedError = &microerror.Error{
 func IsContextAlreadySelected(err error) bool {
 	return microerror.Cause(err) == contextAlreadySelectedError
 }
+
+var invalidAuthConfigurationError = &microerror.Error{
+	Kind: "invalidAuthConfigurationError",
+}
+
+// IsInvalidAuthConfiguration asserts invalidAuthConfigurationError.
+func IsInvalidAuthConfiguration(err error) bool {
+	return microerror.Cause(err) == invalidAuthConfigurationError
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/15200

This PR makes sure that if we're trying to re-use the currently selected kube context for logging in, we validate that it's configured properly, so that none of the properties are missing.

### Preview

<details>
<summary>Logging in with an installation codename/kubectl context (have already been logged in before)</summary>

![image](https://user-images.githubusercontent.com/13508038/105187180-c960f880-5b32-11eb-9b0d-ea6ccd58da7f.png)

</details>

<details>
<summary>Logging in without any arguments (just renewing the token)</summary>

![image](https://user-images.githubusercontent.com/13508038/105186688-4344b200-5b32-11eb-9deb-8f4ad6b7c57a.png)

</details>
