### PR TITLE
Replace `--master-az` with `--control-plane-az` in `template nodepool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Limit the time allowed for the `login` command to call the authentication proxy to one minute.
 
+### Changed
+
+- In the `template cluster` command, the flag `--control-plane-az` is replacing `--master-az`.
+- Updated terminology to use "control plane nodes" instead of "master nodes".
+
 ## [1.28.0] - 2021-05-11
 
 ### Changed

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -56,7 +56,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Common.
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "User-defined cluster ID.")
-	cmd.Flags().StringSliceVar(&f.ControlPlaneAZ, flagControlPlaneAZ, []string{}, "Availability zone(s) to use by control plane nodes.")
+	cmd.Flags().StringSliceVar(&f.ControlPlaneAZ, flagControlPlaneAZ, nil, "Availability zone(s) to use by control plane nodes.")
 	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, nil, "Replaced by --control-plane-az.")
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Workload cluster name.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -75,8 +75,13 @@ func (f *flag) Validate() error {
 	var err error
 
 	// TODO: Remove the flag completely some time after August 2021
-	if len(f.MasterAZ) > 0 && len(f.ControlPlaneAZ) > 0 {
-		return microerror.Maskf(invalidFlagError, "--control-plane-az and --master-az cannot be combined")
+	if len(f.MasterAZ) > 0 {
+		if len(f.ControlPlaneAZ) > 0 {
+			return microerror.Maskf(invalidFlagError, "--control-plane-az and --master-az cannot be combined")
+		}
+
+		f.ControlPlaneAZ = f.MasterAZ
+		f.MasterAZ = nil
 	}
 
 	if f.Provider != key.ProviderAWS && f.Provider != key.ProviderAzure {

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -21,7 +21,7 @@ const (
 	// Common.
 	flagClusterID      = "cluster-id"
 	flagControlPlaneAZ = "control-plane-az"
-	flagMasterAZ       = "master-az" // TODO: Remove some time after August 2020
+	flagMasterAZ       = "master-az" // TODO: Remove some time after August 2021
 	flagName           = "name"
 	flagOutput         = "output"
 	flagOwner          = "owner"
@@ -57,21 +57,21 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// Common.
 	cmd.Flags().StringVar(&f.ClusterID, flagClusterID, "", "User-defined cluster ID.")
 	cmd.Flags().StringSliceVar(&f.ControlPlaneAZ, flagControlPlaneAZ, []string{}, "Availability zone(s) to use by control plane nodes.")
-	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, []string{}, "Replaced by --control-plane-az.")
+	cmd.Flags().StringSliceVar(&f.MasterAZ, flagMasterAZ, nil, "Replaced by --control-plane-az.")
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Workload cluster name.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release. If not given, this remains empty for defaulting to the most recent one via the Management API.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Workload cluster label.")
 
-	// TODO: Remove the flag completely some time after August 2020
+	// TODO: Remove the flag completely some time after August 2021
 	_ = cmd.Flags().MarkDeprecated(flagMasterAZ, "please use --control-plane-az.")
 }
 
 func (f *flag) Validate() error {
 	var err error
 
-	// TODO: Remove the flag completely some time after August 2020
+	// TODO: Remove the flag completely some time after August 2021
 	if len(f.MasterAZ) > 0 && len(f.ControlPlaneAZ) > 0 {
 		return microerror.Maskf(invalidFlagError, "--control-plane-az and --master-az cannot be combined")
 	}

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -17,7 +17,7 @@ func WriteAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 	crsConfig := v1alpha2.ClusterCRsConfig{
 		ClusterID:      config.ClusterID,
 		ExternalSNAT:   config.ExternalSNAT,
-		MasterAZ:       config.MasterAZ,
+		MasterAZ:       config.ControlPlaneAZ,
 		Description:    config.Description,
 		PodsCIDR:       config.PodsCIDR,
 		Owner:          config.Owner,

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -105,8 +105,8 @@ func newAzureClusterCR(config ClusterCRsConfig) *capzv1alpha3.AzureCluster {
 
 func newAzureMasterMachineCR(config ClusterCRsConfig) *capzv1alpha3.AzureMachine {
 	var failureDomain *string
-	if len(config.MasterAZ) > 0 {
-		failureDomain = &config.MasterAZ[0]
+	if len(config.ControlPlaneAZ) > 0 {
+		failureDomain = &config.ControlPlaneAZ[0]
 	}
 
 	machine := &capzv1alpha3.AzureMachine{

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -16,7 +16,7 @@ type ClusterCRsConfig struct {
 	// Common.
 	FileName       string
 	ClusterID      string
-	MasterAZ       []string
+	ControlPlaneAZ []string
 	Description    string
 	Owner          string
 	ReleaseVersion string

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -35,8 +35,8 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Sorting is required before validation for uniqueness.
-	sort.Slice(r.flag.MasterAZ, func(i, j int) bool {
-		return r.flag.MasterAZ[i] < r.flag.MasterAZ[j]
+	sort.Slice(r.flag.ControlPlaneAZ, func(i, j int) bool {
+		return r.flag.ControlPlaneAZ[i] < r.flag.ControlPlaneAZ[j]
 	})
 
 	err := r.flag.Validate()
@@ -61,7 +61,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			FileName:       clusterCRFileName,
 			ClusterID:      r.flag.ClusterID,
 			ExternalSNAT:   r.flag.ExternalSNAT,
-			MasterAZ:       r.flag.MasterAZ,
+			ControlPlaneAZ: r.flag.ControlPlaneAZ,
 			Description:    r.flag.Name,
 			Owner:          r.flag.Owner,
 			PodsCIDR:       r.flag.PodsCIDR,

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -69,6 +69,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Namespace:      metav1.NamespaceDefault,
 		}
 
+		if len(r.flag.MasterAZ) > 0 {
+			config.ControlPlaneAZ = r.flag.MasterAZ
+		}
+
 		if config.ClusterID == "" {
 			config.ClusterID = id.Generate()
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14964

This changes the `kuebctl gs template cluster` command to deprecate the flag `--master-az` and introduce `--control-plane-az` instead.