### PR TITLE
Only set configmap or secret in template appcatalog if values are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Disable unique AZ validation to allow China cluster templating.
 
+### Fixed
+
+- Only set configmap or secret in `template appcatalog` if values are provided.
+
 ### Added
 
 - Add `get appcatalogs` and `get apps` commands.

--- a/cmd/template/appcatalog/runner.go
+++ b/cmd/template/appcatalog/runner.go
@@ -2,7 +2,6 @@ package appcatalog
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"text/template"
@@ -56,8 +55,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	if r.flag.ConfigMap != "" {
-		fmt.Printf("CM %s \n", r.flag.ConfigMap)
-
 		var configMapData string
 
 		configMapData, err = key.ReadConfigMapYamlFromFile(afero.NewOsFs(), r.flag.ConfigMap)
@@ -78,8 +75,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	}
 
 	if r.flag.Secret != "" {
-		fmt.Printf("SECRET %s \n", r.flag.Secret)
-
 		var secretData []byte
 
 		secretData, err = key.ReadSecretYamlFromFile(afero.NewOsFs(), r.flag.Secret)

--- a/cmd/template/appcatalog/runner.go
+++ b/cmd/template/appcatalog/runner.go
@@ -2,6 +2,7 @@ package appcatalog
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"text/template"
@@ -11,10 +12,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-
-	appcatalog "github.com/giantswarm/kubectl-gs/pkg/template/appcatalog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
+	templateappcatalog "github.com/giantswarm/kubectl-gs/pkg/template/appcatalog"
 )
 
 type runner struct {
@@ -41,15 +42,70 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
-	config := appcatalog.Config{
+	var configmapCRYaml []byte
+	var secretCRYaml []byte
+	var err error
+
+	config := templateappcatalog.Config{
 		Description: r.flag.Description,
 		LogoURL:     r.flag.LogoURL,
 		ID:          key.GenerateID(),
 		Name:        r.flag.Name,
+		Namespace:   metav1.NamespaceDefault,
 		URL:         r.flag.URL,
 	}
 
-	appCatalogCR, err := appcatalog.NewAppCatalogCR(config)
+	if r.flag.ConfigMap != "" {
+		fmt.Printf("CM %s \n", r.flag.ConfigMap)
+
+		var configMapData string
+
+		configMapData, err = key.ReadConfigMapYamlFromFile(afero.NewOsFs(), r.flag.ConfigMap)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.CatalogConfigMapName = key.GenerateAssetName(r.flag.Name, config.ID)
+		configmapCR, err := templateappcatalog.NewConfigmapCR(config, configMapData)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		configmapCRYaml, err = yaml.Marshal(configmapCR)
+		if err != nil {
+			return microerror.Maskf(unmashalToMapFailedError, err.Error())
+		}
+	}
+
+	if r.flag.Secret != "" {
+		fmt.Printf("SECRET %s \n", r.flag.Secret)
+
+		var secretData []byte
+
+		secretData, err = key.ReadSecretYamlFromFile(afero.NewOsFs(), r.flag.Secret)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.CatalogSecretName = key.GenerateAssetName(r.flag.Name, config.ID)
+		secretCR, err := templateappcatalog.NewSecretCR(config, secretData)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		secretCRYaml, err = yaml.Marshal(secretCR)
+		if err != nil {
+			return microerror.Maskf(unmashalToMapFailedError, err.Error())
+		}
+	}
+
+	type AppCatalogCROutput struct {
+		AppCatalogCR string
+		ConfigmapCR  string
+		SecretCR     string
+	}
+
+	appCatalogCR, err := templateappcatalog.NewAppCatalogCR(config)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -57,46 +113,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	appCatalogCRYaml, err := yaml.Marshal(appCatalogCR)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	var configMapData string
-	if r.flag.ConfigMap != "" {
-		configMapData, err = key.ReadConfigMapYamlFromFile(afero.NewOsFs(), r.flag.ConfigMap)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-	configmapCR, err := appcatalog.NewConfigmapCR(config, configMapData)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	configmapCRYaml, err := yaml.Marshal(configmapCR)
-	if err != nil {
-		return microerror.Maskf(unmashalToMapFailedError, err.Error())
-	}
-
-	var secretData []byte
-	if r.flag.Secret != "" {
-		secretData, err = key.ReadSecretYamlFromFile(afero.NewOsFs(), r.flag.Secret)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-	secretCR, err := appcatalog.NewSecretCR(config, secretData)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	secretCRYaml, err := yaml.Marshal(secretCR)
-	if err != nil {
-		return microerror.Maskf(unmashalToMapFailedError, err.Error())
-	}
-
-	type AppCatalogCROutput struct {
-		AppCatalogCR string
-		ConfigmapCR  string
-		SecretCR     string
 	}
 
 	appCatalogCROutput := AppCatalogCROutput{

--- a/pkg/template/appcatalog/appCatalog.go
+++ b/pkg/template/appcatalog/appCatalog.go
@@ -7,14 +7,32 @@ import (
 )
 
 type Config struct {
-	Description string
-	ID          string
-	Name        string
-	LogoURL     string
-	URL         string
+	CatalogConfigMapName string
+	CatalogSecretName    string
+	Description          string
+	ID                   string
+	Name                 string
+	Namespace            string
+	LogoURL              string
+	URL                  string
 }
 
 func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
+	catalogConfig := applicationv1alpha1.AppCatalogSpecConfig{}
+
+	if config.CatalogConfigMapName != "" {
+		catalogConfig.ConfigMap = applicationv1alpha1.AppCatalogSpecConfigConfigMap{
+			Name:      config.CatalogConfigMapName,
+			Namespace: config.Namespace,
+		}
+	}
+
+	if config.CatalogSecretName != "" {
+		catalogConfig.Secret = applicationv1alpha1.AppCatalogSpecConfigSecret{
+			Name:      config.CatalogSecretName,
+			Namespace: config.Namespace,
+		}
+	}
 
 	appCatalogCR := &applicationv1alpha1.AppCatalog{
 		TypeMeta: metav1.TypeMeta{
@@ -29,16 +47,7 @@ func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
 			},
 		},
 		Spec: applicationv1alpha1.AppCatalogSpec{
-			Config: applicationv1alpha1.AppCatalogSpecConfig{
-				ConfigMap: applicationv1alpha1.AppCatalogSpecConfigConfigMap{
-					Name:      config.Name + config.ID,
-					Namespace: metav1.NamespaceDefault,
-				},
-				Secret: applicationv1alpha1.AppCatalogSpecConfigSecret{
-					Name:      config.Name + config.ID,
-					Namespace: metav1.NamespaceDefault,
-				},
-			},
+			Config:      catalogConfig,
 			Description: config.Description,
 			LogoURL:     config.LogoURL,
 			Storage: applicationv1alpha1.AppCatalogSpecStorage{
@@ -53,16 +62,14 @@ func NewAppCatalogCR(config Config) (*applicationv1alpha1.AppCatalog, error) {
 }
 
 func NewConfigmapCR(config Config, data string) (*apiv1.ConfigMap, error) {
-
 	configMapCR := &apiv1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name + config.ID,
-			Namespace: metav1.NamespaceDefault,
-			Labels:    map[string]string{},
+			Name:      config.CatalogConfigMapName,
+			Namespace: config.Namespace,
 		},
 		Data: map[string]string{
 			"values": data,
@@ -73,16 +80,14 @@ func NewConfigmapCR(config Config, data string) (*apiv1.ConfigMap, error) {
 }
 
 func NewSecretCR(config Config, data []byte) (*apiv1.Secret, error) {
-
 	secretCR := &apiv1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name + config.ID,
-			Namespace: metav1.NamespaceDefault,
-			Labels:    map[string]string{},
+			Name:      config.CatalogSecretName,
+			Namespace: config.Namespace,
 		},
 		Data: map[string][]byte{
 			"values": data,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16978

Fixes a bug where the configmap and secret are always templated even if the flags are not set.

Without a configmap and secret.

```sh
 go run main.go template appcatalog \
  --name example-catalog \
  --description "An example App Catalog" \
  --url https://example.github.io/my-app-catalog/ \
  --logo https://example.com/logos/example-logo.png
```

```yaml
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: AppCatalog
metadata:
  creationTimestamp: null
  labels:
    app-operator.giantswarm.io/version: 1.0.0
    application.giantswarm.io/catalog-type: awesome
  name: example-catalog
spec:
  config:
    configMap:
      name: ""
      namespace: ""
    secret:
      name: ""
      namespace: ""
  description: An example App Catalog
  logoURL: https://example.com/logos/example-logo.png
  storage:
    URL: https://example.github.io/my-app-catalog/
    type: helm
  title: example-catalog
```

With a configmap.

```sh
go run main.go template appcatalog \
  --name example-catalog \
  --description "An example App Catalog" \
  --url https://example.github.io/my-app-catalog/ \
  --logo https://example.com/logos/example-logo.png \
  --configmap="/tmp/user_config.yaml"
```

```yaml
apiVersion: v1
data:
  values: |
    template: test
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: example-catalog-p0zxa
  namespace: default
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: AppCatalog
metadata:
  creationTimestamp: null
  labels:
    app-operator.giantswarm.io/version: 1.0.0
    application.giantswarm.io/catalog-type: awesome
  name: example-catalog
spec:
  config:
    configMap:
      name: example-catalog-p0zxa
      namespace: default
    secret:
      name: ""
      namespace: ""
  description: An example App Catalog
  logoURL: https://example.com/logos/example-logo.png
  storage:
    URL: https://example.github.io/my-app-catalog/
    type: helm
  title: example-catalog
```

With a configmap and secret.

```sh
go run main.go template appcatalog \
  --name example-catalog \
  --description "An example App Catalog" \
  --url https://example.github.io/my-app-catalog/ \
  --logo https://example.com/logos/example-logo.png \
  --configmap="/tmp/user_config.yaml" \
  --secret="/tmp/user_secrets.yaml"
```

```yaml
apiVersion: v1
data:
  values: |
    template: test
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: example-catalog-5t85e
  namespace: default
---
apiVersion: v1
data:
  values: c2VjcmV0OiB0ZXN0Cg==
kind: Secret
metadata:
  creationTimestamp: null
  name: example-catalog-5t85e
  namespace: default
---
apiVersion: application.giantswarm.io/v1alpha1
kind: AppCatalog
metadata:
  creationTimestamp: null
  labels:
    app-operator.giantswarm.io/version: 1.0.0
    application.giantswarm.io/catalog-type: awesome
  name: example-catalog
spec:
  config:
    configMap:
      name: example-catalog-5t85e
      namespace: default
    secret:
      name: example-catalog-5t85e
      namespace: default
  description: An example App Catalog
  logoURL: https://example.com/logos/example-logo.png
  storage:
    URL: https://example.github.io/my-app-catalog/
    type: helm
  title: example-catalog
```