### PR TITLE
Refactor app data service to return runtime objects

### DIFF
--- a/pkg/app/error.go
+++ b/pkg/app/error.go
@@ -13,6 +13,15 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var invalidTypeError = &microerror.Error{
+	Kind: "invalidTypeError",
+}
+
+// IsInvalidType asserts invalidTypeError.
+func IsInvalidType(err error) bool {
+	return microerror.Cause(err) == invalidTypeError
+}
+
 var noResourcesError = &microerror.Error{
 	Kind: "noResourcesError",
 }

--- a/pkg/app/get.go
+++ b/pkg/app/get.go
@@ -1,1 +1,0 @@
-package app

--- a/pkg/app/service.go
+++ b/pkg/app/service.go
@@ -1,10 +1,9 @@
 package app
 
 import (
+	"github.com/giantswarm/app/v4/pkg/values"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-
-	"github.com/giantswarm/app/v4/pkg/values"
 
 	"github.com/giantswarm/kubectl-gs/pkg/data/client"
 	appdata "github.com/giantswarm/kubectl-gs/pkg/data/domain/app"

--- a/pkg/app/spec.go
+++ b/pkg/app/spec.go
@@ -21,7 +21,7 @@ type ValidationResults []*ValidationResult
 // ValidationResult contains everything we need to show information about a
 // validation attempt.
 type ValidationResult struct {
-	App applicationv1alpha1.App
+	App *applicationv1alpha1.App
 
 	// The schema.values.json file, fetched from the
 	// 'application.giantswarm.io/values-schema' annotation.

--- a/pkg/app/validate.go
+++ b/pkg/app/validate.go
@@ -2,16 +2,17 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"path"
 
+	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
 
-	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
-	"github.com/giantswarm/microerror"
-
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/app"
 	appdata "github.com/giantswarm/kubectl-gs/pkg/data/domain/app"
 	appcatalogdata "github.com/giantswarm/kubectl-gs/pkg/data/domain/appcatalog"
 	"github.com/giantswarm/kubectl-gs/pkg/helmbinary"
@@ -53,15 +54,24 @@ func (s *Service) validateByName(ctx context.Context, name, namespace string, cu
 		Name:      name,
 	}
 
-	app, err := s.appDataService.Get(ctx, options)
-	if err != nil {
+	appResource, err := s.appDataService.Get(ctx, options)
+	if app.IsNotFound(err) {
+		return nil, microerror.Maskf(notFoundError, fmt.Sprintf("An app '%s/%s' cannot be found.\n", options.Namespace, options.Name))
+	} else if err != nil {
 		return results, microerror.Mask(err)
 	}
 
-	valuesSchema, schemaValidationResult, err := s.validateApp(ctx, *app, customValuesSchema)
+	var appCR *applicationv1alpha1.App
+
+	switch a := appResource.(type) {
+	case *app.App:
+		appCR = a.CR
+	}
+
+	valuesSchema, schemaValidationResult, err := s.validateApp(ctx, appCR, customValuesSchema)
 	if err != nil {
 		results = append(results, &ValidationResult{
-			App:          *app,
+			App:          appCR,
 			ValuesSchema: "",
 			Err:          microerror.Mask(err),
 		})
@@ -70,7 +80,7 @@ func (s *Service) validateByName(ctx context.Context, name, namespace string, cu
 	}
 
 	results = append(results, &ValidationResult{
-		App:              *app,
+		App:              appCR,
 		ValuesSchema:     valuesSchema,
 		ValidationErrors: schemaValidationResult.Errors(),
 	})
@@ -82,22 +92,33 @@ func (s *Service) validateByName(ctx context.Context, name, namespace string, cu
 func (s *Service) validateMultiple(ctx context.Context, namespace string, labelSelector string, customValuesSchema string) (ValidationResults, error) {
 	var err error
 
-	options := appdata.ListOptions{
+	options := appdata.GetOptions{
 		Namespace:     namespace,
 		LabelSelector: labelSelector,
 	}
 
-	apps, err := s.appDataService.List(ctx, options)
+	appResource, err := s.appDataService.Get(ctx, options)
 	if err != nil {
 		return nil, microerror.Mask(err)
-	} else if len(apps.Items) == 0 {
+	}
+
+	var apps []*applicationv1alpha1.App
+
+	switch a := appResource.(type) {
+	case *app.Collection:
+		for _, appItem := range a.Items {
+			apps = append(apps, appItem.CR)
+		}
+	}
+
+	if len(apps) == 0 {
 		return nil, microerror.Mask(noResourcesError)
 	}
 
 	// Iterate over all apps and fetch the AppCatalog CR, index.yaml, and
 	// corresponding values.schema.json if it is defined for that app's version.
 	results := ValidationResults{}
-	for _, app := range apps.Items {
+	for _, app := range apps {
 		valuesSchema, schemaValidationResult, err := s.validateApp(ctx, app, customValuesSchema)
 		if err != nil {
 			results = append(results, &ValidationResult{
@@ -120,7 +141,7 @@ func (s *Service) validateMultiple(ctx context.Context, namespace string, labelS
 	return results, nil
 }
 
-func (s *Service) validateApp(ctx context.Context, app applicationv1alpha1.App, customValuesSchema string) (string, *gojsonschema.Result, error) {
+func (s *Service) validateApp(ctx context.Context, app *applicationv1alpha1.App, customValuesSchema string) (string, *gojsonschema.Result, error) {
 	catalogName := app.Spec.Catalog
 
 	// Fetch the catalog's index.yaml if we haven't tried to yet.
@@ -174,7 +195,7 @@ func (s *Service) validateApp(ctx context.Context, app applicationv1alpha1.App, 
 	// 2. Catalog values (configmap & secret)
 	// 3. Cluster values (configmap & secret)
 	// 4. User values (configmap & secret)
-	providedValues, err := s.valuesService.MergeAll(ctx, app, *catalog)
+	providedValues, err := s.valuesService.MergeAll(ctx, *app, *catalog)
 	if err != nil {
 		return "", nil, microerror.Maskf(ioError, "failed fetch and/or merge user provided values: %s", err.Error())
 	}

--- a/pkg/app/validate.go
+++ b/pkg/app/validate.go
@@ -66,6 +66,8 @@ func (s *Service) validateByName(ctx context.Context, name, namespace string, cu
 	switch a := appResource.(type) {
 	case *app.App:
 		appCR = a.CR
+	default:
+		return results, microerror.Maskf(invalidTypeError, "unexpected type %T found", a)
 	}
 
 	valuesSchema, schemaValidationResult, err := s.validateApp(ctx, appCR, customValuesSchema)
@@ -91,6 +93,7 @@ func (s *Service) validateByName(ctx context.Context, name, namespace string, cu
 
 func (s *Service) validateMultiple(ctx context.Context, namespace string, labelSelector string, customValuesSchema string) (ValidationResults, error) {
 	var err error
+	results := ValidationResults{}
 
 	options := appdata.GetOptions{
 		Namespace:     namespace,
@@ -109,6 +112,8 @@ func (s *Service) validateMultiple(ctx context.Context, namespace string, labelS
 		for _, appItem := range a.Items {
 			apps = append(apps, appItem.CR)
 		}
+	default:
+		return results, microerror.Maskf(invalidTypeError, "unexpected type %T found", a)
 	}
 
 	if len(apps) == 0 {
@@ -117,7 +122,6 @@ func (s *Service) validateMultiple(ctx context.Context, namespace string, labelS
 
 	// Iterate over all apps and fetch the AppCatalog CR, index.yaml, and
 	// corresponding values.schema.json if it is defined for that app's version.
-	results := ValidationResults{}
 	for _, app := range apps {
 		valuesSchema, schemaValidationResult, err := s.validateApp(ctx, app, customValuesSchema)
 		if err != nil {

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -102,7 +102,7 @@ func (s *Service) getByName(ctx context.Context, name, namespace string) (Resour
 		if err != nil {
 			return nil, microerror.Mask(err)
 		} else if apierrors.IsNotFound(err) {
-			return nil, microerror.Mask(noResourcesError)
+			return nil, microerror.Mask(notFoundError)
 		}
 
 		app.CR = appCR

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -101,10 +101,10 @@ func (s *Service) getByName(ctx context.Context, namespace, name string) (Resour
 			Namespace: namespace,
 			Name:      name,
 		}, appCR)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		} else if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil, microerror.Mask(notFoundError)
+		} else if err != nil {
+			return nil, microerror.Mask(err)
 		}
 
 		app.CR = appCR

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -114,5 +114,3 @@ func (s *Service) getByName(ctx context.Context, name, namespace string) (Resour
 
 	return app, nil
 }
-
-}

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -44,15 +44,17 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error)
 	var err error
 
 	if len(options.Name) > 0 {
-		resource, err = s.getByName(ctx, options.Name, options.Namespace)
+		resource, err = s.getByName(ctx, options.Namespace, options.Name)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-	} else {
-		resource, err = s.getAll(ctx, options.Namespace)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+
+		return resource, nil
+	}
+
+	resource, err = s.getAll(ctx, options.Namespace)
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
 	return resource, nil
@@ -89,7 +91,7 @@ func (s *Service) getAll(ctx context.Context, namespace string) (Resource, error
 	return appCollection, nil
 }
 
-func (s *Service) getByName(ctx context.Context, name, namespace string) (Resource, error) {
+func (s *Service) getByName(ctx context.Context, namespace, name string) (Resource, error) {
 	var err error
 
 	app := &App{}

--- a/pkg/data/domain/app/spec.go
+++ b/pkg/data/domain/app/spec.go
@@ -4,23 +4,67 @@ import (
 	"context"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+// App abstracts away the custom resource so it can be returned as a runtime
+// object or a typed custom resource.
+type App struct {
+	CR *applicationv1alpha1.App
+}
+
+// Collection wraps a list of apps.
+type Collection struct {
+	Items []App
+}
 
 // GetOptions are the parameters that the Get method takes.
 type GetOptions struct {
-	Name      string
-	Namespace string
+	LabelSelector string
+	Name          string
+	Namespace     string
 }
 
-type ListOptions struct {
-	LabelSelector string
-	Namespace     string
+type Resource interface {
+	Object() runtime.Object
 }
 
 // Interface represents the contract for the app data service.
 // Using this instead of a regular 'struct' makes mocking the
 // service in tests much simpler.
 type Interface interface {
-	Get(context.Context, GetOptions) (*applicationv1alpha1.App, error)
-	List(context.Context, ListOptions) (*applicationv1alpha1.AppList, error)
+	Get(context.Context, GetOptions) (Resource, error)
+}
+
+func (a *App) Object() runtime.Object {
+	if a.CR != nil {
+		return a.CR
+	}
+
+	return nil
+}
+
+func (cc *Collection) Object() runtime.Object {
+	list := &metav1.List{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+	}
+
+	for _, item := range cc.Items {
+		obj := item.Object()
+		if obj == nil {
+			continue
+		}
+
+		raw := runtime.RawExtension{
+			Object: obj,
+		}
+		list.Items = append(list.Items, raw)
+	}
+
+	return list
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#16978

This refactors the app data service to return runtime objects and aligns it with the cluster data service. 
This is prep for adding the `kubectl gs get apps` command.


```sh
$ go run main.go validate apps -n ni0t5

NAMESPACE   NAME                           VERSION   RESULT
ni0t5       cert-exporter                  1.6.1     n/a: app has no values schema
ni0t5       cert-manager                   2.4.3     0 errors
ni0t5       chart-operator                 2.13.0    n/a: app has no values schema
ni0t5       cluster-autoscaler             1.19.2    n/a: app has no values schema
ni0t5       coredns                        1.4.1     n/a: app has no values schema
ni0t5       external-dns                   2.3.0     0 errors
ni0t5       kiam                           1.7.1     n/a: app has no values schema
ni0t5       kube-state-metrics             1.3.1     n/a: app has no values schema
ni0t5       metrics-server                 1.2.2     n/a: app has no values schema
ni0t5       net-exporter                   1.9.3     n/a: app has no values schema
ni0t5       nginx-ingress-controller-app   1.16.1    1 error
ni0t5       node-exporter                  1.7.2     n/a: app has no values schema

$ go run main.go validate app -n ni0t5 nginx-ingress-controller-app -o report

Validated 1 app across 1 namespace

ni0t5 [1 app, 1 error]
  nginx-ingress-controller-app:
    controller.admissionWebhooks.enabled - Invalid type. Expected: boolean, given: string - wrong

$ go run main.go validate apps -n ni0t5 missing-app

Error: Apps.application.giantswarm.io "missing-app" not found
exit status 1
```



