### PR TITLE
Handle x509.UnknownAuthorityError specifically when connecting to athena

### DIFF
--- a/pkg/graphql/error.go
+++ b/pkg/graphql/error.go
@@ -16,6 +16,16 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var unknownAuthorityError = &microerror.Error{
+	Kind: "unknownAuthorityError",
+	Desc: "the server side has presented a certificate that was issued by an untrusted authority",
+}
+
+// IsUnknownAuthority asserts unknownAuthorityError.
+func IsUnknownAuthority(err error) bool {
+	return microerror.Cause(err) == unknownAuthorityError
+}
+
 var httpError = &microerror.Error{
 	Kind: "httpError",
 }

--- a/pkg/installation/info.go
+++ b/pkg/installation/info.go
@@ -43,7 +43,7 @@ func getInstallationInfo(ctx context.Context, gqlClient graphql.Client) (install
 	var info installationInfo
 	err := gqlClient.ExecuteQuery(ctx, infoQuery, nil, &info)
 	if err != nil {
-		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfoError, "make sure you're connected to the internet and that the Athena service is up and running\n%s", err.Error())
+		return installationInfo{}, microerror.Maskf(cannotGetInstallationInfoError, "please make sure you can connect to the athena service.\n%s", err.Error())
 	}
 
 	return info, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16307

This PR should make the error message a bit mor specific when the athena certificate is not trusted.

I know, this is a very specific piece of error handling. However, I did it to debug a problem and figured I might as well suggest it for inclusion. WDYT?