### PR TITLE
Extend template app to only output required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Extend `template app` to only output required fields, the flag `--defaulting-enabled`
+can be set to false to disable this.
+
 ## [1.29.2] - 2021-06-17
 
 - In the `template cluster` command, the flag `--control-plane-az` is replacing `--master-az`.

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -6,18 +6,20 @@ import (
 )
 
 const (
-	flagCatalog       = "catalog"
-	flagCluster       = "cluster"
-	flagName          = "name"
-	flagNamespace     = "namespace"
-	flagUserConfigMap = "user-configmap"
-	flagUserSecret    = "user-secret"
-	flagVersion       = "version"
+	flagCatalog           = "catalog"
+	flagCluster           = "cluster"
+	flagDefaultingEnabled = "defaulting-enabled"
+	flagName              = "name"
+	flagNamespace         = "namespace"
+	flagUserConfigMap     = "user-configmap"
+	flagUserSecret        = "user-secret"
+	flagVersion           = "version"
 )
 
 type flag struct {
 	Catalog           string
 	Cluster           string
+	DefaultingEnabled bool
 	Name              string
 	Namespace         string
 	flagUserConfigMap string
@@ -30,6 +32,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "App name.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Cluster where the app will be deployed.")
+	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user app configmap file data.")
 	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user app secret file data.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -33,13 +33,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Cluster where the app will be deployed.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
