### PR TITLE
Implement `get orgs` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Added
+
+- Added `organizations` subcommand to `kubectl gs get` family of commands to list and display details of organizations
+
 ## [2.20.0] - 2022-09-02
 
 ## Added

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -147,8 +147,8 @@ func New(config Config) (*cobra.Command, error) {
 			FileSystem: config.FileSystem,
 
 			ConfigFlags: config.ConfigFlags,
-			Stderr: config.Stderr,
-			Stdout: config.Stdout,
+			Stderr:      config.Stderr,
+			Stdout:      config.Stdout,
 		}
 
 		releasesCmd, err = releases.New(c)
@@ -165,8 +165,8 @@ func New(config Config) (*cobra.Command, error) {
 			FileSystem: config.FileSystem,
 
 			ConfigFlags: config.ConfigFlags,
-			Stderr: config.Stderr,
-			Stdout: config.Stdout,
+			Stderr:      config.Stderr,
+			Stdout:      config.Stdout,
 		}
 
 		orgsCmd, err = orgs.New(c)

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/kubectl-gs/cmd/get/catalogs"
 	"github.com/giantswarm/kubectl-gs/cmd/get/clusters"
 	"github.com/giantswarm/kubectl-gs/cmd/get/nodepools"
+	"github.com/giantswarm/kubectl-gs/cmd/get/orgs"
 	"github.com/giantswarm/kubectl-gs/cmd/get/releases"
 	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 )
@@ -146,12 +147,30 @@ func New(config Config) (*cobra.Command, error) {
 			FileSystem: config.FileSystem,
 
 			ConfigFlags: config.ConfigFlags,
-
 			Stderr: config.Stderr,
 			Stdout: config.Stdout,
 		}
 
 		releasesCmd, err = releases.New(c)
