### PR TITLE
adding clusterresourcesets and clusterresourcesetbindings to the get cluster-api command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add clusterresourcesets and clusterresourcesetbindings CRDs to the information about Cluster API CRDs and controllers.
+
 ## [1.25.0] - 2021-03-16
 
 ### Changed

--- a/cmd/get/capi/runner.go
+++ b/cmd/get/capi/runner.go
@@ -53,6 +53,16 @@ var (
 			Provider:    providerAll,
 		},
 		{
+			DisplayName: "ClusterResourceSet",
+			Name:        "clusterresourcesets.addons.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
+			DisplayName: "ClusterResourceSetBinding",
+			Name:        "clusterresourcesetbindings.addons.cluster.x-k8s.io",
+			Provider:    providerAll,
+		},
+		{
 			DisplayName: "Machine Pool",
 			Name:        "machinepools.exp.cluster.x-k8s.io",
 			Provider:    providerAll,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16281
This will show whether clusterresourcesets and clusterresourcesetbindings CRDs are ensured on an installation when the `get cluster-api` command is run.