### PR TITLE
Adds capi information command

### DIFF
--- a/cmd/get/capi/command.go
+++ b/cmd/get/capi/command.go
@@ -1,0 +1,54 @@
+package capi
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	name        = "cluster-api"
+	description = "Display information about Cluster API CRDs and controllers"
+)
+
+type Config struct {
+	Logger          micrologger.Logger
+	K8sConfigAccess clientcmd.ConfigAccess
+	Stdout          io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.K8sConfigAccess == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Aliases: []string{"capi"},
+		Short:   description,
+		Long:    description,
+		RunE:    r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/get/capi/error.go
+++ b/cmd/get/capi/error.go
@@ -1,0 +1,23 @@
+package capi
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/get/capi/flag.go
+++ b/cmd/get/capi/flag.go
@@ -1,0 +1,25 @@
+package capi
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type flag struct {
+	config genericclioptions.RESTClientGetter
+	print  *genericclioptions.PrintFlags
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	f.config = genericclioptions.NewConfigFlags(true)
+	f.print = genericclioptions.NewPrintFlags("")
+
+	// Merging current command flags and config flags,
+	// to be able to override kubectl-specific ones.
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+	f.print.AddFlags(cmd)
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/get/capi/runner.go
+++ b/cmd/get/capi/runner.go
@@ -1,0 +1,293 @@
+package capi
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+)
+
+const (
+	giantswarmNamespace = "giantswarm"
+
+	providerAll    = "All"
+	providerAWS    = "AWS"
+	providerAzure  = "Azure"
+	providerVMware = "VMware"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+
+	stdout io.Writer
+}
+
+type crd struct {
+	DisplayName string
+	Name        string
+	Provider    string
+}
+
+type controller struct {
+	DisplayName   string
+	LabelSelector string
+	ContainerName string
+	Provider      string
+}
+
+var (
+	crds = []crd{
+		{
+			DisplayName: "Cluster",
+			Name:        "clusters.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Machine Pool",
+			Name:        "machinepools.exp.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Machine Deployment",
+			Name:        "machinedeployments.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Machine Set",
+			Name:        "machinesets.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Machine",
+			Name:        "machines.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Machine Health Check",
+			Name:        "machinehealthchecks.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Kubeadm Control Plane",
+			Name:        "kubeadmcontrolplanes.controlplane.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Kubeadm Config",
+			Name:        "kubeadmconfigs.bootstrap.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "Kubeadm Config Template",
+			Name:        "kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "AWS Cluster",
+			Name:        "awsclusters.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAWS,
+		},
+		{
+			DisplayName: "AWS Machine Pools",
+			Name:        "awsmachinepools.exp.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAWS,
+		},
+		{
+			DisplayName: "AWS Machine",
+			Name:        "awsmachines.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAWS,
+		},
+		{
+			DisplayName: "AWS Machine Template",
+			Name:        "awsmachinetemplates.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAWS,
+		},
+		{
+			DisplayName: "Azure Cluster",
+			Name:        "azureclusters.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAzure,
+		},
+		{
+			DisplayName: "Azure Machine Pools",
+			Name:        "azuremachinepools.exp.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAzure,
+		},
+		{
+			DisplayName: "Azure Machine",
+			Name:        "azuremachines.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAzure,
+		},
+		{
+			DisplayName: "Azure Machine Template",
+			Name:        "azuremachinetemplates.infrastructure.cluster.x-k8s.io",
+			Provider:    providerAzure,
+		},
+		{
+			DisplayName: "VMware Cluster",
+			Name:        "vsphereclusters.infrastructure.cluster.x-k8s.io",
+			Provider:    providerVMware,
+		},
+		{
+			DisplayName: "VMware Machine",
+			Name:        "vspheremachines.infrastructure.cluster.x-k8s.io",
+			Provider:    providerVMware,
+		},
+		{
+			DisplayName: "VMware Machine Template",
+			Name:        "vspheremachinetemplates.infrastructure.cluster.x-k8s.io",
+			Provider:    providerVMware,
+		},
+		{
+			DisplayName: "VMware VM",
+			Name:        "vspherevms.infrastructure.cluster.x-k8s.io",
+			Provider:    providerVMware,
+		},
+		{
+			DisplayName: "VMware HAProxy",
+			Name:        "haproxyloadbalancers.infrastructure.cluster.x-k8s.io",
+			Provider:    providerVMware,
+		},
+	}
+
+	controllers = []controller{
+		{
+			DisplayName:   "Core",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-core",
+			ContainerName: "manager",
+			Provider:      providerAll,
+		},
+		{
+			DisplayName:   "Kubeadm Bootstrap",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-bootstrap-provider-kubeadm",
+			ContainerName: "manager",
+			Provider:      providerAll,
+		},
+		{
+			DisplayName:   "Kubadm Control Plane",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-control-plane",
+			ContainerName: "manager",
+			Provider:      providerAll,
+		},
+		{
+			DisplayName:   "AWS Provider",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-provider-aws,control-plane=capa-controller-manager",
+			ContainerName: "manager",
+			Provider:      providerAWS,
+		},
+		{
+			DisplayName:   "Azure Provider",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-provider-azure",
+			ContainerName: "manager",
+			Provider:      providerAzure,
+		},
+		{
+			DisplayName:   "VMWare Provider",
+			LabelSelector: "app.kubernetes.io/name=cluster-api-provider-vmware",
+			ContainerName: "manager",
+			Provider:      providerVMware,
+		},
+	}
+)
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var client k8sclient.Interface
+	{
+		config := commonconfig.New(r.flag.config)
+		c, err := config.GetClient(r.logger)
+
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		client = c.K8sClient
+	}
+
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Type", Type: "string"},
+			{Name: "Provider", Type: "string"},
+			{Name: "Name", Type: "string"},
+			{Name: "Version", Type: "string"},
+		},
+	}
+
+	for _, crd := range crds {
+		foundCrd, err := client.ExtClient().ApiextensionsV1().CustomResourceDefinitions().Get(
+			ctx,
+			crd.Name,
+			metav1.GetOptions{},
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			return microerror.Mask(err)
+		}
+
+		if errors.IsNotFound(err) {
+			row := metav1.TableRow{Cells: []interface{}{"CRD", crd.Provider, crd.DisplayName, "NONE"}}
+			table.Rows = append(table.Rows, row)
+		}
+
+		for _, version := range foundCrd.Spec.Versions {
+			row := metav1.TableRow{Cells: []interface{}{"CRD", crd.Provider, crd.DisplayName, version.Name}}
+			table.Rows = append(table.Rows, row)
+		}
+	}
+
+	for _, controller := range controllers {
+		version := "NONE"
+
+		podList, err := client.K8sClient().CoreV1().Pods(giantswarmNamespace).List(
+			ctx,
+			metav1.ListOptions{
+				LabelSelector: controller.LabelSelector,
+			},
+		)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if len(podList.Items) == 1 {
+			for _, container := range podList.Items[0].Spec.Containers {
+				if container.Name == "manager" {
+					version = strings.Split(container.Image, ":")[1]
+				}
+			}
+		}
+
+		row := metav1.TableRow{Cells: []interface{}{"Controller", controller.Provider, controller.DisplayName, version}}
+		table.Rows = append(table.Rows, row)
+	}
+
+	printer := printers.NewTablePrinter(printers.PrintOptions{})
+	err := printer.PrintObj(table, r.stdout)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/giantswarm/kubectl-gs/cmd/get/capi"
 	"github.com/giantswarm/kubectl-gs/cmd/get/clusters"
 	"github.com/giantswarm/kubectl-gs/cmd/get/nodepools"
 )
