### PR TITLE
Use spark CR as bootstrap config ref when templating a new machinepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- The `MachinePool` CRs now hold a reference to the `Spark` CR in their `spec.template.spec.bootstrap.configRef` field.
+
 ## [1.21.0] - 2021-01-29
 
 ### Changed

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -34,7 +34,7 @@ type NodePoolCRsConfig struct {
 	Namespace         string
 }
 
-func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *corev1.ObjectReference) *expcapiv1alpha3.MachinePool {
+func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *corev1.ObjectReference, bootstrapConfigRef *corev1.ObjectReference) *expcapiv1alpha3.MachinePool {
 	mp := &expcapiv1alpha3.MachinePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MachinePool",
@@ -61,6 +61,9 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 				Spec: capiv1alpha3.MachineSpec{
 					ClusterName:       config.ClusterID,
 					InfrastructureRef: *infrastructureRef,
+					Bootstrap: capiv1alpha3.Bootstrap{
+						ConfigRef: bootstrapConfigRef,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Same as https://github.com/giantswarm/api/pull/1223