### PR TITLE
aws-ommit-empty-subnets-nodeppol

### DIFF
--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -217,6 +217,7 @@ func newAWSMachinePoolFromUnstructured(config NodePoolCRsConfig, o unstructured.
 		awsmachinepool.Spec.MinSize = int32(config.NodesMin)
 		awsmachinepool.Spec.MaxSize = int32(config.NodesMax)
 		onDemandBaseCapacity := int64(config.OnDemandBaseCapacity)
+		awsmachinepool.Spec.Subnets = nil // for now we dont allow spec of subnets ID and  this needs to be ommited
 		onDemandPercentageAboveBaseCapacity := int64(config.OnDemandPercentageAboveBaseCapacity)
 		awsmachinepool.Spec.MixedInstancesPolicy = &capav1alpha3.MixedInstancesPolicy{
 			InstancesDistribution: &capav1alpha3.InstancesDistribution{


### PR DESCRIPTION
without the change the generated yaml file contains:
```yaml
spec:
  subnets:
  - {}
```

which breaks node pool creation, if we don't not specify subnets we need to omit it and than controller will reuse subnets from CP

already test, this helps