### PR TITLE
login: add support for having a timeout for calling the auth proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,7 +339,7 @@ This release supports rendering for CRs:
 - `AppCatalog`
 - `App`
 
-[unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v1.28.0...HEAD
+[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v1.28.0...HEAD
 [1.28.0]: https://github.com/giantswarm/kubectl-gs/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/giantswarm/kubectl-gs/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/giantswarm/kubectl-gs/compare/v1.26.0...v1.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Limit the time allowed for the `login` command to call the authentication proxy to one minute.
+
 ## [1.28.0] - 2021-05-11
 
 ### Changed
@@ -43,7 +47,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Removed
 
 - Removed the `--num-availability-zones` flag from the `kubectl-gs template` commands. The `--availability-zones` flag
-should be used to specify a list of availability zones.
+  should be used to specify a list of availability zones.
 
 ### Changed
 
@@ -147,7 +151,6 @@ should be used to specify a list of availability zones.
 ### Removed
 
 - Remove client-side validation of the GS `release` when creating a `Cluster`'s template.
-
 
 ## [0.13.0] - 2020-11-20
 
@@ -336,7 +339,7 @@ This release supports rendering for CRs:
 - `AppCatalog`
 - `App`
 
-[Unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v1.28.0...HEAD
+[unreleased]: https://github.com/giantswarm/kubectl-gs/compare/v1.28.0...HEAD
 [1.28.0]: https://github.com/giantswarm/kubectl-gs/compare/v1.27.1...v1.28.0
 [1.27.1]: https://github.com/giantswarm/kubectl-gs/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/giantswarm/kubectl-gs/compare/v1.26.0...v1.27.0

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -91,3 +91,12 @@ var invalidAuthConfigurationError = &microerror.Error{
 func IsInvalidAuthConfiguration(err error) bool {
 	return microerror.Cause(err) == invalidAuthConfigurationError
 }
+
+var authResponseTimedOutError = &microerror.Error{
+	Kind: "authResponseTimedOutError",
+}
+
+// IsAuthResponseTimedOut asserts authResponseTimedOutError.
+func IsAuthResponseTimedOut(err error) bool {
+	return microerror.Cause(err) == authResponseTimedOutError
+}

--- a/pkg/callbackserver/callbackserver.go
+++ b/pkg/callbackserver/callbackserver.go
@@ -16,6 +16,7 @@ type Config struct {
 	Port        int
 	RedirectURI string
 }
+
 type CallbackServer struct {
 	port        int
 	redirectURI string

--- a/pkg/callbackserver/callbackserver.go
+++ b/pkg/callbackserver/callbackserver.go
@@ -72,7 +72,12 @@ func (cs *CallbackServer) Run(ctx context.Context, callback CallbackFunc) (inter
 			Handler: mux,
 		}
 	}
-	defer server.Shutdown(ctx)
+	defer func() {
+		err := server.Shutdown(ctx)
+		if err != nil {
+			errorCh <- err
+		}
+	}()
 
 	go func() {
 		err := server.ListenAndServe()

--- a/pkg/callbackserver/callbackserver.go
+++ b/pkg/callbackserver/callbackserver.go
@@ -72,12 +72,6 @@ func (cs *CallbackServer) Run(ctx context.Context, callback CallbackFunc) (inter
 			Handler: mux,
 		}
 	}
-	defer func() {
-		err := server.Shutdown(ctx)
-		if err != nil {
-			errorCh <- err
-		}
-	}()
 
 	go func() {
 		err := server.ListenAndServe()
@@ -100,7 +94,16 @@ func (cs *CallbackServer) Run(ctx context.Context, callback CallbackFunc) (inter
 		break
 	}
 
-	return result, microerror.Mask(origErr)
+	err := server.Shutdown(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if origErr != nil {
+		return nil, microerror.Mask(origErr)
+	}
+
+	return result, nil
 }
 
 func (cs *CallbackServer) Port() int {

--- a/pkg/callbackserver/callbackserver.go
+++ b/pkg/callbackserver/callbackserver.go
@@ -47,8 +47,9 @@ func New(config Config) (*CallbackServer, error) {
 // Run starts a server listening at a given path and port and
 // calls a callback function as soon as that path is hit.
 //
-// It blocks and waits until the given path is hit, then shuts
-// down and returns the result of the callback function.
+// It blocks and waits until the given path is hit, or until the
+// context deadline is reached, then shuts down the server and
+// returns the result of the callback function.
 func (cs *CallbackServer) Run(ctx context.Context, callback CallbackFunc) (interface{}, error) {
 	resultCh := make(chan interface{})
 	errorCh := make(chan error)

--- a/pkg/callbackserver/error.go
+++ b/pkg/callbackserver/error.go
@@ -1,0 +1,14 @@
+package callbackserver
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var timedOutError = &microerror.Error{
+	Kind: "timedOutError",
+}
+
+// IsTimedOut asserts timedOutError.
+func IsTimedOut(err error) bool {
+	return microerror.Cause(err) == timedOutError
+}


### PR DESCRIPTION
This PR adds a limit of `1 minute` for the `login` command to call the authentication proxy, so the app won't remain open accidentally if login was not finalized.

Also, the auth proxy port is no longer hardcoded, it is automatically set to an available one.

### Preview

<details>
<summary>Error message, if the timeout is reached</summary>

![image](https://user-images.githubusercontent.com/13508038/118016460-b4b0a680-b355-11eb-92ba-31f58cbbc0e6.png)

</details>