### PR TITLE
Terminology update

### DIFF
--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -26,7 +26,7 @@ Output columns:
 - ID: Unique identifier of the cluster.
 - CREATED: Date and time of the Cluster CR creation.
 - CONDITION: Latest condition reported for the cluster. Can be "CREATING", "CREATED", "UPDATING", "UPDATED", "DELETING".
-- RELEASE: Release version of the cluster.
+- RELEASE: Workload cluster release used by the cluster.
 - ORGANIZATION: Organization owning the cluster.
 - DESCRIPTION: User friendly description for the cluster.`
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -60,7 +60,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Workload cluster name.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
-	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
+	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release. If not given, this remains empty for defaulting to the most recent one via the Management API.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Workload cluster label.")
 }
 

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -24,7 +24,8 @@ func New(provider string) *Service {
 	return s
 }
 
-// Supports checks if a certain feature is supported or not on a given release version.
+// Supports checks if a certain feature is supported or not on a given
+// workload cluster release version.
 func (s *Service) Supports(featureName string, releaseVersion string) bool {
 	feature, exists := s.features[featureName]
 	if !exists {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -1,3 +1,4 @@
+// Package release facilitates handling of workload cluster releases.
 package release
 
 import (


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14339

This modifies some help texts in order to use the term "workload cluster release" where we have enough space for it.

In addition, I'm adding a clarification regarding release workload cluster defaulting (see https://github.com/giantswarm/giantswarm/issues/15828)