### PR TITLE
Print program errors to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- If the CLI quits with an error, display the error via the default OS error stream.
+
 ## [1.23.0] - 2021-02-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - If the CLI quits with an error, display the error via the default OS error stream.
 

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 		ep := errorprinter.New(errorprinter.Config{
 			StackTrace: isDebugMode(),
 		})
-		fmt.Println(ep.Format(err))
+		fmt.Fprintln(os.Stderr, ep.Format(err))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This makes sure that if you're piping the output of the program into a stream, you'll still see error messages in your terminal.

Before
```
kubectl gs some-command-that-fails > /dev/null
```

After
```
kubectl gs some-command-that-fails > /dev/null
Error: Invalid flag: --provider must be either aws or azure
exit status 1
```