### PR TITLE
Fix templating YAML for configmaps and secrets referenced in App and AppCatalog CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix templating related configmaps and secrets for App and AppCatalog CRs.
+- Fix templating nested YAML for configmaps and secrets referenced in App and AppCatalog CRs.
 
 ## [1.26.0] - 2021-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Publish darwin and linux arm64 to krew index.
 
+### Fixed
+
+- Fix problems with templating configmaps and secrets for App and AppCatalog CRs.
+
 ## [1.26.0] - 2021-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix problems with templating configmaps and secrets for App and AppCatalog CRs.
+- Fix templating related configmaps and secrets for App and AppCatalog CRs.
 
 ## [1.26.0] - 2021-04-13
 

--- a/cmd/template/appcatalog/runner.go
+++ b/cmd/template/appcatalog/runner.go
@@ -76,7 +76,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Maskf(unmashalToMapFailedError, err.Error())
 	}
 
-	var secretData map[string][]byte
+	var secretData []byte
 	if r.flag.Secret != "" {
 		secretData, err = key.ReadSecretYamlFromFile(afero.NewOsFs(), r.flag.Secret)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 replace (
 	github.com/Microsoft/hcsshim v0.8.7 => github.com/Microsoft/hcsshim v0.8.10
 	github.com/coreos/etcd => github.com/etcd-io/etcd v3.3.25+incompatible
+	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/docker/docker => github.com/moby/moby v20.10.6+incompatible // Use moby v20.10.x to fix build issue on darwin.
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2 // [CVE-2021-3121]
 	github.com/gorilla/websocket v1.4.0 => github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -174,7 +174,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -81,8 +81,7 @@ func ReadSecretYamlFromFile(fs afero.Fs, path string) ([]byte, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	rawMap := map[string]interface{}{}
-	err = yaml.Unmarshal(data, &rawMap)
+	err = yaml.Unmarshal(data, &map[string]interface{}{})
 	if err != nil {
 		return nil, microerror.Maskf(unmashalToMapFailedError, err.Error())
 	}

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -65,7 +65,7 @@ func ReadConfigMapYamlFromFile(fs afero.Fs, path string) (string, error) {
 		return "", microerror.Mask(err)
 	}
 
-	rawMap := map[string]string{}
+	rawMap := map[string]interface{}{}
 	err = yaml.Unmarshal(data, &rawMap)
 	if err != nil {
 		return "", microerror.Maskf(unmashalToMapFailedError, err.Error())
@@ -75,19 +75,19 @@ func ReadConfigMapYamlFromFile(fs afero.Fs, path string) (string, error) {
 }
 
 // readSecretFromFile reads a configmap from a YAML file.
-func ReadSecretYamlFromFile(fs afero.Fs, path string) (map[string][]byte, error) {
+func ReadSecretYamlFromFile(fs afero.Fs, path string) ([]byte, error) {
 	data, err := afero.ReadFile(fs, path)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	rawMap := map[string][]byte{}
+	rawMap := map[string]interface{}{}
 	err = yaml.Unmarshal(data, &rawMap)
 	if err != nil {
 		return nil, microerror.Maskf(unmashalToMapFailedError, err.Error())
 	}
 
-	return rawMap, nil
+	return data, nil
 }
 
 func OrganizationNamespaceFromName(name string) string {

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -17,7 +17,7 @@ type Config struct {
 }
 
 type SecretConfig struct {
-	Data      map[string][]byte
+	Data      []byte
 	Name      string
 	Namespace string
 }
@@ -117,7 +117,9 @@ func NewSecretCR(config SecretConfig) (*apiv1.Secret, error) {
 			Namespace: config.Namespace,
 			Labels:    map[string]string{},
 		},
-		Data: config.Data,
+		Data: map[string][]byte{
+			"values": config.Data,
+		},
 	}
 
 	return secretCR, nil

--- a/pkg/template/appcatalog/appCatalog.go
+++ b/pkg/template/appcatalog/appCatalog.go
@@ -72,7 +72,7 @@ func NewConfigmapCR(config Config, data string) (*apiv1.ConfigMap, error) {
 	return configMapCR, nil
 }
 
-func NewSecretCR(config Config, data map[string][]byte) (*apiv1.Secret, error) {
+func NewSecretCR(config Config, data []byte) (*apiv1.Secret, error) {
 
 	secretCR := &apiv1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -84,7 +84,9 @@ func NewSecretCR(config Config, data map[string][]byte) (*apiv1.Secret, error) {
 			Namespace: metav1.NamespaceDefault,
 			Labels:    map[string]string{},
 		},
-		Data: data,
+		Data: map[string][]byte{
+			"values": data,
+		},
 	}
 
 	return secretCR, nil


### PR DESCRIPTION
Fixes a problem I found while working on https://github.com/giantswarm/docs/pull/912

When using `kubectl gs template app` or appcatalog nested values can't be passed because we need to convert to a `map[string]interface{}{}` first.
