### PR TITLE
Checks all matching pods for CAPI controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Add support for showing information about Cluster API CRDs and controllers.
+
 ## [1.23.0] - 2021-02-24
 
 ### Changed

--- a/cmd/get/capi/runner.go
+++ b/cmd/get/capi/runner.go
@@ -271,8 +271,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 
-		if len(podList.Items) == 1 {
-			for _, container := range podList.Items[0].Spec.Containers {
+		for _, pod := range podList.Items {
+			for _, container := range pod.Spec.Containers {
 				if container.Name == "manager" {
 					version = strings.Split(container.Image, ":")[1]
 				}


### PR DESCRIPTION
We also match webhooks with our labels, so check all relevant pods for the CAPI controllers.