### PR TITLE
trim v in release version for nodepools

### DIFF
--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/id"
 
@@ -66,6 +67,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		if config.NodePoolID == "" {
 			config.NodePoolID = id.Generate()
 		}
+
+		// Remove leading 'v' from release flag input.
+		config.ReleaseVersion = strings.TrimLeft(config.ReleaseVersion, "v")
 
 		if len(r.flag.AvailabilityZones) > 0 {
 			config.AvailabilityZones = r.flag.AvailabilityZones


### PR DESCRIPTION
We had the problem that using the option `--release v20.0.0` and `--release 20.0.0` would both result in a CAPI cluster being templated but in case of nodepools, it had to be `--release 20.0.0`. This PR makes sure that the `v` is trimmed in nodepool templating as well and both versions work.