### PR TITLE
Refactoring for template app and template appcatalog

### DIFF
--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -41,10 +41,10 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	var userSecretCR *v1.Secret
-	var userConfigMapCR *v1.ConfigMap
-	var userConfigConfigMapCRYaml []byte
-	var userConfigSecretCRYaml []byte
+	var userSecret *v1.Secret
+	var userConfigMap *v1.ConfigMap
+	var userConfigConfigMapYaml []byte
+	var userConfigSecretYaml []byte
 	var err error
 
 	appConfig := app.Config{
@@ -66,13 +66,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
 			Namespace: r.flag.Cluster,
 		}
-		userSecretCR, err = app.NewSecretCR(secretConfig)
+		userSecret, err = app.NewSecret(secretConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		appConfig.UserConfigSecretName = userSecretCR.GetName()
+		appConfig.UserConfigSecretName = userSecret.GetName()
 
-		userConfigSecretCRYaml, err = yaml.Marshal(userSecretCR)
+		userConfigSecretYaml, err = yaml.Marshal(userSecret)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -91,13 +91,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
 			Namespace: r.flag.Cluster,
 		}
-		userConfigMapCR, err = app.NewConfigmapCR(configMapConfig)
+		userConfigMap, err = app.NewConfigmap(configMapConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		appConfig.UserConfigConfigMapName = userConfigMapCR.GetName()
+		appConfig.UserConfigConfigMapName = userConfigMap.GetName()
 
-		userConfigConfigMapCRYaml, err = yaml.Marshal(userConfigMapCR)
+		userConfigConfigMapYaml, err = yaml.Marshal(userConfigMap)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -121,8 +121,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	appCROutput := AppCROutput{
 		AppCR:                 string(appCRYaml),
-		UserConfigConfigMapCR: string(userConfigConfigMapCRYaml),
-		UserConfigSecretCR:    string(userConfigSecretCRYaml),
+		UserConfigConfigMapCR: string(userConfigConfigMapYaml),
+		UserConfigSecretCR:    string(userConfigSecretYaml),
 	}
 
 	t := template.Must(template.New("appCatalogCR").Parse(key.AppCRTemplate))

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -48,7 +48,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var userConfigSecretYaml []byte
 	var err error
 
-	appConfig := app.Config{
+	appConfig := templateapp.Config{
 		Catalog:   r.flag.Catalog,
 		Name:      r.flag.Name,
 		Namespace: r.flag.Namespace,

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/template/app"
@@ -42,8 +42,8 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	var userConfigMap *v1.ConfigMap
-	var userSecret *v1.Secret
+	var userConfigMap *corev1.ConfigMap
+	var userSecret *corev1.Secret
 	var userConfigConfigMapYaml []byte
 	var userConfigSecretYaml []byte
 	var err error

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/template/app"
+	templateapp "github.com/giantswarm/kubectl-gs/pkg/template/app"
 )
 
 type runner struct {
@@ -41,8 +42,8 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	var userSecret *v1.Secret
 	var userConfigMap *v1.ConfigMap
+	var userSecret *v1.Secret
 	var userConfigConfigMapYaml []byte
 	var userConfigSecretYaml []byte
 	var err error
@@ -61,12 +62,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 
-		secretConfig := app.SecretConfig{
+		secretConfig := templateapp.SecretConfig{
 			Data:      userConfigSecretData,
 			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
 			Namespace: r.flag.Cluster,
 		}
-		userSecret, err = app.NewSecret(secretConfig)
+		userSecret, err = templateapp.NewSecret(secretConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -86,12 +87,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				return microerror.Mask(err)
 			}
 		}
-		configMapConfig := app.ConfigMapConfig{
+		configMapConfig := templateapp.ConfigMapConfig{
 			Data:      configMapData,
 			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
 			Namespace: r.flag.Cluster,
 		}
-		userConfigMap, err = app.NewConfigmap(configMapConfig)
+		userConfigMap, err = templateapp.NewConfigMap(configMapConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -114,15 +115,15 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	type AppCROutput struct {
-		AppCR                 string
-		UserConfigSecretCR    string
-		UserConfigConfigMapCR string
+		AppCR               string
+		UserConfigConfigMap string
+		UserConfigSecret    string
 	}
 
 	appCROutput := AppCROutput{
-		AppCR:                 string(appCRYaml),
-		UserConfigConfigMapCR: string(userConfigConfigMapYaml),
-		UserConfigSecretCR:    string(userConfigSecretYaml),
+		AppCR:               string(appCRYaml),
+		UserConfigConfigMap: string(userConfigConfigMapYaml),
+		UserConfigSecret:    string(userConfigSecretYaml),
 	}
 
 	t := template.Must(template.New("appCatalogCR").Parse(key.AppCRTemplate))

--- a/cmd/template/appcatalog/runner.go
+++ b/cmd/template/appcatalog/runner.go
@@ -11,10 +11,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-
-	appcatalog "github.com/giantswarm/kubectl-gs/pkg/template/appcatalog"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
+	templateappcatalog "github.com/giantswarm/kubectl-gs/pkg/template/appcatalog"
 )
 
 type runner struct {

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -1,9 +1,9 @@
 package key
 
 const AppCRTemplate = `
-{{- .UserConfigConfigMapCR -}}
+{{- .UserConfigConfigMap -}}
 ---
-{{ .UserConfigSecretCR -}}
+{{ .UserConfigSecret -}}
 ---
 {{ .AppCR -}}
 `

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -9,9 +9,9 @@ const AppCRTemplate = `
 `
 
 const AppCatalogCRTemplate = `
-{{- .ConfigmapCR -}}
+{{- .CatalogConfigMap -}}
 ---
-{{ .SecretCR -}}
+{{ .CatalogSecret -}}
 ---
 {{ .AppCatalogCR -}}
 `

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,8 +85,8 @@ func NewAppCR(config Config) (*applicationv1alpha1.App, error) {
 	return appCR, nil
 }
 
-func NewConfigMap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
-	configMap := &apiv1.ConfigMap{
+func NewConfigMap(config ConfigMapConfig) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -103,8 +103,8 @@ func NewConfigMap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
 	return configMap, nil
 }
 
-func NewSecret(config SecretConfig) (*apiv1.Secret, error) {
-	secret := &apiv1.Secret{
+func NewSecret(config SecretConfig) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -85,9 +85,8 @@ func NewAppCR(config Config) (*applicationv1alpha1.App, error) {
 	return appCR, nil
 }
 
-func NewConfigmapCR(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
-
-	configMapCR := &apiv1.ConfigMap{
+func NewConfigmap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
+	return &apiv1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -100,14 +99,11 @@ func NewConfigmapCR(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
 		Data: map[string]string{
 			"values": config.Data,
 		},
-	}
-
-	return configMapCR, nil
+	}, nil
 }
 
-func NewSecretCR(config SecretConfig) (*apiv1.Secret, error) {
-
-	secretCR := &apiv1.Secret{
+func NewSecret(config SecretConfig) (*apiv1.Secret, error) {
+	return &apiv1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -115,12 +111,9 @@ func NewSecretCR(config SecretConfig) (*apiv1.Secret, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
 			Namespace: config.Namespace,
-			Labels:    map[string]string{},
 		},
 		Data: map[string][]byte{
 			"values": config.Data,
 		},
-	}
-
-	return secretCR, nil
+	}, nil
 }

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -85,8 +85,8 @@ func NewAppCR(config Config) (*applicationv1alpha1.App, error) {
 	return appCR, nil
 }
 
-func NewConfigmap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
-	return &apiv1.ConfigMap{
+func NewConfigMap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
+	configMap := &apiv1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -94,16 +94,17 @@ func NewConfigmap(config ConfigMapConfig) (*apiv1.ConfigMap, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
 			Namespace: config.Namespace,
-			Labels:    map[string]string{},
 		},
 		Data: map[string]string{
 			"values": config.Data,
 		},
-	}, nil
+	}
+
+	return configMap, nil
 }
 
 func NewSecret(config SecretConfig) (*apiv1.Secret, error) {
-	return &apiv1.Secret{
+	secret := &apiv1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -115,5 +116,7 @@ func NewSecret(config SecretConfig) (*apiv1.Secret, error) {
 		Data: map[string][]byte{
 			"values": config.Data,
 		},
-	}, nil
+	}
+
+	return secret, nil
 }

--- a/pkg/template/appcatalog/appCatalog.go
+++ b/pkg/template/appcatalog/appCatalog.go
@@ -12,11 +12,28 @@ type Config struct {
 	Description          string
 	ID                   string
 	Name                 string
+	Namespace            string
 	LogoURL              string
 	URL                  string
 }
 
 func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
+	catalogConfig := applicationv1alpha1.AppCatalogSpecConfig{}
+
+	if config.CatalogConfigMapName != "" {
+		catalogConfig.ConfigMap = applicationv1alpha1.AppCatalogSpecConfigConfigMap{
+			Name:      config.CatalogConfigMapName,
+			Namespace: config.Namespace,
+		}
+	}
+
+	if config.CatalogSecretName != "" {
+		catalogConfig.Secret = applicationv1alpha1.AppCatalogSpecConfigSecret{
+			Name:      config.CatalogSecretName,
+			Namespace: config.Namespace,
+		}
+	}
+
 	appCatalogCR := &applicationv1alpha1.AppCatalog{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppCatalog",
@@ -30,16 +47,7 @@ func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
 			},
 		},
 		Spec: applicationv1alpha1.AppCatalogSpec{
-			Config: applicationv1alpha1.AppCatalogSpecConfig{
-				ConfigMap: applicationv1alpha1.AppCatalogSpecConfigConfigMap{
-					Name:      config.CatalogConfigMapName,
-					Namespace: metav1.NamespaceDefault,
-				},
-				Secret: applicationv1alpha1.AppCatalogSpecConfigSecret{
-					Name:      config.CatalogSecretName,
-					Namespace: metav1.NamespaceDefault,
-				},
-			},
+			Config:      catalogConfig,
 			Description: config.Description,
 			LogoURL:     config.LogoURL,
 			Storage: applicationv1alpha1.AppCatalogSpecStorage{

--- a/pkg/template/appcatalog/appCatalog.go
+++ b/pkg/template/appcatalog/appCatalog.go
@@ -2,20 +2,21 @@ package appcatalog
 
 import (
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Config struct {
-	Description string
-	ID          string
-	Name        string
-	LogoURL     string
-	URL         string
+	CatalogConfigMapName string
+	CatalogSecretName    string
+	Description          string
+	ID                   string
+	Name                 string
+	LogoURL              string
+	URL                  string
 }
 
 func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
-
 	appCatalogCR := &applicationv1alpha1.AppCatalog{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppCatalog",
@@ -31,11 +32,11 @@ func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
 		Spec: applicationv1alpha1.AppCatalogSpec{
 			Config: applicationv1alpha1.AppCatalogSpecConfig{
 				ConfigMap: applicationv1alpha1.AppCatalogSpecConfigConfigMap{
-					Name:      config.Name + config.ID,
+					Name:      config.CatalogConfigMapName,
 					Namespace: metav1.NamespaceDefault,
 				},
 				Secret: applicationv1alpha1.AppCatalogSpecConfigSecret{
-					Name:      config.Name + config.ID,
+					Name:      config.CatalogSecretName,
 					Namespace: metav1.NamespaceDefault,
 				},
 			},
@@ -59,16 +60,15 @@ func NewConfigMap(config Config, data string) (*corev1.ConfigMap, error) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name + config.ID,
+			Name:      config.CatalogConfigMapName,
 			Namespace: metav1.NamespaceDefault,
-			Labels:    map[string]string{},
 		},
 		Data: map[string]string{
 			"values": data,
 		},
 	}
 
-	return configMapCR, nil
+	return configMap, nil
 }
 
 func NewSecret(config Config, data []byte) (*corev1.Secret, error) {
@@ -78,14 +78,13 @@ func NewSecret(config Config, data []byte) (*corev1.Secret, error) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name + config.ID,
+			Name:      config.CatalogSecretName,
 			Namespace: metav1.NamespaceDefault,
-			Labels:    map[string]string{},
 		},
 		Data: map[string][]byte{
 			"values": data,
 		},
 	}
 
-	return secretCR, nil
+	return secret, nil
 }

--- a/pkg/template/appcatalog/appCatalog.go
+++ b/pkg/template/appcatalog/appCatalog.go
@@ -52,9 +52,8 @@ func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
 	return appCatalogCR, nil
 }
 
-func NewConfigmapCR(config Config, data string) (*apiv1.ConfigMap, error) {
-
-	configMapCR := &apiv1.ConfigMap{
+func NewConfigMap(config Config, data string) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -72,9 +71,8 @@ func NewConfigmapCR(config Config, data string) (*apiv1.ConfigMap, error) {
 	return configMapCR, nil
 }
 
-func NewSecretCR(config Config, data []byte) (*apiv1.Secret, error) {
-
-	secretCR := &apiv1.Secret{
+func NewSecret(config Config, data []byte) (*corev1.Secret, error) {
+	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",


### PR DESCRIPTION
Some refactoring of the template commands and fixes a problem with `template appcatalog`.

```sh
go run main.go template appcatalog \
  --name example-catalog \
  --description "An example App Catalog" \
  --url https://example.github.io/my-app-catalog/ \
  --logo https://example.com/logos/example-logo.png \
  --configmap=/tmp/user_config.yaml
apiVersion: v1
data:
  values: |
    template: test
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: example-catalog-3jhd5
  namespace: default
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: AppCatalog
metadata:
  creationTimestamp: null
  labels:
    app-operator.giantswarm.io/version: 1.0.0
    application.giantswarm.io/catalog-type: awesome
  name: example-catalog
spec:
  config:
    configMap:
      name: example-catalog-3jhd5
      namespace: default
    secret:
      name: example-catalog-3jhd5
      namespace: default
  description: An example App Catalog
  logoURL: https://example.com/logos/example-logo.png
  storage:
    URL: https://example.github.io/my-app-catalog/
    type: helm
  title: example-catalog
```