+
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var orgsCmd *cobra.Command
+	{
+		c := orgs.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			ConfigFlags: config.ConfigFlags,
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		orgsCmd, err = orgs.New(c)
+
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -184,6 +203,7 @@ func New(config Config) (*cobra.Command, error) {
 	c.AddCommand(clustersCmd)
 	c.AddCommand(nodepoolsCmd)
 	c.AddCommand(releasesCmd)
+	c.AddCommand(orgsCmd)
 
 	return c, nil
 }

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -1,0 +1,96 @@
+// Package org defines the 'kubectl gs get orgs' command.
+package orgs
+
+import (
+	"io"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"os"
+
+	"github.com/giantswarm/kubectl-gs/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name = "orgs"
+
+	shortDescription = "Display one or many organizations"
+	longDescription  = `Display one or many organizations.
+
+Output columns:
+
+- NAME: The organization's name, or: name of the Organization (organizations.security.giantswarm.io) resource.
+- NAMESPACE: The namespace belonging to this organization.
+`
+
+	examples = `  # List all organizations you have access to
+  kgs get orgs
+
+  # Get one specific organization
+  kgs get organization acme
+
+  Note: 'kgs' is an alias for 'kubectl gs'.`
+)
+
+var (
+	aliases = []string{"organizations", "org"}
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	ConfigFlags *genericclioptions.RESTClientGetter
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.FileSystem == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
+	}
+	if config.ConfigFlags == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		fs:     config.FileSystem,
+
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Short:   shortDescription,
+		Long:    longDescription,
+		Example: examples,
+		Aliases: aliases,
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    r.Run,
+		PreRunE: middleware.Compose(
+			renewtoken.Middleware(*config.ConfigFlags),
+		),
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -1,4 +1,4 @@
-// Package org defines the 'kubectl gs get orgs' command.
+// Package org defines the 'kubectl gs get organizations' command.
 package orgs
 
 import (
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	name = "orgs [org-name]"
+	name = "organizations [org-name]"
 
 	shortDescription = "Display one or many organizations"
 	longDescription  = `Display one or many organizations.
@@ -31,14 +31,14 @@ Output columns:
 `
 
 	examples = `  # List all organizations you have access to
-  kubectl gs get orgs
+  kubectl gs get organizations
 
   # Get one specific organization
   kubectl gs organization acme`
 )
 
 var (
-	aliases = []string{"organizations", "organization", "org"}
+	aliases = []string{"organization", "orgs", "org"}
 )
 
 type Config struct {

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -2,17 +2,20 @@
 package orgs
 
 import (
-	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 	"io"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"os"
 
-	"github.com/giantswarm/kubectl-gs/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -59,7 +59,7 @@ func New(config Config) (*cobra.Command, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
 	}
 	if config.ConfigFlags == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
+		return nil, microerror.Maskf(invalidConfigError, "%T.ConfigFlags must not be empty", config)
 	}
 	if config.Stderr == nil {
 		config.Stderr = os.Stderr

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -2,6 +2,7 @@
 package orgs
 
 import (
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 	"io"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"os"
@@ -36,7 +37,7 @@ Output columns:
 )
 
 var (
-	aliases = []string{"organizations", "org"}
+	aliases = []string{"organizations", "organization", "org"}
 )
 
 type Config struct {
@@ -69,6 +70,9 @@ func New(config Config) (*cobra.Command, error) {
 	f := &flag{}
 
 	r := &runner{
+		commonConfig: &commonconfig.CommonConfig{
+			ConfigFlags: config.ConfigFlags,
+		},
 		flag:   f,
 		logger: config.Logger,
 		fs:     config.FileSystem,

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	name = "orgs"
+	name = "orgs [org-name]"
 
 	shortDescription = "Display one or many organizations"
 	longDescription  = `Display one or many organizations.
@@ -27,16 +27,14 @@ const (
 Output columns:
 
 - NAME: The organization's name, or: name of the Organization (organizations.security.giantswarm.io) resource.
-- NAMESPACE: The namespace belonging to this organization.
+- ORG NAMESPACE: The namespace belonging to this organization.
 `
 
 	examples = `  # List all organizations you have access to
-  kgs get orgs
+  kubectl gs get orgs
 
   # Get one specific organization
-  kgs get organization acme
-
-  Note: 'kgs' is an alias for 'kubectl gs'.`
+  kubectl gs organization acme`
 )
 
 var (

--- a/cmd/get/orgs/error.go
+++ b/cmd/get/orgs/error.go
@@ -1,0 +1,21 @@
+package orgs
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/cmd/get/orgs/flag.go
+++ b/cmd/get/orgs/flag.go
@@ -1,0 +1,25 @@
+package orgs
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type flag struct {
+	config genericclioptions.RESTClientGetter
+	print  *genericclioptions.PrintFlags
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	f.config = genericclioptions.NewConfigFlags(true)
+	f.print = genericclioptions.NewPrintFlags("")
+
+	// Merging current command flags and config flags,
+	// to be able to override kubectl-specific ones.
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+	f.print.AddFlags(cmd)
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/get/orgs/flag.go
+++ b/cmd/get/orgs/flag.go
@@ -6,17 +6,14 @@ import (
 )
 
 type flag struct {
-	config genericclioptions.RESTClientGetter
-	print  *genericclioptions.PrintFlags
+	print *genericclioptions.PrintFlags
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	f.config = genericclioptions.NewConfigFlags(true)
 	f.print = genericclioptions.NewPrintFlags("")
 
 	// Merging current command flags and config flags,
 	// to be able to override kubectl-specific ones.
-	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
 	f.print.AddFlags(cmd)
 }
 

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -20,14 +20,11 @@ func (r *runner) printOutput(orgResource organization.Resource) error {
 	var resource runtime.Object = orgResource.Object()
 
 	printOptions := printers.PrintOptions{
-		NoHeaders:     false,
-		WithNamespace: true,
-		WithKind:      true,
-		Wide:          true,
-		ShowLabels:    false,
-		//Kind:             schema.GroupKind{},
-		//ColumnLabels:     []string{},
-		//SortBy:           "",
+		NoHeaders:        false,
+		WithNamespace:    false,
+		WithKind:         true,
+		Wide:             true,
+		ShowLabels:       false,
 		AllowMissingKeys: true,
 	}
 	printer = printers.NewTablePrinter(printOptions)

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -43,19 +43,19 @@ func (r *runner) printOutput(orgResource organization.Resource) error {
 			for _, org := range o.Items {
 				table.Rows = append(table.Rows, getTableRow(org))
 			}
-
-			resource = table
-			printOptions := printers.PrintOptions{
-				NoHeaders:        false,
-				WithNamespace:    false,
-				WithKind:         true,
-				Wide:             true,
-				ShowLabels:       false,
-				AllowMissingKeys: true,
-			}
-
-			printer = printers.NewTablePrinter(printOptions)
 		}
+
+		resource = table
+		printOptions := printers.PrintOptions{
+			NoHeaders:        false,
+			WithNamespace:    false,
+			WithKind:         true,
+			Wide:             true,
+			ShowLabels:       false,
+			AllowMissingKeys: true,
+		}
+
+		printer = printers.NewTablePrinter(printOptions)
 	case output.IsOutputName(r.flag.print.OutputFormat):
 		switch res := orgResource.(type) {
 		case *organization.Organization:

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -2,10 +2,12 @@ package orgs
 
 import (
 	"fmt"
-	"github.com/giantswarm/kubectl-gs/pkg/output"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sort"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kubectl-gs/pkg/output"
 
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -1,0 +1,47 @@
+package orgs
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+)
+
+type PrintOptions struct {
+	Name string
+}
+
+func (r *runner) printOutput(orgResource organization.Resource) error {
+	var err error
+	var printer printers.ResourcePrinter
+	var resource runtime.Object = orgResource.Object()
+
+	printOptions := printers.PrintOptions{
+		NoHeaders:     false,
+		WithNamespace: true,
+		WithKind:      true,
+		Wide:          true,
+		ShowLabels:    false,
+		//Kind:             schema.GroupKind{},
+		//ColumnLabels:     []string{},
+		//SortBy:           "",
+		AllowMissingKeys: true,
+	}
+	printer = printers.NewTablePrinter(printOptions)
+
+	err = printer.PrintObj(resource, r.stdout)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) printNoResourcesOutput() {
+	fmt.Fprintf(r.stdout, "No organizations found.\n")
+	fmt.Fprintf(r.stdout, "No resources of type organizations.security.giantswarm.io available. To create one, please check\n\n")
+	fmt.Fprintf(r.stdout, "  https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/\n")
+}

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -2,6 +2,10 @@ package orgs
 
 import (
 	"fmt"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sort"
+	"strings"
 
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,17 +21,67 @@ type PrintOptions struct {
 func (r *runner) printOutput(orgResource organization.Resource) error {
 	var err error
 	var printer printers.ResourcePrinter
-	var resource runtime.Object = orgResource.Object()
+	var resource runtime.Object
 
-	printOptions := printers.PrintOptions{
-		NoHeaders:        false,
-		WithNamespace:    false,
-		WithKind:         true,
-		Wide:             true,
-		ShowLabels:       false,
-		AllowMissingKeys: true,
+	switch {
+	case output.IsOutputDefault(r.flag.print.OutputFormat):
+		table := &metav1.Table{
+			ColumnDefinitions: []metav1.TableColumnDefinition{
+				{Name: "Name", Type: "string"},
+				{Name: "Org Namespace", Type: "string"},
+				{Name: "Age", Type: "string", Format: "date-time"},
+			},
+		}
+
+		switch o := orgResource.(type) {
+		case *organization.Organization:
+			table.Rows = append(table.Rows, getTableRow(*o))
+		case *organization.Collection:
+			sort.Slice(o.Items, func(i, j int) bool {
+				return strings.Compare(o.Items[i].Organization.Name, o.Items[j].Organization.Name) <= 0
+			})
+			for _, org := range o.Items {
+				table.Rows = append(table.Rows, getTableRow(org))
+			}
+
+			resource = table
+			printOptions := printers.PrintOptions{
+				NoHeaders:        false,
+				WithNamespace:    false,
+				WithKind:         true,
+				Wide:             true,
+				ShowLabels:       false,
+				AllowMissingKeys: true,
+			}
+
+			printer = printers.NewTablePrinter(printOptions)
+		}
+	case output.IsOutputName(r.flag.print.OutputFormat):
+		switch res := orgResource.(type) {
+		case *organization.Organization:
+			resource = res.Object()
+		case *organization.Collection:
+			resource = res.Object()
+		}
+
+		err = output.PrintResourceNames(r.stdout, resource)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		return nil
+	default:
+		switch res := orgResource.(type) {
+		case *organization.Organization:
+			resource = res.Object()
+		case *organization.Collection:
+			resource = res.Object()
+		}
+
+		printer, err = r.flag.print.ToPrinter()
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
-	printer = printers.NewTablePrinter(printOptions)
 
 	err = printer.PrintObj(resource, r.stdout)
 	if err != nil {
@@ -41,4 +95,17 @@ func (r *runner) printNoResourcesOutput() {
 	fmt.Fprintf(r.stdout, "No organizations found.\n")
 	fmt.Fprintf(r.stdout, "No resources of type organizations.security.giantswarm.io available. To create one, please check\n\n")
 	fmt.Fprintf(r.stdout, "  https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/\n")
+}
+
+func getTableRow(org organization.Organization) metav1.TableRow {
+	return metav1.TableRow{
+		Cells: []interface{}{
+			org.Organization.Name,
+			org.Organization.Status.Namespace,
+			output.TranslateTimestampSince(org.Organization.CreationTimestamp),
+		},
+		Object: runtime.RawExtension{
+			Object: org.Organization,
+		},
+	}
 }

--- a/cmd/get/orgs/printer_test.go
+++ b/cmd/get/orgs/printer_test.go
@@ -2,15 +2,17 @@ package orgs
 
 import (
 	"bytes"
+	"testing"
+	"time"
+
 	"github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
-	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/pkg/output"
-	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"testing"
-	"time"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 )
 
 func Test_printOutput(t *testing.T) {

--- a/cmd/get/orgs/printer_test.go
+++ b/cmd/get/orgs/printer_test.go
@@ -1,0 +1,148 @@
+package orgs
+
+import (
+	"bytes"
+	"github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"testing"
+	"time"
+)
+
+func Test_printOutput(t *testing.T) {
+	testCases := []struct {
+		name               string
+		orgRes             organization.Resource
+		outputType         string
+		expectedGoldenFile string
+	}{
+		{
+			name:               "case 0: print list of orgs, with table output",
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_list_of_orgs_table_output.golden",
+			orgRes: newOrgCollection(
+				*newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)),
+				*newOrgResource("test-2", "org-test-2", time.Now().Format(time.RFC3339)),
+				*newOrgResource("test-3", "org-test-3", time.Now().Format(time.RFC3339)),
+			),
+		},
+		{
+			name:               "case 1: print list of orgs, with JSON output",
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_list_of_orgs_json_output.golden",
+			orgRes: newOrgCollection(
+				*newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-2", "org-test-2", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-3", "org-test-3", "2022-08-18T08:07:48Z"),
+			),
+		},
+		{
+			name:               "case 2: print list of orgs, with YAML output",
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_list_of_orgs_yaml_output.golden",
+			orgRes: newOrgCollection(
+				*newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-2", "org-test-2", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-3", "org-test-3", "2022-08-18T08:07:48Z"),
+			),
+		},
+		{
+			name:               "case 3: print list of orgs, with name output",
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_list_of_orgs_name_output.golden",
+			orgRes: newOrgCollection(
+				*newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-2", "org-test-2", "2022-08-18T08:07:48Z"),
+				*newOrgResource("test-3", "org-test-3", "2022-08-18T08:07:48Z"),
+			),
+		},
+		{
+			name:               "case 4: print single org, with table output",
+			outputType:         output.TypeDefault,
+			expectedGoldenFile: "print_single_org_table_output.golden",
+			orgRes:             newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)),
+		},
+		{
+			name:               "case 4: print single org, with JSON output",
+			outputType:         output.TypeJSON,
+			expectedGoldenFile: "print_single_org_json_output.golden",
+			orgRes:             newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+		},
+		{
+			name:               "case 4: print single org, with YAML output",
+			outputType:         output.TypeYAML,
+			expectedGoldenFile: "print_single_org_yaml_output.golden",
+			orgRes:             newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+		},
+		{
+			name:               "case 4: print single org, with name output",
+			outputType:         output.TypeName,
+			expectedGoldenFile: "print_single_org_name_output.golden",
+			orgRes:             newOrgResource("test-1", "org-test-1", "2022-08-18T08:07:48Z"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := &flag{
+				print: genericclioptions.NewPrintFlags("").WithDefaultOutput(tc.outputType),
+			}
+			out := new(bytes.Buffer)
+			runner := &runner{
+				flag:   flag,
+				stdout: out,
+			}
+
+			err := runner.printOutput(tc.orgRes)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			var expectedResult []byte
+			{
+				gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+				expectedResult, err = gf.Read()
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+			}
+
+			diff := cmp.Diff(string(expectedResult), out.String())
+			if diff != "" {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
+		})
+	}
+}
+
+func newOrgResource(name, namespace, created string) *organization.Organization {
+	location, _ := time.LoadLocation("UTC")
+	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
+	creationTimestamp := metav1.NewTime(parsedCreationDate)
+	return &organization.Organization{
+		Organization: &v1alpha1.Organization{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "security.giantswarm.io/v1alpha1",
+				Kind:       "Organization",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: creationTimestamp,
+			},
+			Spec: v1alpha1.OrganizationSpec{},
+			Status: v1alpha1.OrganizationStatus{
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+func newOrgCollection(orgs ...organization.Organization) *organization.Collection {
+	return &organization.Collection{
+		Items: orgs,
+	}
+}

--- a/cmd/get/orgs/runner.go
+++ b/cmd/get/orgs/runner.go
@@ -1,0 +1,105 @@
+package orgs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	fs     afero.Fs
+
+	service organization.Interface
+
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	config := commonconfig.New(r.flag.config)
+	{
+		err = r.getService(config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var resource organization.Resource
+	{
+		options := organization.GetOptions{}
+		{
+			if len(args) > 0 {
+				options.Name = strings.ToLower(args[0])
+			}
+		}
+
+		resource, err = r.service.Get(ctx, options)
+		if organization.IsNotFound(err) {
+			return microerror.Maskf(notFoundError, fmt.Sprintf("An organization with name '%s' cannot be found.\n", options.Name))
+		} else if organization.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
+			r.printNoResourcesOutput()
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = r.printOutput(resource)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) getService(config *commonconfig.CommonConfig) error {
+	if r.service != nil {
+		return nil
+	}
+
+	client, err := config.GetClient(r.logger)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	serviceConfig := organization.Config{
+		Client: client,
+	}
+	r.service, err = organization.New(serviceConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/get/orgs/runner.go
+++ b/cmd/get/orgs/runner.go
@@ -18,9 +18,9 @@ import (
 
 type runner struct {
 	commonConfig *commonconfig.CommonConfig
-	flag   *flag
-	logger micrologger.Logger
-	fs     afero.Fs
+	flag         *flag
+	logger       micrologger.Logger
+	fs           afero.Fs
 
 	service organization.Interface
 

--- a/cmd/get/orgs/runner.go
+++ b/cmd/get/orgs/runner.go
@@ -17,6 +17,7 @@ import (
 )
 
 type runner struct {
+	commonConfig *commonconfig.CommonConfig
 	flag   *flag
 	logger micrologger.Logger
 	fs     afero.Fs
@@ -46,9 +47,8 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 
-	config := commonconfig.New(r.flag.config)
 	{
-		err = r.getService(config)
+		err = r.getService()
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -83,12 +83,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	return nil
 }
 
-func (r *runner) getService(config *commonconfig.CommonConfig) error {
+func (r *runner) getService() error {
 	if r.service != nil {
 		return nil
 	}
 
-	client, err := config.GetClient(r.logger)
+	client, err := r.commonConfig.GetClient(r.logger)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/get/orgs/runner_test.go
+++ b/cmd/get/orgs/runner_test.go
@@ -2,20 +2,22 @@ package orgs
 
 import (
 	"bytes"
-	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/pkg/output"
-	"github.com/giantswarm/kubectl-gs/test/goldenfile"
-	"github.com/giantswarm/kubectl-gs/test/kubeclient"
-	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
+	"testing"
+	"time"
+
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"testing"
-	"time"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/test/kubeclient"
+	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
 )
 
 func Test_run(t *testing.T) {

--- a/cmd/get/orgs/runner_test.go
+++ b/cmd/get/orgs/runner_test.go
@@ -1,0 +1,198 @@
+package orgs
+
+import (
+	"bytes"
+	"github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
+	"github.com/giantswarm/microerror"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+func Test_run(t *testing.T) {
+	testCases := []struct {
+		name               string
+		storage            []runtime.Object
+		args               []string
+		expectedGoldenFile string
+		errorMatcher       func(error) bool
+	}{
+		{
+			name: "case0: get orgs for admin user",
+			storage: []runtime.Object{
+				newOrg("test-1", "org-test-1"),
+				newOrg("test-2", "org-test-2"),
+				newOrg("test-3", "org-test-3"),
+			},
+			args: nil,
+			expectedGoldenFile: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeKubeConfig := kubeconfig.CreateFakeKubeConfig()
+			flag := &flag{
+				print: genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault),
+			}
+
+			out := new(bytes.Buffer)
+			runner := &runner{
+				commonConfig: commonconfig.New(genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig)),
+				flag: flag,
+				service: newOrgService(t),
+				stdout: out,
+			}
+
+			err := runner.Run(nil, tc.args)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func newOrg(name, namespace string) *v1alpha1.Organization {
+	return &v1alpha1.Organization{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "security.giantswarm.io/v1alpha1",
+			Kind: "Organization",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+		Spec: v1alpha1.OrganizationSpec{},
+		Status: v1alpha1.OrganizationStatus{
+			Namespace: namespace,
+		},
+	}
+}
+
+func newOrgService(t *testing.T, object ...runtime.Object) *organization.Service {
+	clientScheme, err := scheme.NewScheme()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+	}
+
+	/*
+	apiVersion: rbac.authorization.k8s.io/v1
+	kind: ClusterRole
+	metadata:
+	  annotations:
+	    kubectl.kubernetes.io/last-applied-configuration: |
+	      {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"annotations":{},"name":"all-orgs"},"rules":[{"apiGroups":["security.giantswarm.io"],"resources":["organizations"],"verbs":["list"]}]}
+	  creationTimestamp: "2021-03-08T12:59:04Z"
+	  name: all-orgs
+	  resourceVersion: "261464181"
+	  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/all-orgs
+	  uid: c6dc57be-d9b8-4f9c-96d1-1c4a3ae6ab52
+	rules:
+	- apiGroups:
+	  - security.giantswarm.io
+	  resources:
+	  - organizations
+	  verbs:
+	  - list
+	*/
+
+	listOrgsClusterRole := &v1.ClusterRole{
+		Rules: []v1.PolicyRule{
+			{
+				APIGroups: []string{"security.giantswarm.io"},
+				Resources: []string{"organizations"},
+				Verbs: []string{"list"},
+			},
+		},
+	}
+
+	listOrgsClusterRoleBinding := &v1.ClusterRoleBinding{
+		Subjects: []v1.Subject{
+			{
+				Kind: "User",
+				Name: "clean",
+				Namespace: "default",
+			},
+		},
+	}
+
+	/*simpleClientSet := k8sfake.NewSimpleClientset(listOrgsClusterRole, listOrgsClusterRoleBinding)
+
+	fakeRbac := fake2.FakeRbacV1{&simpleClientSet.Fake}
+	fakeRbac.ClusterRoles().Create()*/
+
+	clients := k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+		CtrlClient: fake.NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(object...).Build(),
+		K8sClient: k8sfake.NewSimpleClientset(listOrgsClusterRole, listOrgsClusterRoleBinding),
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+	}
+
+	service, err := organization.New(organization.Config{
+		Client: clients,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+	}
+
+
+
+	return service.(*organization.Service)
+
+	/*
+		clientScheme, err := scheme.NewScheme()
+		if err != nil {
+			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+		}
+
+		clients := k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+			CtrlClient: fake.NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(object...).Build(),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+		}
+
+		service, err := nodepool.New(nodepool.Config{
+			Client: clients.CtrlClient(),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
+		}
+
+		return service
+	 */
+}
+
+/*
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: "2022-08-11T05:39:25Z"
+  labels:
+    giantswarm.io/managed-by: rbac-operator
+  name: organization-vaclav-v-read
+  resourceVersion: "784438506"
+  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/organization-vaclav-v-read
+  uid: 601aa381-b258-459e-b914-6eda976cd1c4
+rules:
+- apiGroups:
+  - security.giantswarm.io
+  resourceNames:
+  - vaclav-v
+  resources:
+  - organizations
+  verbs:
+  - get
+ */

--- a/cmd/get/orgs/runner_test.go
+++ b/cmd/get/orgs/runner_test.go
@@ -2,24 +2,18 @@ package orgs
 
 import (
 	"bytes"
-	"github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
-	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
 	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
 	"github.com/giantswarm/kubectl-gs/pkg/data/domain/organization"
 	"github.com/giantswarm/kubectl-gs/pkg/output"
-	"github.com/giantswarm/kubectl-gs/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/test/kubeclient"
 	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
 	"github.com/giantswarm/microerror"
-	"github.com/stretchr/testify/require"
-	v12 "k8s.io/api/authorization/v1"
-	v1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 	"time"
 )
@@ -29,31 +23,78 @@ func Test_run(t *testing.T) {
 		name               string
 		storage            []runtime.Object
 		args               []string
+		isAdmin            bool
+		permittedResources []v1.ResourceRule
 		expectedGoldenFile string
 		errorMatcher       func(error) bool
 	}{
 		{
-			name: "case0: get orgs for admin user",
+			name:               "case 0: get orgs for admin",
+			isAdmin:            true,
+			args:               nil,
+			expectedGoldenFile: "run_get_orgs_admin.golden",
 			storage: []runtime.Object{
-				newOrg("test-1", "org-test-1"),
-				newOrg("test-2", "org-test-2"),
-				newOrg("test-3", "org-test-3"),
+				newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-2", "org-test-2", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-3", "org-test-3", time.Now().Format(time.RFC3339)).Organization,
 			},
-			args: nil,
-			expectedGoldenFile: "",
+		},
+		{
+			name:               "case 1: get orgs for non-admin",
+			args:               nil,
+			expectedGoldenFile: "run_get_orgs_non_admin.golden",
+			storage: []runtime.Object{
+				newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-2", "org-test-2", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-3", "org-test-3", time.Now().Format(time.RFC3339)).Organization,
+			},
+			permittedResources: []v1.ResourceRule{
+				{
+					Verbs:         []string{"get"},
+					Resources:     []string{"organizations"},
+					APIGroups:     []string{"security.giantswarm.io/v1alpha1"},
+					ResourceNames: []string{"test-2"},
+				},
+			},
+		},
+		{
+			name:               "case 2: get orgs for admin, with empty response",
+			isAdmin:            true,
+			args:               nil,
+			expectedGoldenFile: "run_get_orgs_empty.golden",
+		},
+		{
+			name:               "case 3: get orgs for non-admin, with no permitted resources",
+			args:               nil,
+			expectedGoldenFile: "run_get_orgs_empty.golden",
+			storage: []runtime.Object{
+				newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-2", "org-test-2", time.Now().Format(time.RFC3339)).Organization,
+				newOrgResource("test-3", "org-test-3", time.Now().Format(time.RFC3339)).Organization,
+			},
+		},
+		{
+			name:               "case 4: get org by name",
+			args:               []string{"test-1"},
+			expectedGoldenFile: "run_get_org_by_name.golden",
+			storage: []runtime.Object{
+				newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)).Organization,
+			},
+		},
+		{
+			name:         "case 5: get org by name, not available in storage",
+			args:         []string{"test-2"},
+			errorMatcher: IsNotFound,
+			storage: []runtime.Object{
+				newOrgResource("test-1", "org-test-1", time.Now().Format(time.RFC3339)).Organization,
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			config := kubeconfig.CreateValidTestConfig()
-
-			authInfo, _ := config.AuthInfos["clean"]
-			authInfo.Impersonate = "user:default:test"
-			authInfo.ImpersonateGroups = []string{"admins"}
-
-			fakeKubeConfig := kubeconfig.CreateFakeKubeConfigFromConfig(config)
+			fakeKubeConfig := kubeconfig.CreateFakeKubeConfigFromConfig(kubeconfig.CreateValidTestConfig())
 
 			flg := &flag{
 				print: genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault),
@@ -62,251 +103,50 @@ func Test_run(t *testing.T) {
 			out := new(bytes.Buffer)
 			runner := &runner{
 				commonConfig: commonconfig.New(genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig)),
-				flag: flg,
-				service: newOrgService(t, fakeKubeConfig),
-				stdout: out,
+				flag:         flg,
+				service:      newOrgService(t, tc.isAdmin, tc.permittedResources, tc.storage...),
+				stdout:       out,
 			}
 
 			err := runner.Run(nil, tc.args)
-			require.NoError(t, err)
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
+				}
+
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			var expectedResult []byte
+			{
+				gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+				expectedResult, err = gf.Read()
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+			}
+
+			diff := cmp.Diff(string(expectedResult), out.String())
+			if diff != "" {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
 		})
 	}
 }
 
-func newOrg(name, namespace string) *v1alpha1.Organization {
-	return &v1alpha1.Organization{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "security.giantswarm.io/v1alpha1",
-			Kind: "Organization",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			CreationTimestamp: metav1.Time{Time: time.Now()},
-		},
-		Spec: v1alpha1.OrganizationSpec{},
-		Status: v1alpha1.OrganizationStatus{
-			Namespace: namespace,
-		},
-	}
-}
-
-func newOrgService(t *testing.T, config clientcmd.ClientConfig, object ...runtime.Object) *organization.Service {
-	clientScheme, err := scheme.NewScheme()
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}
-
-	//ctx := context.TODO()
-
-	clientConfig, err := config.ClientConfig()
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}
-
-	impersonationConfig := rest.ImpersonationConfig{
-		UserName: "user:default:test",
-		Groups: []string{"admins"},
-	}
-
-	clientConfig.Impersonate = impersonationConfig
-
-	/*
-	apiVersion: rbac.authorization.k8s.io/v1
-	kind: ClusterRole
-	metadata:
-	  annotations:
-	    kubectl.kubernetes.io/last-applied-configuration: |
-	      {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"annotations":{},"name":"all-orgs"},"rules":[{"apiGroups":["security.giantswarm.io"],"resources":["organizations"],"verbs":["list"]}]}
-	  creationTimestamp: "2021-03-08T12:59:04Z"
-	  name: all-orgs
-	  resourceVersion: "261464181"
-	  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/all-orgs
-	  uid: c6dc57be-d9b8-4f9c-96d1-1c4a3ae6ab52
-	rules:
-	- apiGroups:
-	  - security.giantswarm.io
-	  resources:
-	  - organizations
-	  verbs:
-	  - list
-	*/
-
-	listOrgsClusterRole := &v1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind: "ClusterRole",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "list-orgs-clusterrole",
-		},
-		Rules: []v1.PolicyRule{
-			{
-				APIGroups: []string{"security.giantswarm.io"},
-				Resources: []string{"organizations"},
-				Verbs: []string{"list"},
-			},
-		},
-	}
-
-	listOrgsClusterRoleBinding := &v1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind: "ClusterRoleBinding",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "list-orgs-clusterrolebinding",
-		},
-		RoleRef: v1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind: "ClusterRole",
-			Name: "list-orgs-clusterrole",
-		},
-		Subjects: []v1.Subject{
-			{
-				Kind: "Group",
-				Name: "admins",
-			},
-		},
-	}
-
-
-
-	/*selfSubjectAccessReview := &v12.SelfSubjectAccessReview{
-		TypeMeta: metav1.TypeMeta{
-
-		},
-		ObjectMeta: metav1.ObjectMeta{
-
-		},
-		Spec: v12.SelfSubjectAccessReviewSpec{
-
-		},
-		Status: v12.SubjectAccessReviewStatus{
-			Allowed: true,
-		},
-	}
-
-	selfSubjectRulesReview := &v12.SelfSubjectRulesReview{
-		TypeMeta: metav1.TypeMeta{
-
-		},
-		ObjectMeta: metav1.ObjectMeta{
-
-		},
-		Spec: v12.SelfSubjectRulesReviewSpec{
-			Namespace: "default",
-		},
-		Status: v12.SubjectRulesReviewStatus{
-
-		},
-	}*/
-
-	selfSubjectAccessReview := v12.SelfSubjectAccessReview{
-		Spec: {
-			ResourceAttributes: v12.ResourceAttributes{
-
-			},
-		},
-		Status: {
-
-		},
-	}
-
-	err = k8sfake.AddToScheme(clientScheme)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}
-
-	simpleClientSet := k8sfake.NewSimpleClientset(listOrgsClusterRole, listOrgsClusterRoleBinding)
-
-
-	/*_, err = simpleClientSet.RbacV1().ClusterRoles().Create(ctx, listOrgsClusterRole, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}
-
-	_, err = simpleClientSet.RbacV1().ClusterRoleBindings().Create(ctx, listOrgsClusterRoleBinding, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}*/
-
-
-
-
-
-
-	/*simpleClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
-		return true, selfSubjectAccessReview, nil
-	})
-	simpleClientSet.PrependReactor("create", "selfsubjectrulesreviews", func(action testing2.Action) (handled bool, ret runtime.Object, err error) {
-		return true, selfSubjectRulesReview, nil
-	})*/
-
-	/*fakeRbac := fake2.FakeRbacV1{&simpleClientSet.Fake}
-	fakeRbac.ClusterRoles().Create()*/
-
-	clients := k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
-		CtrlClient: fake.NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(object...).Build(),
-		K8sClient: simpleClientSet,
-	})
-
-	if err != nil {
-		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-	}
+func newOrgService(t *testing.T, isAdmin bool, permittedResources []v1.ResourceRule, object ...runtime.Object) *organization.Service {
+	client := kubeclient.FakeK8sClient(object...)
+	client.AddSubjectAccess(isAdmin)
+	client.AddSubjectResourceRules("default", permittedResources)
 
 	service, err := organization.New(organization.Config{
-		Client: clients,
+		Client: client,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
 	}
 
-
-
 	return service.(*organization.Service)
-
-	/*
-		clientScheme, err := scheme.NewScheme()
-		if err != nil {
-			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-		}
-
-		clients := k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
-			CtrlClient: fake.NewClientBuilder().WithScheme(clientScheme).WithRuntimeObjects(object...).Build(),
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-		}
-
-		service, err := nodepool.New(nodepool.Config{
-			Client: clients.CtrlClient(),
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %s", microerror.Pretty(err, true))
-		}
-
-		return service
-	 */
 }
-
-/*
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: "2022-08-11T05:39:25Z"
-  labels:
-    giantswarm.io/managed-by: rbac-operator
-  name: organization-vaclav-v-read
-  resourceVersion: "784438506"
-  selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/organization-vaclav-v-read
-  uid: 601aa381-b258-459e-b914-6eda976cd1c4
-rules:
-- apiGroups:
-  - security.giantswarm.io
-  resourceNames:
-  - vaclav-v
-  resources:
-  - organizations
-  verbs:
-  - get
- */

--- a/cmd/get/orgs/testdata/print_list_of_orgs_json_output.golden
+++ b/cmd/get/orgs/testdata/print_list_of_orgs_json_output.golden
@@ -1,0 +1,43 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "kind": "Organization",
+            "apiVersion": "security.giantswarm.io/v1alpha1",
+            "metadata": {
+                "name": "test-1",
+                "creationTimestamp": "2022-08-18T08:07:48Z"
+            },
+            "spec": {},
+            "status": {
+                "namespace": "org-test-1"
+            }
+        },
+        {
+            "kind": "Organization",
+            "apiVersion": "security.giantswarm.io/v1alpha1",
+            "metadata": {
+                "name": "test-2",
+                "creationTimestamp": "2022-08-18T08:07:48Z"
+            },
+            "spec": {},
+            "status": {
+                "namespace": "org-test-2"
+            }
+        },
+        {
+            "kind": "Organization",
+            "apiVersion": "security.giantswarm.io/v1alpha1",
+            "metadata": {
+                "name": "test-3",
+                "creationTimestamp": "2022-08-18T08:07:48Z"
+            },
+            "spec": {},
+            "status": {
+                "namespace": "org-test-3"
+            }
+        }
+    ]
+}

--- a/cmd/get/orgs/testdata/print_list_of_orgs_name_output.golden
+++ b/cmd/get/orgs/testdata/print_list_of_orgs_name_output.golden
@@ -1,0 +1,3 @@
+organization.security.giantswarm.io/test-1
+organization.security.giantswarm.io/test-2
+organization.security.giantswarm.io/test-3

--- a/cmd/get/orgs/testdata/print_list_of_orgs_table_output.golden
+++ b/cmd/get/orgs/testdata/print_list_of_orgs_table_output.golden
@@ -1,0 +1,4 @@
+NAME     ORG NAMESPACE   AGE
+test-1   org-test-1      0s
+test-2   org-test-2      0s
+test-3   org-test-3      0s

--- a/cmd/get/orgs/testdata/print_list_of_orgs_yaml_output.golden
+++ b/cmd/get/orgs/testdata/print_list_of_orgs_yaml_output.golden
@@ -1,0 +1,28 @@
+apiVersion: v1
+items:
+- apiVersion: security.giantswarm.io/v1alpha1
+  kind: Organization
+  metadata:
+    creationTimestamp: "2022-08-18T08:07:48Z"
+    name: test-1
+  spec: {}
+  status:
+    namespace: org-test-1
+- apiVersion: security.giantswarm.io/v1alpha1
+  kind: Organization
+  metadata:
+    creationTimestamp: "2022-08-18T08:07:48Z"
+    name: test-2
+  spec: {}
+  status:
+    namespace: org-test-2
+- apiVersion: security.giantswarm.io/v1alpha1
+  kind: Organization
+  metadata:
+    creationTimestamp: "2022-08-18T08:07:48Z"
+    name: test-3
+  spec: {}
+  status:
+    namespace: org-test-3
+kind: List
+metadata: {}

--- a/cmd/get/orgs/testdata/print_single_org_json_output.golden
+++ b/cmd/get/orgs/testdata/print_single_org_json_output.golden
@@ -1,0 +1,12 @@
+{
+    "kind": "Organization",
+    "apiVersion": "security.giantswarm.io/v1alpha1",
+    "metadata": {
+        "name": "test-1",
+        "creationTimestamp": "2022-08-18T08:07:48Z"
+    },
+    "spec": {},
+    "status": {
+        "namespace": "org-test-1"
+    }
+}

--- a/cmd/get/orgs/testdata/print_single_org_name_output.golden
+++ b/cmd/get/orgs/testdata/print_single_org_name_output.golden
@@ -1,0 +1,1 @@
+organization.security.giantswarm.io/test-1

--- a/cmd/get/orgs/testdata/print_single_org_table_output.golden
+++ b/cmd/get/orgs/testdata/print_single_org_table_output.golden
@@ -1,0 +1,2 @@
+NAME     ORG NAMESPACE   AGE
+test-1   org-test-1      0s

--- a/cmd/get/orgs/testdata/print_single_org_yaml_output.golden
+++ b/cmd/get/orgs/testdata/print_single_org_yaml_output.golden
@@ -1,0 +1,8 @@
+apiVersion: security.giantswarm.io/v1alpha1
+kind: Organization
+metadata:
+  creationTimestamp: "2022-08-18T08:07:48Z"
+  name: test-1
+spec: {}
+status:
+  namespace: org-test-1

--- a/cmd/get/orgs/testdata/run_get_org_by_name.golden
+++ b/cmd/get/orgs/testdata/run_get_org_by_name.golden
@@ -1,0 +1,2 @@
+NAME     ORG NAMESPACE   AGE
+test-1   org-test-1      0s

--- a/cmd/get/orgs/testdata/run_get_orgs_admin.golden
+++ b/cmd/get/orgs/testdata/run_get_orgs_admin.golden
@@ -1,0 +1,4 @@
+NAME     ORG NAMESPACE   AGE
+test-1   org-test-1      0s
+test-2   org-test-2      0s
+test-3   org-test-3      0s

--- a/cmd/get/orgs/testdata/run_get_orgs_empty.golden
+++ b/cmd/get/orgs/testdata/run_get_orgs_empty.golden
@@ -1,0 +1,4 @@
+No organizations found.
+No resources of type organizations.security.giantswarm.io available. To create one, please check
+
+  https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/

--- a/cmd/get/orgs/testdata/run_get_orgs_non_admin.golden
+++ b/cmd/get/orgs/testdata/run_get_orgs_non_admin.golden
@@ -1,0 +1,2 @@
+NAME     ORG NAMESPACE   AGE
+test-2   org-test-2      0s

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -38,7 +38,7 @@ func (r *runner) getServiceSet(client k8sclient.Interface) (serviceSet, error) {
 	var organizationService organization.Interface
 	{
 		serviceConfig := organization.Config{
-			Client: client.CtrlClient(),
+			Client: client,
 		}
 		organizationService, err = organization.New(serviceConfig)
 		if err != nil {

--- a/cmd/login/wc_test.go
+++ b/cmd/login/wc_test.go
@@ -6,13 +6,14 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	v1 "k8s.io/api/authorization/v1"
 	"math/big"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+
+	v1 "k8s.io/api/authorization/v1"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/core/v1alpha1"
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v6/pkg/apis/infrastructure/v1alpha3"

--- a/pkg/data/domain/organization/auth.go
+++ b/pkg/data/domain/organization/auth.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"context"
+
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -10,8 +11,8 @@ func (s *Service) getSelfSubjectAccessReview(ctx context.Context) (*v1.SelfSubje
 	request := &v1.SelfSubjectAccessReview{
 		Spec: v1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &v1.ResourceAttributes{
-				Verb: "list",
-				Group: "security.giantswarm.io",
+				Verb:     "list",
+				Group:    "security.giantswarm.io",
 				Resource: "organizations",
 			},
 		},

--- a/pkg/data/domain/organization/auth.go
+++ b/pkg/data/domain/organization/auth.go
@@ -1,0 +1,35 @@
+package organization
+
+import (
+	"context"
+	v1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (s *Service) getSelfSubjectAccessReview(ctx context.Context) (*v1.SelfSubjectAccessReview, error) {
+	request := &v1.SelfSubjectAccessReview{
+		Spec: v1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &v1.ResourceAttributes{
+				Verb: "list",
+				Group: "security.giantswarm.io",
+				Resource: "organizations",
+			},
+		},
+	}
+
+	createOptions := metav1.CreateOptions{}
+
+	return s.client.K8sClient().AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, request, createOptions)
+}
+
+func (s *Service) getSelfSubjectRulesReview(ctx context.Context) (*v1.SelfSubjectRulesReview, error) {
+	request := &v1.SelfSubjectRulesReview{
+		Spec: v1.SelfSubjectRulesReviewSpec{
+			Namespace: "default",
+		},
+	}
+
+	createOptions := metav1.CreateOptions{}
+
+	return s.client.K8sClient().AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, request, createOptions)
+}

--- a/pkg/data/domain/organization/common.go
+++ b/pkg/data/domain/organization/common.go
@@ -2,13 +2,14 @@ package organization
 
 import (
 	"context"
+	"sort"
+
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
 )
 
 func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {
@@ -49,9 +50,9 @@ func (s *Service) getByName(ctx context.Context, name string) (Resource, error) 
 
 		o.Organization = omitManagedFields(org)
 		o.Organization.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
-			Group: securityv1alpha1.SchemeGroupVersion.Group,
+			Group:   securityv1alpha1.SchemeGroupVersion.Group,
 			Version: securityv1alpha1.SchemeGroupVersion.Version,
-			Kind: "Organization",
+			Kind:    "Organization",
 		})
 	}
 
@@ -132,8 +133,6 @@ func (s *Service) getAllPermittedOrgResources(ctx context.Context) (Resource, er
 func (s *Service) getByNames(ctx context.Context, names []string) (*Collection, error) {
 
 	orgCollection := &Collection{}
-
-
 
 	for _, name := range names {
 		resource, err := s.getByName(ctx, name)

--- a/pkg/data/domain/organization/common.go
+++ b/pkg/data/domain/organization/common.go
@@ -1,0 +1,169 @@
+package organization
+
+import (
+	"context"
+	securityv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
+)
+
+func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {
+	var resource Resource
+	var err error
+
+	if len(options.Name) > 0 {
+		resource, err = s.getByName(ctx, options.Name)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else {
+		resource, err = s.getAll(ctx)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resource, nil
+}
+
+func (s *Service) getByName(ctx context.Context, name string) (Resource, error) {
+	var err error
+
+	o := &Organization{}
+	{
+		org := &securityv1alpha1.Organization{}
+		err = s.client.CtrlClient().Get(ctx, client.ObjectKey{
+			Name:      name,
+			Namespace: metav1.NamespaceNone,
+		}, org)
+
+		if apierrors.IsNotFound(err) {
+			return nil, microerror.Mask(notFoundError)
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		o.Organization = omitManagedFields(org)
+		o.Organization.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+			Group: securityv1alpha1.SchemeGroupVersion.Group,
+			Version: securityv1alpha1.SchemeGroupVersion.Version,
+			Kind: "Organization",
+		})
+	}
+
+	return o, nil
+}
+
+func (s *Service) getAll(ctx context.Context) (Resource, error) {
+	accessReview, err := s.getSelfSubjectAccessReview(ctx)
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	} else if accessReview.Status.Allowed {
+		return s.getAllCRs(ctx)
+	} else {
+		return s.getAllPermittedOrgResources(ctx)
+	}
+}
+
+func (s *Service) getAllCRs(ctx context.Context) (Resource, error) {
+	var err error
+	orgCollection := &Collection{}
+	{
+		orgs := &securityv1alpha1.OrganizationList{}
+		{
+			err = s.client.CtrlClient().List(ctx, orgs)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			} else if len(orgs.Items) == 0 {
+				return nil, microerror.Mask(noResourcesError)
+			}
+		}
+
+		for _, org := range orgs.Items {
+			o := Organization{
+				Organization: org.DeepCopy(),
+			}
+			o.Organization.ManagedFields = nil
+
+			orgCollection.Items = append(orgCollection.Items, o)
+		}
+	}
+
+	return orgCollection, nil
+}
+
+func (s *Service) getAllPermittedOrgResources(ctx context.Context) (Resource, error) {
+	rulesReview, err := s.getSelfSubjectRulesReview(ctx)
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	contains := func(slice []string, value string) bool {
+		for _, item := range slice {
+			if item == value {
+				return true
+			}
+		}
+		return false
+	}
+
+	var orgNames []string
+	for _, rule := range rulesReview.Status.ResourceRules {
+		if contains(rule.Verbs, "get") && contains(rule.Resources, "organizations") {
+			orgNames = append(orgNames, rule.ResourceNames...)
+		}
+	}
+
+	if len(orgNames) == 0 {
+		return nil, microerror.Mask(noResourcesError)
+	}
+
+	sort.Strings(orgNames)
+
+	return s.getByNames(ctx, orgNames)
+}
+
+func (s *Service) getByNames(ctx context.Context, names []string) (*Collection, error) {
+
+	orgCollection := &Collection{}
+
+
+
+	for _, name := range names {
+		resource, err := s.getByName(ctx, name)
+
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		org := resource.(*Organization)
+		if org == nil {
+			continue
+		}
+
+		o := Organization{
+			Organization: org.Organization.DeepCopy(),
+		}
+
+		orgCollection.Items = append(orgCollection.Items, o)
+	}
+
+	if len(orgCollection.Items) == 0 {
+		return nil, microerror.Mask(noResourcesError)
+	}
+
+	return orgCollection, nil
+}
+
+// omitManagedFields removes managed fields to make YAML output easier to read.
+// With Kubernetes 1.21 we can use OmitManagedFieldsPrinter and remove this.
+func omitManagedFields(org *securityv1alpha1.Organization) *securityv1alpha1.Organization {
+	org.ManagedFields = nil
+	return org
+}

--- a/pkg/data/domain/organization/service.go
+++ b/pkg/data/domain/organization/service.go
@@ -2,7 +2,6 @@ package organization
 
 import (
 	"context"
-
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -10,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ Interface = (*Service)(nil)
+var _ Interface = &Service{}
 
 type Config struct {
 	Client client.Client
@@ -20,7 +19,7 @@ type Service struct {
 	client client.Client
 }
 
-func New(config Config) (*Service, error) {
+func New(config Config) (Interface, error) {
 	if config.Client == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Client must not be empty", config)
 	}
@@ -67,7 +66,6 @@ func (s *Service) getByName(ctx context.Context, name string) (Resource, error) 
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
-
 	return org, nil
 }
 
@@ -98,3 +96,4 @@ func (s *Service) getAll(ctx context.Context) (Resource, error) {
 
 	return orgCollection, nil
 }
+

--- a/pkg/data/domain/organization/service.go
+++ b/pkg/data/domain/organization/service.go
@@ -1,22 +1,18 @@
 package organization
 
 import (
-	"context"
-	securityv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ Interface = &Service{}
 
 type Config struct {
-	Client client.Client
+	Client k8sclient.Interface
 }
 
 type Service struct {
-	client client.Client
+	client k8sclient.Interface
 }
 
 func New(config Config) (Interface, error) {
@@ -30,70 +26,3 @@ func New(config Config) (Interface, error) {
 
 	return s, nil
 }
-
-func (s *Service) Get(ctx context.Context, getOptions GetOptions) (Resource, error) {
-	var resource Resource
-	var err error
-
-	if len(getOptions.Name) > 0 {
-		resource, err = s.getByName(ctx, getOptions.Name)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	} else {
-		resource, err = s.getAll(ctx)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	return resource, nil
-}
-
-func (s *Service) getByName(ctx context.Context, name string) (Resource, error) {
-	org := &Organization{
-		Organization: &securityv1alpha1.Organization{},
-	}
-
-	key := client.ObjectKey{
-		Name:      name,
-		Namespace: metav1.NamespaceNone,
-	}
-
-	err := s.client.Get(ctx, key, org.Organization)
-	if apierrors.IsNotFound(err) {
-		return nil, microerror.Mask(notFoundError)
-	} else if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	return org, nil
-}
-
-func (s *Service) getAll(ctx context.Context) (Resource, error) {
-	var err error
-
-	orgCollection := &Collection{}
-	{
-		orgs := &securityv1alpha1.OrganizationList{}
-		{
-			err = s.client.List(ctx, orgs)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			} else if len(orgs.Items) == 0 {
-				return nil, microerror.Mask(noResourcesError)
-			}
-		}
-
-		for _, org := range orgs.Items {
-			o := Organization{
-				Organization: org.DeepCopy(),
-			}
-			o.Organization.ManagedFields = nil
-
-			orgCollection.Items = append(orgCollection.Items, o)
-		}
-	}
-
-	return orgCollection, nil
-}
-

--- a/pkg/data/domain/organization/spec.go
+++ b/pkg/data/domain/organization/spec.go
@@ -43,12 +43,11 @@ func (c *Collection) Object() runtime.Object {
 	}
 
 	for _, item := range c.Items {
-		obj := item.Object()
-		if obj == nil {
+		if item.Organization == nil {
 			continue
 		}
 		raw := runtime.RawExtension{
-			Object: obj,
+			Object: item.Object(),
 		}
 		list.Items = append(list.Items, raw)
 	}

--- a/pkg/data/domain/organization/spec.go
+++ b/pkg/data/domain/organization/spec.go
@@ -15,9 +15,12 @@ type Organization struct {
 	Organization *securityv1alpha1.Organization
 }
 
-// Collection wraps a list of organizations.
 type Collection struct {
 	Items []Organization
+}
+
+type Interface interface {
+	Get(context.Context, GetOptions) (Resource, error)
 }
 
 type GetOptions struct {
@@ -26,10 +29,6 @@ type GetOptions struct {
 
 type Resource interface {
 	Object() runtime.Object
-}
-
-type Interface interface {
-	Get(context.Context, GetOptions) (Resource, error)
 }
 
 func (k *Organization) Object() runtime.Object {

--- a/pkg/data/domain/organization/spec.go
+++ b/pkg/data/domain/organization/spec.go
@@ -3,8 +3,6 @@
 package organization
 
 import (
-	"context"
-
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/security/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,10 +15,6 @@ type Organization struct {
 
 type Collection struct {
 	Items []Organization
-}
-
-type Interface interface {
-	Get(context.Context, GetOptions) (Resource, error)
 }
 
 type GetOptions struct {

--- a/pkg/data/domain/organization/spec.go
+++ b/pkg/data/domain/organization/spec.go
@@ -1,3 +1,5 @@
+// Package organization provides services to deal with Organizations
+// in the Giant Swarm Management API.
 package organization
 
 import (
@@ -8,10 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Organization gives access to the actual Organization resource.
 type Organization struct {
 	Organization *securityv1alpha1.Organization
 }
 
+// Collection wraps a list of organizations.
 type Collection struct {
 	Items []Organization
 }
@@ -50,7 +54,6 @@ func (c *Collection) Object() runtime.Object {
 		if obj == nil {
 			continue
 		}
-
 		raw := runtime.RawExtension{
 			Object: obj,
 		}

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -3,7 +3,6 @@ package kubeclient
 import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
-	"github.com/giantswarm/kubectl-gs/pkg/scheme"
 	v1 "k8s.io/api/authorization/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +13,8 @@ import (
 	"k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/giantswarm/kubectl-gs/pkg/scheme"
 )
 
 type fakeK8sClient struct {

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -3,16 +3,17 @@ package kubeclient
 import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
+	"github.com/giantswarm/kubectl-gs/pkg/scheme"
+	v1 "k8s.io/api/authorization/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/giantswarm/kubectl-gs/pkg/scheme"
 )
 
 type fakeK8sClient struct {
@@ -20,18 +21,29 @@ type fakeK8sClient struct {
 	k8sClient  *fakek8s.Clientset
 }
 
-func FakeK8sClient(objects ...runtime.Object) k8sclient.Interface {
-	var k8sClient k8sclient.Interface
+type Interface interface {
+	k8sclient.Interface
+	AddSubjectAccessResolver(accessResolver authAccessResolver)
+	AddSubjectAccess(accessAllowed bool)
+	AddSubjectResourceRules(namespace string, rules []v1.ResourceRule)
+}
+
+type authAccessResolver func(action testing.Action) bool
+
+func FakeK8sClient(objects ...runtime.Object) Interface {
+	var k8sClient *fakeK8sClient
 	{
 		scheme, err := scheme.NewScheme()
+
 		if err != nil {
 			panic(err)
 		}
-		client := fakek8s.NewSimpleClientset(objects...)
+
+		clientSet := fakek8s.NewSimpleClientset()
 
 		k8sClient = &fakeK8sClient{
 			ctrlClient: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build(),
-			k8sClient:  client,
+			k8sClient:  clientSet,
 		}
 	}
 
@@ -68,4 +80,44 @@ func (f *fakeK8sClient) RESTConfig() *rest.Config {
 
 func (f *fakeK8sClient) Scheme() *runtime.Scheme {
 	return nil
+}
+
+func (f *fakeK8sClient) AddSubjectAccess(accessAllowed bool) {
+	f.AddSubjectAccessResolver(func(action testing.Action) bool {
+		return accessAllowed
+	})
+}
+
+func (f *fakeK8sClient) AddSubjectAccessResolver(accessResolver authAccessResolver) {
+	f.k8sClient.PrependReactor("create", "selfsubjectaccessreviews", newSelfSubjectAccessReviewReaction(accessResolver))
+}
+
+func (f *fakeK8sClient) AddSubjectResourceRules(namespace string, rules []v1.ResourceRule) {
+	f.k8sClient.PrependReactor("create", "selfsubjectrulesreviews", newSelfSubjectRulesReviewReaction(namespace, rules))
+}
+
+func newSelfSubjectAccessReviewReaction(accessResolver authAccessResolver) testing.ReactionFunc {
+	return func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+		selfSubjectAccessReview := &v1.SelfSubjectAccessReview{
+			Spec: v1.SelfSubjectAccessReviewSpec{},
+			Status: v1.SubjectAccessReviewStatus{
+				Allowed: accessResolver(action),
+			},
+		}
+		return true, selfSubjectAccessReview, nil
+	}
+}
+
+func newSelfSubjectRulesReviewReaction(namespace string, resourceRules []v1.ResourceRule) testing.ReactionFunc {
+	return func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+		selfSubjectResourceRules := &v1.SelfSubjectRulesReview{
+			Spec: v1.SelfSubjectRulesReviewSpec{
+				Namespace: namespace,
+			},
+			Status: v1.SubjectRulesReviewStatus{
+				ResourceRules: resourceRules,
+			},
+		}
+		return true, selfSubjectResourceRules, nil
+	}
 }


### PR DESCRIPTION
This PR adds a `get orgs` command.

Compared to `kubectl get organizations` it offers two benefits:

- The command also works for non admins (users which only have  `get` permissions to specific Organization resources).
- The output shows both the organization name and the organization namespace.

## Output preview

```nohighlight
TODO: add help output
```

## Help

```
NAME                  ORG NAMESPACE             AGE
anti-party            org-anti-party            20d
antonia               org-antonia               311d
cedric                org-cedric                257d
dmitry                org-dmitry                151d
george                org-george                47d
giantswarm            org-giantswarm            489d
gollum-subscription   org-gollum-subscription   552d
gremlin               org-gremlin               487d
herve                 org-herve                 47d
ljakimczuk            org-ljakimczuk            322d
marcel                org-marcel                277d
marian                org-marian                384d
nikola                org-nikola                353d
party-org             org-party-org             379d
ross                  org-ross                  347d
sandy                 org-sandy                 361d
team-rainbow          org-team-rainbow          185d
theo                  org-theo                  266d
tobias                org-tobias                70d
vaclav-v              org-vaclav-v              12d
```