### PR TITLE
Use absolute paths for k8s certs

### DIFF
--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -202,7 +202,7 @@ func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.In
 		config.CurrentContext = contextName
 	}
 
-	err = clientcmd.ModifyConfig(k8sConfigAccess, *config, true)
+	err = clientcmd.ModifyConfig(k8sConfigAccess, *config, false)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/15265

Pretty straightforward