-	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user app configmap file data.")
-	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user app secret file data.")
+	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
+	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user secrets YAML file.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")
 }
 
 func (f *flag) Validate() error {
-
 	if f.Catalog == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagCatalog)
 	}

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	templateapp "github.com/giantswarm/kubectl-gs/pkg/template/app"

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -45,11 +45,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var err error
 
 	appConfig := templateapp.Config{
-		Catalog:   r.flag.Catalog,
-		Name:      r.flag.Name,
-		Namespace: r.flag.Namespace,
-		Cluster:   r.flag.Cluster,
-		Version:   r.flag.Version,
+		Catalog:           r.flag.Catalog,
+		Name:              r.flag.Name,
+		Namespace:         r.flag.Namespace,
+		Cluster:           r.flag.Cluster,
+		DefaultingEnabled: r.flag.DefaultingEnabled,
+		Version:           r.flag.Version,
 	}
 
 	if r.flag.flagUserSecret != "" {
@@ -100,12 +101,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
-	appCR, err := templateapp.NewAppCR(appConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	appCRYaml, err := yaml.Marshal(appCR)
+	appCRYaml, err := templateapp.NewAppCR(appConfig)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/appcatalog/runner.go
+++ b/cmd/template/appcatalog/runner.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 	templateappcatalog "github.com/giantswarm/kubectl-gs/pkg/template/appcatalog"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.22.0
-	github.com/giantswarm/app/v4 v4.12.0
+	github.com/giantswarm/app/v4 v4.11.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/micrologger v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/fatih/color v1.10.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.22.0
 	github.com/giantswarm/app/v4 v4.11.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.22.0 h1:Nkn0POdMBks58zDVCaDJ4HDkbDC0qU6bD9uV5tcKlp0=
 github.com/giantswarm/apiextensions/v3 v3.22.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
-github.com/giantswarm/app/v4 v4.12.0 h1:kRbFEmomrMf5YP3jTST8U9RORDn0KuAOIc1Ug96J6qU=
-github.com/giantswarm/app/v4 v4.12.0/go.mod h1:HdEgovjIiuIrf+ejAM00YS3A9U/2Gd04RnUzoGZ7OsE=
+github.com/giantswarm/app/v4 v4.11.0 h1:tzwyq4y7vp1X1O0648TZamoM9ZuTjTVl0dEIGrTQlcQ=
+github.com/giantswarm/app/v4 v4.11.0/go.mod h1:5Sku0gVZw8id9U/G2RJ1A//ntikvU8YGgU7NpyO6sgg=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/cluster-api v0.3.13-gs h1:ZgOMYkSuM1KnRmdDkPTfYj8G+Bdn6K1+sI0RnsPoBSc=
@@ -235,8 +235,6 @@ github.com/giantswarm/cluster-api-provider-azure v0.4.12-gsalpha3 h1:hfYVY9E862A
 github.com/giantswarm/cluster-api-provider-azure v0.4.12-gsalpha3/go.mod h1:v/WBSPW45C0QHslLmrmg7YGGmaN70kT2XxjDKby8Yh4=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8smetadata v0.1.0 h1:Y+rIUEEMiqV4DghTIz9jobVeKZxN/AMDX09PJfrz1tw=
-github.com/giantswarm/k8smetadata v0.1.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.3.0 h1:V/9cXlIEddNGaRYiA0vYJmgM2+sTQy+k8M7kVjOy4XM=
 github.com/giantswarm/microerror v0.3.0/go.mod h1:g8oCEMFAoEs70riRRmj9+6eiz7SqNxYl+2OfxFh1po0=

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
+	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/kubectl-gs/pkg/normalize"
 )

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -1,7 +1,10 @@
 package app
 
 import (
+	"github.com/ghodss/yaml"
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -9,10 +12,11 @@ import (
 type Config struct {
 	Catalog                 string
 	Cluster                 string
-	UserConfigConfigMapName string
-	UserConfigSecretName    string
+	DefaultingEnabled       bool
 	Name                    string
 	Namespace               string
+	UserConfigConfigMapName string
+	UserConfigSecretName    string
 	Version                 string
 }
 
@@ -28,7 +32,7 @@ type ConfigMapConfig struct {
 	Namespace string
 }
 
-func NewAppCR(config Config) (*applicationv1alpha1.App, error) {
+func NewAppCR(config Config) ([]byte, error) {
 	userConfig := applicationv1alpha1.AppSpecUserConfig{}
 
 	if config.UserConfigConfigMapName != "" {
@@ -53,36 +57,42 @@ func NewAppCR(config Config) (*applicationv1alpha1.App, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
 			Namespace: config.Cluster,
-			Labels: map[string]string{
-				"app-operator.giantswarm.io/version": "1.0.0",
-			},
 		},
 		Spec: applicationv1alpha1.AppSpec{
 			Catalog:   config.Catalog,
 			Name:      config.Name,
 			Namespace: config.Namespace,
-			Config: applicationv1alpha1.AppSpecConfig{
-				ConfigMap: applicationv1alpha1.AppSpecConfigConfigMap{
-					Name:      config.Cluster + "-cluster-values",
-					Namespace: config.Cluster,
-				},
-			},
 			KubeConfig: applicationv1alpha1.AppSpecKubeConfig{
-				Context: applicationv1alpha1.AppSpecKubeConfigContext{
-					Name: config.Cluster + "-kubeconfig",
-				},
 				InCluster: false,
-				Secret: applicationv1alpha1.AppSpecKubeConfigSecret{
-					Name:      config.Cluster + "-kubeconfig",
-					Namespace: config.Cluster,
-				},
 			},
 			UserConfig: userConfig,
 			Version:    config.Version,
 		},
 	}
 
-	return appCR, nil
+	if !config.DefaultingEnabled {
+		appCR.SetLabels(map[string]string{
+			"app-operator.giantswarm.io/version": "1.0.0",
+		})
+		appCR.Spec.Config = applicationv1alpha1.AppSpecConfig{
+			ConfigMap: applicationv1alpha1.AppSpecConfigConfigMap{
+				Name:      config.Cluster + "-cluster-values",
+				Namespace: config.Cluster,
+			},
+		}
+		appCR.Spec.KubeConfig = applicationv1alpha1.AppSpecKubeConfig{
+			Context: applicationv1alpha1.AppSpecKubeConfigContext{
+				Name: config.Cluster + "-kubeconfig",
+			},
+			InCluster: false,
+			Secret: applicationv1alpha1.AppSpecKubeConfigSecret{
+				Name:      config.Cluster + "-kubeconfig",
+				Namespace: config.Cluster,
+			},
+		}
+	}
+
+	return printAppCR(appCR, config.DefaultingEnabled)
 }
 
 func NewConfigMap(config ConfigMapConfig) (*corev1.ConfigMap, error) {
@@ -119,4 +129,65 @@ func NewSecret(config SecretConfig) (*corev1.Secret, error) {
 	}
 
 	return secret, nil
+}
+
+// printAppCR removes empty fields from the app CR YAML. This is needed because
+// although the fields are optional we do not use struct pointers. This will
+// be fixed in a future version of the App CRD.
+func printAppCR(appCR *v1alpha1.App, defaultingEnabled bool) ([]byte, error) {
+	appCRYaml, err := yaml.Marshal(appCR)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	rawAppCR := map[string]interface{}{}
+	err = yaml.Unmarshal(appCRYaml, &rawAppCR)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	delete(rawAppCR, "status")
+
+	metadata, ok := rawAppCR["metadata"].(map[string]interface{})
+	if !ok {
+		return nil, microerror.Maskf(executionFailedError, "failed to get metadata for app CR")
+	}
+	delete(metadata, "creationTimestamp")
+
+	spec, ok := rawAppCR["spec"].(map[string]interface{})
+	if !ok {
+		return nil, microerror.Maskf(executionFailedError, "failed to get spec for app CR")
+	}
+
+	delete(spec, "install")
+	delete(spec, "namespaceConfig")
+
+	if defaultingEnabled {
+		delete(spec, "config")
+		spec["kubeConfig"] = map[string]bool{
+			"inCluster": false,
+		}
+	}
+
+	if appCR.Spec.UserConfig.ConfigMap.Name == "" && appCR.Spec.UserConfig.Secret.Name == "" {
+		delete(spec, "userConfig")
+	} else {
+		userConfig, ok := spec["userConfig"].(map[string]interface{})
+		if !ok {
+			return nil, microerror.Maskf(executionFailedError, "failed to get userConfig for app CR")
+		}
+
+		if appCR.Spec.UserConfig.ConfigMap.Name != "" && appCR.Spec.UserConfig.Secret.Name == "" {
+			delete(userConfig, "secret")
+		} else if appCR.Spec.UserConfig.ConfigMap.Name == "" && appCR.Spec.UserConfig.Secret.Name != "" {
+			delete(userConfig, "configMap")
+		}
+	}
+
+	outputYaml, err := yaml.Marshal(rawAppCR)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return outputYaml, nil
 }

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -1,12 +1,12 @@
 package app
 
 import (
-	"github.com/ghodss/yaml"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type Config struct {

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -14,7 +14,6 @@ func Test_NewAppCR(t *testing.T) {
 		name               string
 		config             Config
 		expectedGoldenFile string
-		errorMatcher       func(err error) bool
 	}{
 		{
 			name: "case 0: flawless flow",
@@ -72,23 +71,15 @@ func Test_NewAppCR(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Log(tc.name)
 
-			appCRYaml, err := NewAppCR(tc.config)
-
 			gf := goldenfile.New("testdata", tc.expectedGoldenFile)
 			expectedResult, err := gf.Read()
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
 
-			switch {
-			case err == nil && tc.errorMatcher == nil:
-				// correct; carry on
-			case err != nil && tc.errorMatcher == nil:
-				t.Fatalf("error == %#v, want nil", err)
-			case err == nil && tc.errorMatcher != nil:
-				t.Fatalf("error == nil, want non-nil")
-			case !tc.errorMatcher(err):
-				t.Fatalf("error == %#v, want matching", err)
+			appCRYaml, err := NewAppCR(tc.config)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
 			}
 
 			if !cmp.Equal(appCRYaml, expectedResult) {

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_NewAppCR(t *testing.T) {
+	testCases := []struct {
+		name               string
+		config             Config
+		expectedGoldenFile string
+		errorMatcher       func(err error) bool
+	}{
+		{
+			name: "case 0: flawless flow",
+			config: Config{
+				Catalog:           "giantswarm",
+				Cluster:           "eggs2",
+				DefaultingEnabled: true,
+				Name:              "nginx-ingress-controller-app",
+				Namespace:         "kube-system",
+				Version:           "1.17.0",
+			},
+			expectedGoldenFile: "app_flawless_flow_yaml_output.golden",
+		},
+		{
+			name: "case 1: defaulting disabled",
+			config: Config{
+				Catalog:           "giantswarm",
+				Cluster:           "eggs2",
+				DefaultingEnabled: false,
+				Name:              "nginx-ingress-controller-app",
+				Namespace:         "kube-system",
+				Version:           "1.17.0",
+			},
+			expectedGoldenFile: "app_defaulting_disabled_yaml_output.golden",
+		},
+		{
+			name: "case 2: user values",
+			config: Config{
+				Catalog:                 "giantswarm",
+				Cluster:                 "eggs2",
+				DefaultingEnabled:       true,
+				Name:                    "nginx-ingress-controller-app",
+				Namespace:               "kube-system",
+				UserConfigConfigMapName: "nginx-ingress-controller-app-user-values",
+				Version:                 "1.17.0",
+			},
+			expectedGoldenFile: "app_user_values_yaml_output.golden",
+		},
+		{
+			name: "case 3: user secrets with defauting disabled",
+			config: Config{
+				Catalog:              "giantswarm",
+				Cluster:              "eggs2",
+				DefaultingEnabled:    false,
+				Name:                 "nginx-ingress-controller-app",
+				Namespace:            "kube-system",
+				UserConfigSecretName: "nginx-ingress-controller-app-user-secrets",
+				Version:              "1.17.0",
+			},
+			expectedGoldenFile: "app_user_secrets_yaml_output.golden",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			appCRYaml, err := NewAppCR(tc.config)
+
+			gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+			expectedResult, err := gf.Read()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !cmp.Equal(appCRYaml, expectedResult) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(string(expectedResult), string(appCRYaml)))
+			}
+		})
+	}
+}

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -4,8 +4,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 )
 
 func Test_NewAppCR(t *testing.T) {

--- a/pkg/template/app/error.go
+++ b/pkg/template/app/error.go
@@ -1,0 +1,9 @@
+package app
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/pkg/template/app/testdata/app_defaulting_disabled_yaml_output.golden
+++ b/pkg/template/app/testdata/app_defaulting_disabled_yaml_output.golden
@@ -1,0 +1,26 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 1.0.0
+  name: nginx-ingress-controller-app
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  config:
+    configMap:
+      name: eggs2-cluster-values
+      namespace: eggs2
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: eggs2-kubeconfig
+    inCluster: false
+    secret:
+      name: eggs2-kubeconfig
+      namespace: eggs2
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  version: 1.17.0

--- a/pkg/template/app/testdata/app_flawless_flow_yaml_output.golden
+++ b/pkg/template/app/testdata/app_flawless_flow_yaml_output.golden
@@ -1,0 +1,12 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: nginx-ingress-controller-app
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: false
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  version: 1.17.0

--- a/pkg/template/app/testdata/app_user_secrets_yaml_output.golden
+++ b/pkg/template/app/testdata/app_user_secrets_yaml_output.golden
@@ -1,0 +1,30 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 1.0.0
+  name: nginx-ingress-controller-app
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  config:
+    configMap:
+      name: eggs2-cluster-values
+      namespace: eggs2
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: eggs2-kubeconfig
+    inCluster: false
+    secret:
+      name: eggs2-kubeconfig
+      namespace: eggs2
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  userConfig:
+    secret:
+      name: nginx-ingress-controller-app-user-secrets
+      namespace: eggs2
+  version: 1.17.0

--- a/pkg/template/app/testdata/app_user_values_yaml_output.golden
+++ b/pkg/template/app/testdata/app_user_values_yaml_output.golden
@@ -1,0 +1,16 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: nginx-ingress-controller-app
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: false
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  userConfig:
+    configMap:
+      name: nginx-ingress-controller-app-user-values
+      namespace: eggs2
+  version: 1.17.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16978

Docs: https://github.com/giantswarm/docs/pull/986

The current `template app` can be improved because it defaults a lot of boiler plate fields that will be set by app-admission-controller.

We also have ugly empty fields because although fields are optional in the CRD we don't use struct pointers. So the YAML
serialization doesn't work. I'd like us to fix that in a future v1alpha2 App CRD but its non-trivial as we'll need a conversion webhook.

### Before

```yaml
go run main.go template app \
  --catalog giantswarm-playground \
  --name keda \
  --namespace default \
  --cluster 2hr7z  \
  --version 0.1.0
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  creationTimestamp: null
  labels:
    app-operator.giantswarm.io/version: 1.0.0
  name: keda
  namespace: 2hr7z
spec:
  catalog: giantswarm-playground
  config:
    configMap:
      name: 2hr7z-cluster-values
      namespace: 2hr7z
    secret:
      name: ""
      namespace: ""
  install: {}
  kubeConfig:
    context:
      name: 2hr7z-kubeconfig
    inCluster: false
    secret:
      name: 2hr7z-kubeconfig
      namespace: 2hr7z
  name: keda
  namespace: default
  namespaceConfig: {}
  userConfig:
    configMap:
      name: ""
      namespace: ""
    secret:
      name: ""
      namespace: ""
  version: 0.1.0
status:
  appVersion: ""
  release:
    lastDeployed: null
    status: ""
  version: ""
```

### After

```yaml
go run main.go template app \
  --catalog giantswarm-playground \
  --name keda \
  --namespace default \
  --cluster 2hr7z  \
  --version 0.1.0
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: keda
  namespace: 2hr7z
spec:
  catalog: giantswarm-playground
  kubeConfig:
    inCluster: false
  name: keda
  namespace: default
  version: 0.1.0
```

