### PR TITLE
Add experimental support for building windows binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ kubectl-gs*
 bin-dist
 .vscode
 .DS_Store
+/certs

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -46,3 +46,12 @@ spec:
     - from: ./kubectl-gs-*/*
       to: .
     bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-windows-amd64.zip" .TagName }}
+    files:
+    - from: ./kubectl-gs-*/*
+      to: .
+    bin: ./kubectl-gs

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -102,8 +102,9 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(V
 		  quay.io/giantswarm/signcode-util:latest \
 		  sign \
 		  -pkcs12 /mnt/certs/code-signing.p12 \
-		  -n "kubectl-gs" \
+		  -n "Giant Swarm plugin for kubectl" \
 		  -i https://github.com/giantswarm/kubectl-gs \
+		  -ts http://timestamp.digicert.com -verbose \
 		  -in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
 		  -out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
 		  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -23,7 +23,7 @@ LDFLAGS        ?= -w -linkmode 'auto' -extldflags '$(EXTLDFLAGS)' \
 
 ##@ Go
 
-.PHONY: build build-darwin build-darwin-64 build-linux build-linux-arm64
+.PHONY: build build-darwin build-darwin-64 build-linux build-linux-arm64 build-windows-amd64
 build: $(APPLICATION) ## Builds a local binary.
 	@echo "====> $@"
 build-darwin: $(APPLICATION)-darwin ## Builds a local binary for darwin/amd64.
@@ -33,6 +33,8 @@ build-darwin-arm64: $(APPLICATION)-darwin-arm64 ## Builds a local binary for dar
 build-linux: $(APPLICATION)-linux ## Builds a local binary for linux/amd64.
 	@echo "====> $@"
 build-linux-arm64: $(APPLICATION)-linux-arm64 ## Builds a local binary for linux/arm64.
+	@echo "====> $@"
+build-windows-amd64: $(APPLICATION)-windows-amd64.exe ## Builds a local binary for windows/amd64.
 	@echo "====> $@"
 
 $(APPLICATION): $(APPLICATION)-v$(VERSION)-$(OS)-amd64
@@ -55,6 +57,10 @@ $(APPLICATION)-linux-arm64: $(APPLICATION)-v$(VERSION)-linux-arm64
 	@echo "====> $@"
 	cp -a $< $@
 
+$(APPLICATION)-windows-amd64.exe: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
+	@echo "====> $@"
+	cp -a $< $@
+
 $(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
 	@echo "====> $@"
 	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
@@ -63,7 +69,12 @@ $(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
 	@echo "====> $@"
 	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ .
 
-.PHONY: package-darwin-amd64 package-darwin-arm64 package-linux-amd64 package-linux-arm64
+$(APPLICATION)-v$(VERSION)-windows-amd64.exe: $(SOURCES)
+	@echo "====> $@"
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
+
+.PHONY: package-darwin-amd64 package-darwin-arm64 package-linux-amd64 package-linux-arm64 package-windows-amd64
 package-darwin-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz ## Prepares a packaged darwin/amd64 version.
 	@echo "====> $@"
 package-darwin-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-arm64.tar.gz ## Prepares a packaged darwin/arm64 version.
@@ -72,6 +83,21 @@ package-linux-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.g
 	@echo "====> $@"
 package-linux-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-arm64.tar.gz ## Prepares a packaged linux/arm64 version.
 	@echo "====> $@"
+package-windows-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip ## Prepares a packaged windows/amd64 version.
+	@echo "====> $@"
+
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
+	@echo "====> $@"
+
+	@echo "Creating directory $(DIR)"
+	mkdir -p $(DIR)
+	cp $< $(DIR)/$(APPLICATION).exe
+	cp README.md LICENSE $(DIR)
+	cd ./bin-dist && zip $(APPLICATION)-v$(VERSION)-windows-amd64.zip $(APPLICATION)-v$(VERSION)-windows-amd64/*
+	rm -rf $(DIR)
+	rm -rf $<
+
 
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -104,7 +104,7 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(V
 		  -pkcs12 /mnt/certs/code-signing.p12 \
 		  -n "Giant Swarm plugin for kubectl" \
 		  -i https://github.com/giantswarm/kubectl-gs \
-		  -ts http://timestamp.digicert.com -verbose \
+		  -t http://timestamp.digicert.com -verbose \
 		  -in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
 		  -out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
 		  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -90,24 +90,23 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 	@echo "====> $@"
 
-	@if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
+	@ if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
 	  echo 'Signing the Windows binary'; \
-	  echo ${PWD}; \
-	  ls -la \
 	  mkdir -p certs; \
 	  echo ${CODE_SIGNING_CERT_BUNDLE_BASE64} | base64 -d > certs/code-signing.p12; \
-	#   docker run --rm -ti \
-	# 	  -v ${PWD}/certs:/mnt/certs \
-	# 	  -v ${PWD}/build:/mnt/binaries \
-	# 	  --user ${USERID}:${GROUPID} \
-	# 	  quay.io/giantswarm/signcode-util:latest \
-	# 	  sign \
-	# 	  -pkcs12 /mnt/certs/code-signing.p12 \
-	# 	  -n "kubectl-gs" \
-	# 	  -i https://github.com/giantswarm/kubectl-gs \
-	# 	  -in /mnt/binaries/bin/${BIN}-$$OS \
-	# 	  -out /mnt/binaries/$(BIN)-$(VERSION)-$$OS/$(BIN).exe \
-	# 	  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \
+	  mv ${APPLICATION}-v${VERSION}-windows-amd64.exe ${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe; \
+	  docker run --rm -ti \
+		  -v ${PWD}/certs:/mnt/certs \
+		  -v ${PWD}:/mnt/binaries \
+		  --user ${USERID}:${GROUPID} \
+		  quay.io/giantswarm/signcode-util:latest \
+		  sign \
+		  -pkcs12 /mnt/certs/code-signing.p12 \
+		  -n "kubectl-gs" \
+		  -i https://github.com/giantswarm/kubectl-gs \
+		  -in /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64-unsigned.exe \
+		  -out /mnt/binaries/${APPLICATION}-v${VERSION}-windows-amd64.exe \
+		  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \
 	fi
 
 	@echo "Creating directory $(DIR)"

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -90,6 +90,26 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 	@echo "====> $@"
 
+	@if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
+	  echo 'Signing the Windows binary'; \
+	  echo ${PWD}; \
+	  ls -la \
+	  mkdir -p certs; \
+	  echo ${CODE_SIGNING_CERT_BUNDLE_BASE64} | base64 -d > certs/code-signing.p12; \
+	#   docker run --rm -ti \
+	# 	  -v ${PWD}/certs:/mnt/certs \
+	# 	  -v ${PWD}/build:/mnt/binaries \
+	# 	  --user ${USERID}:${GROUPID} \
+	# 	  quay.io/giantswarm/signcode-util:latest \
+	# 	  sign \
+	# 	  -pkcs12 /mnt/certs/code-signing.p12 \
+	# 	  -n "kubectl-gs" \
+	# 	  -i https://github.com/giantswarm/kubectl-gs \
+	# 	  -in /mnt/binaries/bin/${BIN}-$$OS \
+	# 	  -out /mnt/binaries/$(BIN)-$(VERSION)-$$OS/$(BIN).exe \
+	# 	  -pass $(CODE_SIGNING_CERT_BUNDLE_PASSWORD); \
+	fi
+
 	@echo "Creating directory $(DIR)"
 	mkdir -p $(DIR)
 	cp $< $(DIR)/$(APPLICATION).exe


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/333 , https://github.com/giantswarm/giantswarm/issues/17271

The result of `make package-windows-amd64` is a ZIP file containing an unsigned EXE file.

Note: This PR is a draft only. The modified file `Makefile.gen.go.mk` is meant to be generated by [devctl](https://github.com/giantswarm/devctl).