### PR TITLE
Return the CAPI Cluster resource from the 'get clusters' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Make the `login` command validate the current context before considering it good to go.
 - Re-enabled the `--pods-cidr` flag in the `template cluster` command.
+- Return the Cluster API `Cluster` resource when using the `get clusters` command with `YAML`/`JSON` output.
 
 ## [1.20.0] - 2021-01-18
 

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -9,22 +9,24 @@ import (
 
 	"github.com/giantswarm/kubectl-gs/cmd/get/clusters/provider"
 	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
 	"github.com/giantswarm/kubectl-gs/pkg/output"
 )
 
-func (r *runner) printOutput(resource runtime.Object) error {
+func (r *runner) printOutput(clusterResource cluster.Resource) error {
 	var (
-		err     error
-		printer printers.ResourcePrinter
+		err      error
+		printer  printers.ResourcePrinter
+		resource runtime.Object
 	)
 
 	switch {
 	case output.IsOutputDefault(r.flag.print.OutputFormat):
 		switch r.provider {
 		case key.ProviderAWS:
-			resource = provider.GetAWSTable(resource)
+			resource = provider.GetAWSTable(clusterResource)
 		case key.ProviderAzure:
-			resource = provider.GetAzureTable(resource)
+			resource = provider.GetAzureTable(clusterResource)
 		}
 
 		printOptions := printers.PrintOptions{
@@ -33,6 +35,7 @@ func (r *runner) printOutput(resource runtime.Object) error {
 		printer = printers.NewTablePrinter(printOptions)
 
 	case output.IsOutputName(r.flag.print.OutputFormat):
+		resource = clusterResource.Object()
 		err = output.PrintResourceNames(r.stdout, resource)
 		if err != nil {
 			return microerror.Mask(err)
@@ -41,6 +44,7 @@ func (r *runner) printOutput(resource runtime.Object) error {
 		return nil
 
 	default:
+		resource = clusterResource.Object()
 		printer, err = r.flag.print.ToPrinter()
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -251,6 +251,10 @@ func Test_printOutput(t *testing.T) {
 
 func newCAPIV1alpha2Cluster(id, namespace string) *capiv1alpha2.Cluster {
 	c := &capiv1alpha2.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1alpha2",
+			Kind:       "Cluster",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      id,
 			Namespace: namespace,
@@ -267,6 +271,10 @@ func newCAPIV1alpha3Cluster(id, created, release, org, description string, condi
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	c := &capiv1alpha3.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
+			Kind:       "Cluster",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              id,
 			Namespace:         "default",
@@ -291,11 +299,6 @@ func newCAPIV1alpha3Cluster(id, created, release, org, description string, condi
 	}
 	c.SetConditions(resConditions)
 
-	{
-		c.APIVersion = "v1alpha3"
-		c.Kind = "Cluster"
-	}
-
 	return c
 }
 
@@ -310,6 +313,7 @@ func newAWSClusterResource(id, created, release, org, description string, condit
 			Labels: map[string]string{
 				label.ReleaseVersion: release,
 				label.Organization:   org,
+				label.Cluster:        id,
 			},
 		},
 		Spec: infrastructurev1alpha2.AWSClusterSpec{
@@ -347,6 +351,10 @@ func newAWSCluster(id, created, release, org, description string, conditions []s
 
 func newAzureClusterResource(id, namespace string) *capzv1alpha3.AzureCluster {
 	c := &capzv1alpha3.AzureCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+			Kind:       "AzureCluster",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      id,
 			Namespace: namespace,

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -10,13 +10,15 @@ import (
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/internal/label"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
 	"github.com/giantswarm/kubectl-gs/pkg/output"
 	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 )
@@ -30,14 +32,14 @@ var update = goflag.Bool("update", false, "update .golden reference test files")
 func Test_printOutput(t *testing.T) {
 	testCases := []struct {
 		name               string
-		cr                 runtime.Object
+		clusterRes         cluster.Resource
 		provider           string
 		outputType         string
 		expectedGoldenFile string
 	}{
 		{
 			name: "case 0: print list of AWS clusters, with table output",
-			cr: newAWSClusterList(
+			clusterRes: newClusterCollection(
 				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -51,7 +53,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 1: print list of AWS clusters, with JSON output",
-			cr: newAWSClusterList(
+			clusterRes: newClusterCollection(
 				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -65,7 +67,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 2: print list of AWS clusters, with YAML output",
-			cr: newAWSClusterList(
+			clusterRes: newClusterCollection(
 				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -79,7 +81,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 3: print list of AWS clusters, with name output",
-			cr: newAWSClusterList(
+			clusterRes: newClusterCollection(
 				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -93,35 +95,35 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name:               "case 4: print single AWS cluster, with table output",
-			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeDefault,
 			expectedGoldenFile: "print_single_aws_cluster_table_output.golden",
 		},
 		{
 			name:               "case 5: print single AWS cluster, with JSON output",
-			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeJSON,
 			expectedGoldenFile: "print_single_aws_cluster_json_output.golden",
 		},
 		{
 			name:               "case 6: print single AWS cluster, with YAML output",
-			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeYAML,
 			expectedGoldenFile: "print_single_aws_cluster_yaml_output.golden",
 		},
 		{
 			name:               "case 7: print single AWS cluster, with name output",
-			cr:                 newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeName,
 			expectedGoldenFile: "print_single_aws_cluster_name_output.golden",
 		},
 		{
 			name: "case 8: print list of Azure clusters, with table output",
-			cr: newAzureClusterList(
+			clusterRes: newClusterCollection(
 				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -135,7 +137,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 9: print list of Azure clusters, with JSON output",
-			cr: newAzureClusterList(
+			clusterRes: newClusterCollection(
 				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -149,7 +151,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 10: print list of Azure clusters, with YAML output",
-			cr: newAzureClusterList(
+			clusterRes: newClusterCollection(
 				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -163,7 +165,7 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name: "case 11: print list of Azure clusters, with name output",
-			cr: newAzureClusterList(
+			clusterRes: newClusterCollection(
 				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
 				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha2.ClusterStatusConditionCreated, infrastructurev1alpha2.ClusterStatusConditionCreating}),
@@ -177,28 +179,28 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name:               "case 12: print single Azure cluster, with table output",
-			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeDefault,
 			expectedGoldenFile: "print_single_azure_cluster_table_output.golden",
 		},
 		{
 			name:               "case 13: print single Azure cluster, with JSON output",
-			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeJSON,
 			expectedGoldenFile: "print_single_azure_cluster_json_output.golden",
 		},
 		{
 			name:               "case 14: print single Azure cluster, with YAML output",
-			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeYAML,
 			expectedGoldenFile: "print_single_azure_cluster_yaml_output.golden",
 		},
 		{
 			name:               "case 15: print single Azure cluster, with name output",
-			cr:                 newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha2.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeName,
 			expectedGoldenFile: "print_single_azure_cluster_name_output.golden",
@@ -217,7 +219,7 @@ func Test_printOutput(t *testing.T) {
 				provider: tc.provider,
 			}
 
-			err := runner.printOutput(tc.cr)
+			err := runner.printOutput(tc.clusterRes)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
@@ -247,17 +249,57 @@ func Test_printOutput(t *testing.T) {
 	}
 }
 
-func newAWSClusterList(clusters ...infrastructurev1alpha2.AWSCluster) *infrastructurev1alpha2.AWSClusterList {
-	clusterList := &infrastructurev1alpha2.AWSClusterList{}
+func newCAPIV1alpha2Cluster(id, namespace string) *capiv1alpha2.Cluster {
+	c := &capiv1alpha2.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: namespace,
+			Labels: map[string]string{
+				label.Cluster: id,
+			},
+		},
+	}
 
-	clusterList.Items = clusters
-	clusterList.APIVersion = "v1"
-	clusterList.Kind = "List"
-
-	return clusterList
+	return c
 }
 
-func newAWSCluster(id, created, release, org, description string, conditions []string) *infrastructurev1alpha2.AWSCluster {
+func newCAPIV1alpha3Cluster(id, created, release, org, description string, conditions []string) *capiv1alpha3.Cluster {
+	location, _ := time.LoadLocation("UTC")
+	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
+	c := &capiv1alpha3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              id,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(parsedCreationDate),
+			Labels: map[string]string{
+				label.ReleaseVersion:          release,
+				label.Organization:            org,
+				capiv1alpha3.ClusterLabelName: id,
+			},
+			Annotations: map[string]string{
+				annotation.ClusterDescription: description,
+			},
+		},
+	}
+
+	resConditions := make([]capiv1alpha3.Condition, 0, len(conditions))
+	for _, condition := range conditions {
+		resConditions = append(resConditions, capiv1alpha3.Condition{
+			Type:   capiv1alpha3.ConditionType(condition),
+			Status: "True",
+		})
+	}
+	c.SetConditions(resConditions)
+
+	{
+		c.APIVersion = "v1alpha3"
+		c.Kind = "Cluster"
+	}
+
+	return c
+}
+
+func newAWSClusterResource(id, created, release, org, description string, conditions []string) *infrastructurev1alpha2.AWSCluster {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	c := &infrastructurev1alpha2.AWSCluster{
@@ -291,49 +333,49 @@ func newAWSCluster(id, created, release, org, description string, conditions []s
 	return c
 }
 
-func newAzureClusterList(clusters ...capiv1alpha3.Cluster) *capiv1alpha3.ClusterList {
-	clusterList := &capiv1alpha3.ClusterList{}
+func newAWSCluster(id, created, release, org, description string, conditions []string) *cluster.Cluster {
+	awsCluster := newAWSClusterResource(id, created, release, org, description, conditions)
+	capiCluster := newCAPIV1alpha2Cluster(id, "default")
 
-	clusterList.Items = clusters
-	clusterList.APIVersion = "v1"
-	clusterList.Kind = "List"
-
-	return clusterList
-}
-
-func newAzureCluster(id, created, release, org, description string, conditions []string) *capiv1alpha3.Cluster {
-	location, _ := time.LoadLocation("UTC")
-	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
-	c := &capiv1alpha3.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              id,
-			Namespace:         "default",
-			CreationTimestamp: metav1.NewTime(parsedCreationDate),
-			Labels: map[string]string{
-				label.ReleaseVersion: release,
-				label.Organization:   org,
-			},
-			Annotations: map[string]string{
-				annotation.ClusterDescription: description,
-			},
-		},
-	}
-
-	resConditions := make([]capiv1alpha3.Condition, 0, len(conditions))
-	for _, condition := range conditions {
-		resConditions = append(resConditions, capiv1alpha3.Condition{
-			Type:   capiv1alpha3.ConditionType(condition),
-			Status: "True",
-		})
-	}
-	c.SetConditions(resConditions)
-
-	{
-		c.APIVersion = "v1alpha3"
-		c.Kind = "Cluster"
+	c := &cluster.Cluster{
+		AWSCluster:      awsCluster,
+		V1Alpha2Cluster: capiCluster,
 	}
 
 	return c
+}
+
+func newAzureClusterResource(id, namespace string) *capzv1alpha3.AzureCluster {
+	c := &capzv1alpha3.AzureCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: namespace,
+			Labels: map[string]string{
+				capiv1alpha3.ClusterLabelName: id,
+			}},
+	}
+
+	return c
+}
+
+func newAzureCluster(id, created, release, org, description string, conditions []string) *cluster.Cluster {
+	azureCluster := newAzureClusterResource(id, "default")
+	capiCluster := newCAPIV1alpha3Cluster(id, created, release, org, description, conditions)
+
+	c := &cluster.Cluster{
+		AzureCluster: azureCluster,
+		Cluster:      capiCluster,
+	}
+
+	return c
+}
+
+func newClusterCollection(clusters ...cluster.Cluster) *cluster.Collection {
+	collection := &cluster.Collection{
+		Items: clusters,
+	}
+
+	return collection
 }
 
 func Test_printNoResourcesOutput(t *testing.T) {

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
@@ -64,7 +63,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
-	var resource runtime.Object
+	var resource cluster.Resource
 	{
 		options := cluster.GetOptions{
 			Provider: r.provider,

--- a/cmd/get/clusters/runner_test.go
+++ b/cmd/get/clusters/runner_test.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
@@ -34,10 +32,10 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 0: get clusters",
 			storage: []runtime.Object{
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
-				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
-				newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				newCAPIV1alpha2Cluster("1sad2", "default"),
+				newAWSClusterResource("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				newCAPIV1alpha2Cluster("f930q", "default"),
+				newAWSClusterResource("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
 			},
 			args:               nil,
 			expectedGoldenFile: "run_get_clusters.golden",
@@ -51,10 +49,10 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 2: get cluster by id",
 			storage: []runtime.Object{
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
-				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
-				newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
+				newCAPIV1alpha2Cluster("1sad2", "default"),
+				newAWSClusterResource("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				newCAPIV1alpha2Cluster("f930q", "default"),
+				newAWSClusterResource("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
 			},
 			args:               []string{"f930q"},
 			expectedGoldenFile: "run_get_cluster_by_id.golden",
@@ -68,9 +66,9 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 4: get cluster by id, with no infrastructure cluster",
 			storage: []runtime.Object{
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "1sad2", Namespace: "default"}},
-				newAWSCluster("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
-				&apiv1alpha2.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "f930q", Namespace: "default"}},
+				newCAPIV1alpha2Cluster("1sad2", "default"),
+				newAWSClusterResource("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
+				newCAPIV1alpha2Cluster("f930q", "default"),
 			},
 			args:         []string{"f930q"},
 			errorMatcher: IsNotFound,

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
@@ -4,303 +4,105 @@
     "metadata": {},
     "items": [
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "1sad2",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "test",
-                    "release.giantswarm.io/version": "12.0.0"
+                    "giantswarm.io/cluster": "1sad2"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 1",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {},
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         },
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "2a03f",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "test",
-                    "release.giantswarm.io/version": "11.0.0"
+                    "giantswarm.io/cluster": "2a03f"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 2",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {
-                    "conditions": [
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Created"
-                        }
-                    ]
-                },
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         },
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "asd29",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "test",
-                    "release.giantswarm.io/version": "10.5.0"
+                    "giantswarm.io/cluster": "asd29"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 3",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {
-                    "conditions": [
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Created"
-                        },
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Creating"
-                        }
-                    ]
-                },
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         },
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "f930q",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "some-other",
-                    "release.giantswarm.io/version": "11.0.0"
+                    "giantswarm.io/cluster": "f930q"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 4",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {},
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         },
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "9f012",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "test",
-                    "release.giantswarm.io/version": "9.0.0"
+                    "giantswarm.io/cluster": "9f012"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 5",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {
-                    "conditions": [
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Deleting"
-                        }
-                    ]
-                },
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         },
         {
-            "kind": "AWSCluster",
-            "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+            "kind": "Cluster",
+            "apiVersion": "cluster.x-k8s.io/v1alpha2",
             "metadata": {
                 "name": "2f0as",
                 "namespace": "default",
-                "creationTimestamp": "2021-01-02T15:04:32Z",
+                "creationTimestamp": null,
                 "labels": {
-                    "giantswarm.io/organization": "random",
-                    "release.giantswarm.io/version": "10.5.0"
+                    "giantswarm.io/cluster": "2f0as"
                 }
             },
-            "spec": {
-                "cluster": {
-                    "description": "test cluster 6",
-                    "dns": {
-                        "domain": ""
-                    },
-                    "kubeProxy": {},
-                    "oidc": {
-                        "claims": {}
-                    }
-                },
-                "provider": {
-                    "credentialSecret": {
-                        "name": "",
-                        "namespace": ""
-                    },
-                    "master": {
-                        "availabilityZone": "",
-                        "instanceType": ""
-                    },
-                    "nodes": {},
-                    "pods": {},
-                    "region": ""
-                }
-            },
+            "spec": {},
             "status": {
-                "cluster": {
-                    "conditions": [
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Deleting"
-                        },
-                        {
-                            "lastTransitionTime": null,
-                            "condition": "Created"
-                        }
-                    ]
-                },
-                "provider": {
-                    "network": {}
-                }
+                "infrastructureReady": false,
+                "controlPlaneInitialized": false
             }
         }
     ]

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_name_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_name_output.golden
@@ -1,6 +1,6 @@
-awscluster.infrastructure.giantswarm.io/1sad2
-awscluster.infrastructure.giantswarm.io/2a03f
-awscluster.infrastructure.giantswarm.io/asd29
-awscluster.infrastructure.giantswarm.io/f930q
-awscluster.infrastructure.giantswarm.io/9f012
-awscluster.infrastructure.giantswarm.io/2f0as
+cluster.cluster.x-k8s.io/1sad2
+cluster.cluster.x-k8s.io/2a03f
+cluster.cluster.x-k8s.io/asd29
+cluster.cluster.x-k8s.io/f930q
+cluster.cluster.x-k8s.io/9f012
+cluster.cluster.x-k8s.io/2f0as

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
@@ -1,206 +1,76 @@
 apiVersion: v1
 items:
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: test
-      release.giantswarm.io/version: 12.0.0
+      giantswarm.io/cluster: 1sad2
     name: 1sad2
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 1
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster: {}
-    provider:
-      network: {}
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: test
-      release.giantswarm.io/version: 11.0.0
+      giantswarm.io/cluster: 2a03f
     name: 2a03f
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 2
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster:
-      conditions:
-      - condition: Created
-        lastTransitionTime: null
-    provider:
-      network: {}
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: test
-      release.giantswarm.io/version: 10.5.0
+      giantswarm.io/cluster: asd29
     name: asd29
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 3
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster:
-      conditions:
-      - condition: Created
-        lastTransitionTime: null
-      - condition: Creating
-        lastTransitionTime: null
-    provider:
-      network: {}
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: some-other
-      release.giantswarm.io/version: 11.0.0
+      giantswarm.io/cluster: f930q
     name: f930q
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 4
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster: {}
-    provider:
-      network: {}
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: test
-      release.giantswarm.io/version: 9.0.0
+      giantswarm.io/cluster: 9f012
     name: 9f012
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 5
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster:
-      conditions:
-      - condition: Deleting
-        lastTransitionTime: null
-    provider:
-      network: {}
-- apiVersion: infrastructure.giantswarm.io/v1alpha2
-  kind: AWSCluster
+    controlPlaneInitialized: false
+    infrastructureReady: false
+- apiVersion: cluster.x-k8s.io/v1alpha2
+  kind: Cluster
   metadata:
-    creationTimestamp: "2021-01-02T15:04:32Z"
+    creationTimestamp: null
     labels:
-      giantswarm.io/organization: random
-      release.giantswarm.io/version: 10.5.0
+      giantswarm.io/cluster: 2f0as
     name: 2f0as
     namespace: default
-  spec:
-    cluster:
-      description: test cluster 6
-      dns:
-        domain: ""
-      kubeProxy: {}
-      oidc:
-        claims: {}
-    provider:
-      credentialSecret:
-        name: ""
-        namespace: ""
-      master:
-        availabilityZone: ""
-        instanceType: ""
-      nodes: {}
-      pods: {}
-      region: ""
+  spec: {}
   status:
-    cluster:
-      conditions:
-      - condition: Deleting
-        lastTransitionTime: null
-      - condition: Created
-        lastTransitionTime: null
-    provider:
-      network: {}
+    controlPlaneInitialized: false
+    infrastructureReady: false
 kind: List
 metadata: {}

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
@@ -5,12 +5,13 @@
     "items": [
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "1sad2",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "1sad2",
                     "giantswarm.io/organization": "test",
                     "release.giantswarm.io/version": "12.0.0"
                 },
@@ -31,12 +32,13 @@
         },
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "2a03f",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "2a03f",
                     "giantswarm.io/organization": "test",
                     "release.giantswarm.io/version": "11.0.0"
                 },
@@ -64,12 +66,13 @@
         },
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "asd29",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "asd29",
                     "giantswarm.io/organization": "test",
                     "release.giantswarm.io/version": "10.5.0"
                 },
@@ -102,12 +105,13 @@
         },
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "f930q",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "f930q",
                     "giantswarm.io/organization": "some-other",
                     "release.giantswarm.io/version": "11.0.0"
                 },
@@ -128,12 +132,13 @@
         },
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "9f012",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "9f012",
                     "giantswarm.io/organization": "test",
                     "release.giantswarm.io/version": "9.0.0"
                 },
@@ -161,12 +166,13 @@
         },
         {
             "kind": "Cluster",
-            "apiVersion": "v1alpha3",
+            "apiVersion": "cluster.x-k8s.io/v1alpha3",
             "metadata": {
                 "name": "2f0as",
                 "namespace": "default",
                 "creationTimestamp": "2021-01-02T15:04:32Z",
                 "labels": {
+                    "cluster.x-k8s.io/cluster-name": "2f0as",
                     "giantswarm.io/organization": "random",
                     "release.giantswarm.io/version": "10.5.0"
                 },

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_name_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_name_output.golden
@@ -1,6 +1,6 @@
-cluster/1sad2
-cluster/2a03f
-cluster/asd29
-cluster/f930q
-cluster/9f012
-cluster/2f0as
+cluster.cluster.x-k8s.io/1sad2
+cluster.cluster.x-k8s.io/2a03f
+cluster.cluster.x-k8s.io/asd29
+cluster.cluster.x-k8s.io/f930q
+cluster.cluster.x-k8s.io/9f012
+cluster.cluster.x-k8s.io/2f0as

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
@@ -1,12 +1,13 @@
 apiVersion: v1
 items:
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 1
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: 1sad2
       giantswarm.io/organization: test
       release.giantswarm.io/version: 12.0.0
     name: 1sad2
@@ -18,13 +19,14 @@ items:
   status:
     controlPlaneInitialized: false
     infrastructureReady: false
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 2
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: 2a03f
       giantswarm.io/organization: test
       release.giantswarm.io/version: 11.0.0
     name: 2a03f
@@ -40,13 +42,14 @@ items:
       type: Created
     controlPlaneInitialized: false
     infrastructureReady: false
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 3
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: asd29
       giantswarm.io/organization: test
       release.giantswarm.io/version: 10.5.0
     name: asd29
@@ -65,13 +68,14 @@ items:
       type: Creating
     controlPlaneInitialized: false
     infrastructureReady: false
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 4
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: f930q
       giantswarm.io/organization: some-other
       release.giantswarm.io/version: 11.0.0
     name: f930q
@@ -83,13 +87,14 @@ items:
   status:
     controlPlaneInitialized: false
     infrastructureReady: false
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 5
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: 9f012
       giantswarm.io/organization: test
       release.giantswarm.io/version: 9.0.0
     name: 9f012
@@ -105,13 +110,14 @@ items:
       type: Deleting
     controlPlaneInitialized: false
     infrastructureReady: false
-- apiVersion: v1alpha3
+- apiVersion: cluster.x-k8s.io/v1alpha3
   kind: Cluster
   metadata:
     annotations:
       cluster.giantswarm.io/description: test cluster 6
     creationTimestamp: "2021-01-02T15:04:32Z"
     labels:
+      cluster.x-k8s.io/cluster-name: 2f0as
       giantswarm.io/organization: random
       release.giantswarm.io/version: 10.5.0
     name: 2f0as

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
@@ -1,51 +1,17 @@
 {
-    "kind": "AWSCluster",
-    "apiVersion": "infrastructure.giantswarm.io/v1alpha2",
+    "kind": "Cluster",
+    "apiVersion": "cluster.x-k8s.io/v1alpha2",
     "metadata": {
         "name": "f930q",
         "namespace": "default",
-        "creationTimestamp": "2021-01-02T15:04:32Z",
+        "creationTimestamp": null,
         "labels": {
-            "giantswarm.io/organization": "some-other",
-            "release.giantswarm.io/version": "11.0.0"
+            "giantswarm.io/cluster": "f930q"
         }
     },
-    "spec": {
-        "cluster": {
-            "description": "test cluster 4",
-            "dns": {
-                "domain": ""
-            },
-            "kubeProxy": {},
-            "oidc": {
-                "claims": {}
-            }
-        },
-        "provider": {
-            "credentialSecret": {
-                "name": "",
-                "namespace": ""
-            },
-            "master": {
-                "availabilityZone": "",
-                "instanceType": ""
-            },
-            "nodes": {},
-            "pods": {},
-            "region": ""
-        }
-    },
+    "spec": {},
     "status": {
-        "cluster": {
-            "conditions": [
-                {
-                    "lastTransitionTime": null,
-                    "condition": "Created"
-                }
-            ]
-        },
-        "provider": {
-            "network": {}
-        }
+        "infrastructureReady": false,
+        "controlPlaneInitialized": false
     }
 }

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_name_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_name_output.golden
@@ -1,1 +1,1 @@
-awscluster.infrastructure.giantswarm.io/f930q
+cluster.cluster.x-k8s.io/f930q

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
@@ -1,34 +1,12 @@
-apiVersion: infrastructure.giantswarm.io/v1alpha2
-kind: AWSCluster
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Cluster
 metadata:
-  creationTimestamp: "2021-01-02T15:04:32Z"
+  creationTimestamp: null
   labels:
-    giantswarm.io/organization: some-other
-    release.giantswarm.io/version: 11.0.0
+    giantswarm.io/cluster: f930q
   name: f930q
   namespace: default
-spec:
-  cluster:
-    description: test cluster 4
-    dns:
-      domain: ""
-    kubeProxy: {}
-    oidc:
-      claims: {}
-  provider:
-    credentialSecret:
-      name: ""
-      namespace: ""
-    master:
-      availabilityZone: ""
-      instanceType: ""
-    nodes: {}
-    pods: {}
-    region: ""
+spec: {}
 status:
-  cluster:
-    conditions:
-    - condition: Created
-      lastTransitionTime: null
-  provider:
-    network: {}
+  controlPlaneInitialized: false
+  infrastructureReady: false

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
@@ -1,11 +1,12 @@
 {
     "kind": "Cluster",
-    "apiVersion": "v1alpha3",
+    "apiVersion": "cluster.x-k8s.io/v1alpha3",
     "metadata": {
         "name": "f930q",
         "namespace": "default",
         "creationTimestamp": "2021-01-02T15:04:32Z",
         "labels": {
+            "cluster.x-k8s.io/cluster-name": "f930q",
             "giantswarm.io/organization": "some-other",
             "release.giantswarm.io/version": "11.0.0"
         },

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_name_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_name_output.golden
@@ -1,1 +1,1 @@
-cluster/f930q
+cluster.cluster.x-k8s.io/f930q

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
@@ -1,10 +1,11 @@
-apiVersion: v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   annotations:
     cluster.giantswarm.io/description: test cluster 4
   creationTimestamp: "2021-01-02T15:04:32Z"
   labels:
+    cluster.x-k8s.io/cluster-name: f930q
     giantswarm.io/organization: some-other
     release.giantswarm.io/version: 11.0.0
   name: f930q

--- a/pkg/data/client/client.go
+++ b/pkg/data/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/rest"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -44,6 +45,7 @@ func New(config Config) (*Client, error) {
 			SchemeBuilder: k8sclient.SchemeBuilder{
 				capiv1alpha2.AddToScheme,
 				capiv1alpha3.AddToScheme,
+				capzv1alpha3.AddToScheme,
 				capiexpv1alpha3.AddToScheme,
 				capzexpv1alpha3.AddToScheme,
 				applicationv1alpha1.AddToScheme,

--- a/pkg/data/client/k8sclient_fake.go
+++ b/pkg/data/client/k8sclient_fake.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -39,6 +40,7 @@ func NewFakeK8sClient() k8sclient.Interface {
 		schemeBuilder := runtime.SchemeBuilder(k8sclient.SchemeBuilder{
 			capiv1alpha2.AddToScheme,
 			capiv1alpha3.AddToScheme,
+			capzv1alpha3.AddToScheme,
 			capiexpv1alpha3.AddToScheme,
 			capzexpv1alpha3.AddToScheme,
 			applicationv1alpha1.AddToScheme,

--- a/pkg/data/domain/cluster/aws.go
+++ b/pkg/data/domain/cluster/aws.go
@@ -4,11 +4,12 @@ import (
 	"context"
 
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
-	"github.com/giantswarm/kubectl-gs/internal/label"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/kubectl-gs/internal/label"
 )
 
 func (s *Service) getAllAWS(ctx context.Context, namespace string) (Resource, error) {

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -4,16 +4,15 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
-func (s *Service) Get(ctx context.Context, options GetOptions) (runtime.Object, error) {
+func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {
+	var resource Resource
 	var err error
 
-	var resource runtime.Object
-	if options.ID != "" {
+	if len(options.ID) > 0 {
 		resource, err = s.getById(ctx, options.Provider, options.ID, options.Namespace)
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -28,20 +27,20 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (runtime.Object, 
 	return resource, nil
 }
 
-func (s *Service) getById(ctx context.Context, provider, id, namespace string) (runtime.Object, error) {
+func (s *Service) getById(ctx context.Context, provider, id, namespace string) (Resource, error) {
 	var err error
 
-	var resource runtime.Object
+	var cluster Resource
 	{
 		switch provider {
 		case key.ProviderAWS:
-			resource, err = s.getByIdAWS(ctx, id, namespace)
+			cluster, err = s.getByIdAWS(ctx, id, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
 		case key.ProviderAzure:
-			resource, err = s.getByIdAzure(ctx, id, namespace)
+			cluster, err = s.getByIdAzure(ctx, id, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
@@ -51,23 +50,23 @@ func (s *Service) getById(ctx context.Context, provider, id, namespace string) (
 		}
 	}
 
-	return resource, nil
+	return cluster, nil
 }
 
-func (s *Service) getAll(ctx context.Context, provider, namespace string) (runtime.Object, error) {
+func (s *Service) getAll(ctx context.Context, provider, namespace string) (Resource, error) {
 	var err error
 
-	var clusterList runtime.Object
+	var clusterCollection Resource
 	{
 		switch provider {
 		case key.ProviderAWS:
-			clusterList, err = s.getAllAWS(ctx, namespace)
+			clusterCollection, err = s.getAllAWS(ctx, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
 		case key.ProviderAzure:
-			clusterList, err = s.getAllAzure(ctx, namespace)
+			clusterCollection, err = s.getAllAzure(ctx, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
@@ -77,5 +76,5 @@ func (s *Service) getAll(ctx context.Context, provider, namespace string) (runti
 		}
 	}
 
-	return clusterList, nil
+	return clusterCollection, nil
 }

--- a/pkg/data/domain/cluster/service_fake.go
+++ b/pkg/data/domain/cluster/service_fake.go
@@ -35,7 +35,7 @@ func NewFakeService(storage []runtime.Object) *FakeService {
 	return ms
 }
 
-func (ms *FakeService) Get(ctx context.Context, options GetOptions) (runtime.Object, error) {
+func (ms *FakeService) Get(ctx context.Context, options GetOptions) (Resource, error) {
 	var err error
 	for _, res := range ms.storage {
 		err = ms.service.client.K8sClient.CtrlClient().Create(ctx, res)

--- a/pkg/data/domain/cluster/spec.go
+++ b/pkg/data/domain/cluster/spec.go
@@ -3,7 +3,12 @@ package cluster
 import (
 	"context"
 
+	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 type GetOptions struct {
@@ -16,5 +21,58 @@ type GetOptions struct {
 // Using this instead of a regular 'struct' makes mocking the
 // service in tests much simpler.
 type Interface interface {
-	Get(context.Context, GetOptions) (runtime.Object, error)
+	Get(context.Context, GetOptions) (Resource, error)
+}
+
+type Resource interface {
+	Object() runtime.Object
+}
+
+// Cluster abstracts away provider-specific
+// node pool resources.
+type Cluster struct {
+	V1Alpha2Cluster *capiv1alpha2.Cluster
+	Cluster         *capiv1alpha3.Cluster
+
+	AWSCluster   *infrastructurev1alpha2.AWSCluster
+	AzureCluster *capzv1alpha3.AzureCluster
+}
+
+func (n *Cluster) Object() runtime.Object {
+	if n.V1Alpha2Cluster != nil {
+		return n.V1Alpha2Cluster
+	} else if n.Cluster != nil {
+		return n.Cluster
+	}
+
+	return nil
+}
+
+// Collection wraps a list of clusters.
+type Collection struct {
+	Items []Cluster
+}
+
+func (cc *Collection) Object() runtime.Object {
+	list := &metav1.List{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+	}
+
+	for _, item := range cc.Items {
+		obj := item.Object()
+		if obj == nil {
+			continue
+		}
+
+		raw := runtime.RawExtension{
+			Object: obj,
+		}
+		list.Items = append(list.Items, raw)
+	}
+
+	return list
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/13748

This PR makes use of the [same type of abstraction](https://github.com/giantswarm/kubectl-gs/pull/260) that we used with the `get nodepools` command, so we can make use of whatever resources we want when printing information (such as both CAPI `Cluster` and custom `AWSCluster` resource on AWS). 