### PR TITLE
Allow overriding the app name in template app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow overriding the app CR name in the `template app` command.
+
 ### Changed
 
 - Update Dockerfile to use alpine:3.14 as a base image

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -6,6 +6,7 @@ import (
 )
 
 const (
+	flagAppName           = "app-name"
 	flagCatalog           = "catalog"
 	flagCluster           = "cluster"
 	flagDefaultingEnabled = "defaulting-enabled"
@@ -17,6 +18,7 @@ const (
 )
 
 type flag struct {
+	AppName           string
 	Catalog           string
 	Cluster           string
 	DefaultingEnabled bool
@@ -28,8 +30,9 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.AppName, flagAppName, "", "Optionally set a different name for the App CR.")
 	cmd.Flags().StringVar(&f.Catalog, flagCatalog, "", "Catalog name where app is stored.")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "App name.")
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the app in the Catalog.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Cluster where the app will be deployed.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Config struct {
+	AppName                 string
 	Catalog                 string
 	Cluster                 string
 	DefaultingEnabled       bool
@@ -49,13 +50,17 @@ func NewAppCR(config Config) ([]byte, error) {
 		}
 	}
 
+	if config.AppName == "" {
+		config.AppName = config.Name
+	}
+
 	appCR := &applicationv1alpha1.App{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "App",
 			APIVersion: "application.giantswarm.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.Name,
+			Name:      config.AppName,
 			Namespace: config.Cluster,
 		},
 		Spec: applicationv1alpha1.AppSpec{

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -65,6 +65,19 @@ func Test_NewAppCR(t *testing.T) {
 			},
 			expectedGoldenFile: "app_user_secrets_yaml_output.golden",
 		},
+		{
+			name: "case 4: override app name",
+			config: Config{
+				AppName:           "internal-nginx-ingress-controller",
+				Catalog:           "giantswarm",
+				Cluster:           "eggs2",
+				DefaultingEnabled: true,
+				Name:              "nginx-ingress-controller-app",
+				Namespace:         "kube-system",
+				Version:           "1.17.0",
+			},
+			expectedGoldenFile: "app_override_app_name_yaml_output.golden",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/template/app/testdata/app_override_app_name_yaml_output.golden
+++ b/pkg/template/app/testdata/app_override_app_name_yaml_output.golden
@@ -1,0 +1,12 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: internal-nginx-ingress-controller
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: false
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  version: 1.17.0


### PR DESCRIPTION
See https://github.com/giantswarm/docs/pull/912#issuecomment-875634640

Currently the `--name` param in `template app` is used for both the name of the app in the catalog and the app CR name. However in some situations like installing multiple ingress controllers you also need to be able to set the app name.

This adds a new optional `--app-name` param for this.



