### PR TITLE
Rename age field to created for clarity

### DIFF
--- a/cmd/get/appcatalogs/command.go
+++ b/cmd/get/appcatalogs/command.go
@@ -25,7 +25,7 @@ Output columns:
 
 - NAME: Name of the appcatalog.
 - URL: URL for the Helm chart repository.
-- AGE: How long ago the appcatalog was created.
+- CREATED: How long ago the appcatalog was created.
 
 Getting an appcatalog by name will display the latest versions of the apps
 in this catalog according to semantic versioning.
@@ -36,7 +36,7 @@ Output columns:
 - APP NAME: Name of the app.
 - APP VERSION: Upstream version of the app.
 - VERSION: Latest version of the app.
-- AGE: How long ago the app release was created.`
+- CREATED: How long ago the app release was created.`
 
 	examples = `  # List all public app catalogs
   kubectl gs get appcatalogs

--- a/cmd/get/appcatalogs/printer.go
+++ b/cmd/get/appcatalogs/printer.go
@@ -82,7 +82,7 @@ func getAppCatalogEntryTable(appCatalogResource *appcatalog.AppCatalog) *metav1.
 		{Name: "App Name", Type: "string"},
 		{Name: "App Version", Type: "string"},
 		{Name: "Version", Type: "string"},
-		{Name: "Age", Type: "string"},
+		{Name: "Created", Type: "string"},
 	}
 
 	for _, ace := range appCatalogResource.Entries.Items {
@@ -116,7 +116,7 @@ func getAppCatalogTable(appCatalogResource appcatalog.Resource) *metav1.Table {
 	table.ColumnDefinitions = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Catalog URL", Type: "string"},
-		{Name: "Age", Type: "string", Format: "date-time"},
+		{Name: "Created", Type: "string", Format: "date-time"},
 	}
 
 	switch c := appCatalogResource.(type) {


### PR DESCRIPTION
See https://github.com/giantswarm/docs/pull/937#discussion_r627714169

Changing the field name from `AGE` to `CREATED` as it maps to the creation timestamp of the CR.