@@ -47,6 +48,20 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	var err error
+
+	var clusterApiCmd *cobra.Command
+	{
+		c := capi.Config{
+			Logger:          config.Logger,
+			K8sConfigAccess: config.K8sConfigAccess,
+			Stdout:          config.Stdout,
+		}
+
+		clusterApiCmd, err = capi.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var clustersCmd *cobra.Command
 	{
@@ -102,6 +117,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(clusterApiCmd)
 	c.AddCommand(clustersCmd)
 	c.AddCommand(nodepoolsCmd)
 


### PR DESCRIPTION
Adds `get cluster-api` command to show status of CAPI CRDs and controllers.

e.g:
```
$ kubectl gs get cluster-api
TYPE         PROVIDER   NAME                      VERSION
CRD          All        Cluster                   v1alpha2
CRD          All        Cluster                   v1alpha3
CRD          All        Machine Pool              v1alpha3
CRD          All        Machine Deployment        v1alpha2
CRD          All        Machine Deployment        v1alpha3
CRD          All        Machine Set               v1alpha3
CRD          All        Machine                   v1alpha3
CRD          All        Machine Health Check      v1alpha3
CRD          All        Kubeadm Control Plane     v1alpha3
CRD          All        Kubeadm Config            v1alpha3
CRD          All        Kubeadm Config Template   v1alpha3
CRD          AWS        AWS Cluster               v1alpha3
CRD          AWS        AWS Machine Pools         NONE
CRD          AWS        AWS Machine               v1alpha3
CRD          AWS        AWS Machine Template      v1alpha3
CRD          Azure      Azure Cluster             NONE
CRD          Azure      Azure Machine Pools       NONE
CRD          Azure      Azure Machine             NONE
CRD          Azure      Azure Machine Template    NONE
CRD          VMware     VMware Cluster            NONE
CRD          VMware     VMware Machine            NONE
CRD          VMware     VMware Machine Template   NONE
CRD          VMware     VMware VM                 NONE
CRD          VMware     VMware HAProxy            NONE
Controller   All        Core                      v0.3.14
Controller   All        Kubeadm Bootstrap         v0.3.14
Controller   All        Kubadm Control Plane      v0.3.14
Controller   AWS        AWS Provider              v0.6.4
Controller   Azure      Azure Provider            NONE
Controller   VMware     VMWare Provider           NONE
```
(for an AWS MC).
