### PR TITLE
Allow 0 nodes for node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow having node pools with the scaling set to `0`.
+
 ## [1.22.0] - 2021-02-11
 
 ### Changed

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -131,11 +131,11 @@ func (f *flag) Validate() error {
 		}
 
 		// Validate scaling.
-		if f.NodesMax < 1 {
-			return microerror.Maskf(invalidFlagError, "--%s must be > 0", flagNodesMax)
+		if f.NodesMax < 0 {
+			return microerror.Maskf(invalidFlagError, "--%s must be >= 0", flagNodesMax)
 		}
-		if f.NodesMin < 1 {
-			return microerror.Maskf(invalidFlagError, "--%s must be > 0", flagNodesMin)
+		if f.NodesMin < 0 {
+			return microerror.Maskf(invalidFlagError, "--%s must be >= 0", flagNodesMin)
 		}
 		if f.NodesMin > f.NodesMax {
 			return microerror.Maskf(invalidFlagError, "--%s must be <= --%s", flagNodesMin, flagNodesMax)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15897

Allow setting scaling to `0` while templating node pools.