### PR TITLE
accept scaling parameters for AWSMachinePool

### DIFF
--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -214,6 +214,8 @@ func newAWSMachinePoolFromUnstructured(config NodePoolCRsConfig, o unstructured.
 		awsmachinepool.Spec.AvailabilityZones = config.AvailabilityZones
 		awsmachinepool.Spec.AWSLaunchTemplate.InstanceType = config.AWSInstanceType
 		awsmachinepool.Spec.AWSLaunchTemplate.IamInstanceProfile = key.GetNodeInstanceProfile(config.NodePoolID, config.ClusterID)
+		awsmachinepool.Spec.MinSize = int32(config.NodesMin)
+		awsmachinepool.Spec.MaxSize = int32(config.NodesMax)
 		onDemandBaseCapacity := int64(config.OnDemandBaseCapacity)
 		onDemandPercentageAboveBaseCapacity := int64(config.OnDemandPercentageAboveBaseCapacity)
 		awsmachinepool.Spec.MixedInstancesPolicy = &capav1alpha3.MixedInstancesPolicy{

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -170,7 +170,7 @@ func getCAPANodepoolTemplate(config NodePoolCRsConfig) (client.Template, error) 
 
 	templateOptions := client.GetClusterTemplateOptions{
 		ClusterName:       config.ClusterID,
-		TargetNamespace:   config.Owner,
+		TargetNamespace:   key.OrganizationNamespaceFromName(config.Owner),
 		KubernetesVersion: "v1.19.9",
 		ProviderRepositorySource: &client.ProviderRepositorySourceOptions{
 			InfrastructureProvider: "aws:v0.6.6",


### PR DESCRIPTION
We want to set the scaling parameters for `AWSMachinePools` based on the flags.
Also fixing the namespace for machinepool creation.