### PR TITLE
Add internal API flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Publish darwin and linux arm64 to krew index.
+- Login command now support internal API.
 
 ### Fixed
 

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -124,7 +124,7 @@ func handleAuthCallback(ctx context.Context, a *oidc.Authenticator) func(w http.
 
 // storeCredentials stores the installation's CA certificate, and
 // updates the kubeconfig with the configuration for the k8s api access.
-func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult oidc.UserInfo, fs afero.Fs) error {
+func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult oidc.UserInfo, fs afero.Fs, internalAPI bool) error {
 	config, err := k8sConfigAccess.GetStartingConfig()
 	if err != nil {
 		return microerror.Mask(err)
@@ -168,7 +168,11 @@ func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.In
 			initialCluster = clientcmdapi.NewCluster()
 		}
 
-		initialCluster.Server = i.K8sApiURL
+		if internalAPI {
+			initialCluster.Server = i.K8sInternalApiURL
+		} else {
+			initialCluster.Server = i.K8sApiURL
+		}
 
 		var certPath string
 		certPath, err = kubeconfig.GetKubeCertFilePath(clusterName)

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -6,14 +6,17 @@ import (
 
 const (
 	flagClusterAdmin = "cluster-admin"
+	flagInternalAPI  = "internal-api"
 )
 
 type flag struct {
 	ClusterAdmin bool
+	InternalAPI  bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.ClusterAdmin, flagClusterAdmin, false, "Login with cluster-admin access.")
+	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -184,7 +184,7 @@ func (r *runner) loginWithURL(ctx context.Context, path string) error {
 	}
 
 	// Store kubeconfig and CA certificate.
-	err = storeCredentials(r.k8sConfigAccess, i, authResult, r.fs)
+	err = storeCredentials(r.k8sConfigAccess, i, authResult, r.fs, r.flag.InternalAPI)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/flag.go
+++ b/cmd/template/flag.go
@@ -4,8 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const ()
-
 type flag struct {
 }
 

--- a/cmd/validate/flag.go
+++ b/cmd/validate/flag.go
@@ -4,8 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const ()
-
 type flag struct {
 }
 

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/giantswarm/microerror"
@@ -13,14 +14,20 @@ import (
 
 const (
 	requestTimeout = 15 * time.Second
+
+	// management cluster internal api prefix
+	internalAPIPrefix = "internal-g8s"
+
+	urlDelimiter = "."
 )
 
 type Installation struct {
-	K8sApiURL string
-	AuthURL   string
-	Provider  string
-	Codename  string
-	CACert    string
+	K8sApiURL         string
+	K8sInternalApiURL string
+	AuthURL           string
+	Provider          string
+	Codename          string
+	CACert            string
 }
 
 func New(ctx context.Context, fromUrl string) (*Installation, error) {
@@ -50,12 +57,15 @@ func New(ctx context.Context, fromUrl string) (*Installation, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	baseEndpoint := strings.Split(info.Kubernetes.ApiUrl, urlDelimiter)[1:]
+	k8sInternalAPI := fmt.Sprintf("https://%s.%s", internalAPIPrefix, strings.Join(baseEndpoint, urlDelimiter))
 	i := &Installation{
-		K8sApiURL: info.Kubernetes.ApiUrl,
-		AuthURL:   info.Kubernetes.AuthUrl,
-		Provider:  info.Identity.Provider,
-		Codename:  info.Identity.Codename,
-		CACert:    info.Kubernetes.CaCert,
+		K8sApiURL:         info.Kubernetes.ApiUrl,
+		K8sInternalApiURL: k8sInternalAPI,
+		AuthURL:           info.Kubernetes.AuthUrl,
+		Provider:          info.Identity.Provider,
+		Codename:          info.Identity.Codename,
+		CACert:            info.Kubernetes.CaCert,
 	}
 
 	return i, nil

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -16,8 +16,6 @@ const (
 
 	// management cluster internal api prefix
 	internalAPIPrefix = "internal-g8s"
-
-	urlDelimiter = "."
 )
 
 type Installation struct {

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/giantswarm/microerror"
@@ -57,8 +56,7 @@ func New(ctx context.Context, fromUrl string) (*Installation, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	baseEndpoint := strings.Split(info.Kubernetes.ApiUrl, urlDelimiter)[1:]
-	k8sInternalAPI := fmt.Sprintf("https://%s.%s", internalAPIPrefix, strings.Join(baseEndpoint, urlDelimiter))
+	k8sInternalAPI := fmt.Sprintf("https://%s.%s", internalAPIPrefix, basePath)
 	i := &Installation{
 		K8sApiURL:         info.Kubernetes.ApiUrl,
 		K8sInternalApiURL: k8sInternalAPI,


### PR DESCRIPTION
As request from a customer, let's add internal API to allow them run kubectl gs from internal network.