### PR TITLE
Publish arm64 builds for darwin and linux to krew index

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -21,9 +21,27 @@ spec:
     bin: ./kubectl-gs
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-arm64.tar.gz" .TagName }}
+    files:
+    - from: ./kubectl-gs-*/*
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
+    files:
+    - from: ./kubectl-gs-*/*
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-arm64.tar.gz" .TagName }}
     files:
     - from: ./kubectl-gs-*/*
       to: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Publish darwin and linux arm64 to krew index.
+
 ## [1.26.0] - 2021-04-13
 
 ### Added


### PR DESCRIPTION
Since last version we have arm64 builds for mac and linux. This PR publishes the binaries to the krew index

Tested:

```
$ docker run -v $(pwd)/.krew.yaml:/tmp/template-file.yaml rajatjindal/krew-release-bot:v0.0.38 krew-release-bot template --tag v1.26.0 --template-file /tmp/template-file.yaml
Unable to find image 'rajatjindal/krew-release-bot:v0.0.38' locally
v0.0.38: Pulling from rajatjindal/krew-release-bot
89d9c30c1d48: Already exists 
473fadbdb6da: Pull complete 
47bb8ee9cf07: Pull complete 
c381c68e6db4: Pull complete 
681c7f8cbe61: Pull complete 
Digest: sha256:b0141afadf30bac460155b4a2f15cddd28031932f466ab637b7486082e0e33b3
Status: Downloaded newer image for rajatjindal/krew-release-bot:v0.0.38
time="2021-04-14T11:24:07Z" level=info msg="getting sha256 for https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-darwin-amd64.tar.gz"
time="2021-04-14T11:24:10Z" level=info msg="downloaded file /tmp/145278721/1618399447"
time="2021-04-14T11:24:10Z" level=info msg="getting sha256 for https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-darwin-arm64.tar.gz"
time="2021-04-14T11:24:12Z" level=info msg="downloaded file /tmp/281377900/1618399450"
time="2021-04-14T11:24:12Z" level=info msg="getting sha256 for https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-linux-amd64.tar.gz"
time="2021-04-14T11:24:14Z" level=info msg="downloaded file /tmp/969207515/1618399452"
time="2021-04-14T11:24:14Z" level=info msg="getting sha256 for https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-linux-arm64.tar.gz"
time="2021-04-14T11:24:15Z" level=info msg="downloaded file /tmp/040587902/1618399454"
apiVersion: krew.googlecontainertools.github.com/v1alpha2
kind: Plugin
metadata:
  name: gs
spec:
  version: v1.26.0
  homepage: https://github.com/giantswarm/kubectl-gs
  shortDescription: Handle custom resources with Giant Swarm
  description: |
    Simplifies creating clusters and node pools via Giant Swarm
    management clusters, as well as installing app catalogs and apps.
  platforms:
  - selector:
      matchLabels:
        os: darwin
        arch: amd64
    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-darwin-amd64.tar.gz
    sha256: 804faa31272052db1791dee57368d96e79c81e49a21653ca971095b4b6978c84
    files:
    - from: ./kubectl-gs-*/*
      to: .
    bin: ./kubectl-gs
  - selector:
      matchLabels:
        os: darwin
        arch: arm64
    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-darwin-arm64.tar.gz
    sha256: 6c38146f0171f29812bc0d2260234b37d9cea84af18551913f2ca309845b42b4
    files:
    - from: ./kubectl-gs-*/*
      to: .
    bin: ./kubectl-gs
  - selector:
      matchLabels:
        os: linux
        arch: amd64
    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-linux-amd64.tar.gz
    sha256: 6352bce00b641cc3d2ee03a81ae069ba2107454c34394459314556a32ff3afef
    files:
    - from: ./kubectl-gs-*/*
      to: .
    bin: ./kubectl-gs
  - selector:
      matchLabels:
        os: linux
        arch: arm64
    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v1.26.0/kubectl-gs-v1.26.0-linux-arm64.tar.gz
    sha256: a934c03736524bf37b05a1594ff435337b76935b52e10b80cf796a0dacd7cfdb
    files:
    - from: ./kubectl-gs-*/*
      to: .
    bin: ./kubectl-gs

```