### PR TITLE
Add get appcatalogs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add get apps command.
+- Add `get appcatalogs` and `get apps` commands.
 
 ## [1.27.1] - 2021-04-28
 

--- a/cmd/get/appcatalogs/command.go
+++ b/cmd/get/appcatalogs/command.go
@@ -1,0 +1,102 @@
+package appcatalogs
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/giantswarm/kubectl-gs/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
+)
+
+const (
+	name  = "appcatalogs <catalog-name>"
+	alias = "appcatalog"
+
+	shortDescription = "Display app catalogs and available apps"
+	longDescription  = `Display app catalogs and available apps
+
+Output columns:
+
+- NAME: Name of the appcatalog.
+- URL: URL for the Helm chart repository.
+- AGE: How long ago the appcatalog was created.
+
+Getting an appcatalog by name will display the latest versions of the apps
+in this catalog according to semantic versioning.
+
+Output columns:
+
+- CATALOG: Name of the appcatalog.
+- APP NAME: Name of the app.
+- APP VERSION: Upstream version of the app.
+- VERSION: Latest version of the app.
+- AGE: How long ago the app release was created.`
+
+	examples = `  # List all public app catalogs
+  kubectl gs get appcatalogs
+  
+  # List all available apps for a catalog
+  kubectl gs get appcatalog giantswarm`
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	K8sConfigAccess clientcmd.ConfigAccess
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.FileSystem == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
+	}
+	if config.K8sConfigAccess == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		fs:     config.FileSystem,
+
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Short:   shortDescription,
+		Long:    longDescription,
+		Example: examples,
+		Aliases: []string{alias},
+		Args:    cobra.MaximumNArgs(1),
+		RunE:    r.Run,
+		PreRunE: middleware.Compose(
+			renewtoken.Middleware(config.K8sConfigAccess),
+		),
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/get/appcatalogs/error.go
+++ b/cmd/get/appcatalogs/error.go
@@ -1,0 +1,30 @@
+package appcatalogs
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/cmd/get/appcatalogs/flag.go
+++ b/cmd/get/appcatalogs/flag.go
@@ -1,0 +1,34 @@
+package appcatalogs
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	flagLabelSelector     = "selector"
+	publicCatalogSelector = "application.giantswarm.io/catalog-visibility=public"
+)
+
+type flag struct {
+	LabelSelector string
+
+	config genericclioptions.RESTClientGetter
+	print  *genericclioptions.PrintFlags
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.LabelSelector, flagLabelSelector, "l", publicCatalogSelector, "Specify label selector(s) to filter Apps by.")
+
+	f.config = genericclioptions.NewConfigFlags(true)
+	f.print = genericclioptions.NewPrintFlags("")
+
+	// Merging current command flags and config flags,
+	// to be able to override kubectl-specific ones.
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+	f.print.AddFlags(cmd)
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/get/appcatalogs/printer.go
+++ b/cmd/get/appcatalogs/printer.go
@@ -1,0 +1,143 @@
+package appcatalogs
+
+import (
+	"fmt"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/appcatalog"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+)
+
+func (r *runner) printOutput(appCatalogResource appcatalog.Resource) error {
+	var (
+		err      error
+		printer  printers.ResourcePrinter
+		resource runtime.Object
+	)
+
+	switch {
+	case output.IsOutputDefault(r.flag.print.OutputFormat):
+		resource = getTable(appCatalogResource)
+		printOptions := printers.PrintOptions{}
+		printer = printers.NewTablePrinter(printOptions)
+	case output.IsOutputName(r.flag.print.OutputFormat):
+		resource = appCatalogResource.Object()
+		err = output.PrintResourceNames(r.stdout, resource)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+
+	default:
+		resource = appCatalogResource.Object()
+		printer, err = r.flag.print.ToPrinter()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = printer.PrintObj(resource, r.stdout)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) printNoMatchOutput() {
+	fmt.Fprintf(r.stdout, "No AppCatalog CRD found.\n")
+	fmt.Fprintf(r.stdout, "Please check you are accessing a management cluster\n\n")
+}
+
+func (r *runner) printNoResourcesOutput() {
+	fmt.Fprintf(r.stdout, "No appcatalogs found.\n")
+	fmt.Fprintf(r.stdout, "To create an appcatalog, please check\n\n")
+	fmt.Fprintf(r.stdout, "  kubectl gs template appcatalog --help\n")
+}
+
+func getAppCatalogEntryRow(ace applicationv1alpha1.AppCatalogEntry) metav1.TableRow {
+	return metav1.TableRow{
+		Cells: []interface{}{
+			ace.Spec.Catalog.Name,
+			ace.Spec.AppName,
+			ace.Spec.AppVersion,
+			ace.Spec.Version,
+			output.TranslateTimestampSince(ace.CreationTimestamp),
+		},
+	}
+}
+
+func getAppCatalogEntryTable(appCatalogResource *appcatalog.AppCatalog) *metav1.Table {
+	// Creating a custom table resource.
+	table := &metav1.Table{}
+
+	table.ColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Catalog", Type: "string"},
+		{Name: "App Name", Type: "string"},
+		{Name: "App Version", Type: "string"},
+		{Name: "Version", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
+
+	for _, ace := range appCatalogResource.Entries.Items {
+		table.Rows = append(table.Rows, getAppCatalogEntryRow(ace))
+	}
+
+	return table
+}
+
+func getAppCatalogRow(a appcatalog.AppCatalog) metav1.TableRow {
+	if a.CR == nil {
+		return metav1.TableRow{}
+	}
+
+	return metav1.TableRow{
+		Cells: []interface{}{
+			a.CR.Name,
+			a.CR.Spec.Storage.URL,
+			output.TranslateTimestampSince(a.CR.CreationTimestamp),
+		},
+		Object: runtime.RawExtension{
+			Object: a.CR,
+		},
+	}
+}
+
+func getAppCatalogTable(appCatalogResource appcatalog.Resource) *metav1.Table {
+	// Creating a custom table resource.
+	table := &metav1.Table{}
+
+	table.ColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Catalog URL", Type: "string"},
+		{Name: "Age", Type: "string", Format: "date-time"},
+	}
+
+	switch c := appCatalogResource.(type) {
+	case *appcatalog.AppCatalog:
+		table.Rows = append(table.Rows, getAppCatalogRow(*c))
+	case *appcatalog.Collection:
+		for _, appCatalogItem := range c.Items {
+			table.Rows = append(table.Rows, getAppCatalogRow(appCatalogItem))
+		}
+	}
+
+	return table
+}
+
+func getTable(appCatalogResource appcatalog.Resource) *metav1.Table {
+	switch c := appCatalogResource.(type) {
+	case *appcatalog.AppCatalog:
+		return getAppCatalogEntryTable(c)
+	case *appcatalog.Collection:
+		return getAppCatalogTable(c)
+	}
+
+	return nil
+}

--- a/cmd/get/appcatalogs/runner.go
+++ b/cmd/get/appcatalogs/runner.go
@@ -1,0 +1,125 @@
+package appcatalogs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/app"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/appcatalog"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	fs     afero.Fs
+
+	service appcatalog.Interface
+
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	config := commonconfig.New(r.flag.config)
+	{
+		err = r.getService(config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var name, selector string
+	{
+		if len(args) > 0 {
+			name = strings.ToLower(args[0])
+			selector = fmt.Sprintf("application.giantswarm.io/catalog=%s,latest=true", name)
+		} else {
+			selector = r.flag.LabelSelector
+		}
+	}
+
+	var labelSelector labels.Selector
+	{
+		labelSelector, err = labels.Parse(selector)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var appCatalogResource appcatalog.Resource
+	{
+
+		options := appcatalog.GetOptions{
+			Name:          name,
+			LabelSelector: labelSelector,
+		}
+		appCatalogResource, err = r.service.Get(ctx, options)
+		if appcatalog.IsNotFound(err) {
+			return microerror.Maskf(notFoundError, fmt.Sprintf("An appcatalog '%s' cannot be found.\n", options.Name))
+		} else if app.IsNoMatch(err) {
+			r.printNoMatchOutput()
+			return nil
+		} else if appcatalog.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
+			r.printNoResourcesOutput()
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	err = r.printOutput(appCatalogResource)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) getService(config *commonconfig.CommonConfig) error {
+	if r.service != nil {
+		return nil
+	}
+
+	client, err := config.GetClient(r.logger)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	serviceConfig := appcatalog.Config{
+		Client: client,
+	}
+	r.service, err = appcatalog.New(serviceConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/giantswarm/kubectl-gs/cmd/get/appcatalogs"
 	"github.com/giantswarm/kubectl-gs/cmd/get/apps"
 	"github.com/giantswarm/kubectl-gs/cmd/get/capi"
 	"github.com/giantswarm/kubectl-gs/cmd/get/clusters"
@@ -63,6 +64,24 @@ func New(config Config) (*cobra.Command, error) {
 		}
 
 		appsCmd, err = apps.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var appCatalogsCmd *cobra.Command
+	{
+		c := appcatalogs.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			K8sConfigAccess: config.K8sConfigAccess,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		appCatalogsCmd, err = appcatalogs.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -137,6 +156,7 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(appsCmd)
+	c.AddCommand(appCatalogsCmd)
 	c.AddCommand(clusterApiCmd)
 	c.AddCommand(clustersCmd)
 	c.AddCommand(nodepoolsCmd)


### PR DESCRIPTION
Towards giantswarm/giantswarm#16978

Adds new command that gets the public app catalogs. Getting a single app catalog returns the latest apps for that catalog.

```sh
$ kubectl gs get appcatalogs -h

Display app catalogs and available apps

Output columns:

- NAME: Name of the appcatalog.
- URL: URL for the Helm chart repository.
- AGE: How long ago the appcatalog was created.

Getting an appcatalog by name will display the latest versions of the apps
in this catalog according to semantic versioning.

Output columns:

- CATALOG: Name of the appcatalog.
- APP NAME: Name of the app.
- APP VERSION: Upstream version of the app.
- VERSION: Latest version of the app.
- AGE: How long ago the app release was created.

Usage:
  kubectl gs get appcatalogs <catalog-name> [flags]

Aliases:
  appcatalogs, appcatalog

Examples:
  # List all public app catalogs
  kubectl gs get appcatalogs

  # List all available apps for a catalog
  kubectl gs get appcatalog giantswarm
...

$ kubectl gs get appcatalogs

NAME                    CATALOG URL                                                   AGE
giantswarm              https://giantswarm.github.io/giantswarm-catalog/              279d
giantswarm-playground   https://giantswarm.github.io/giantswarm-playground-catalog/   279d
helm-stable             https://charts.helm.sh/stable/packages/                       279d

$ kubectl gs get appcatalog giantswarm

CATALOG      APP NAME                       APP VERSION   VERSION                                          AGE
giantswarm   aqua-app-enforcer              5.3.21119     5.3.5                                            4d23h
giantswarm   aqua-app-scanner               5.3.21119     5.3.5                                            4d23h
giantswarm   aqua-app-server                5.3.21119     5.3.5                                            4d23h
...
```
```
