### PR TITLE
Add support for spot VMs on azure machine pool template cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Spot VMs for Azure Node Pools.
+
 ## [1.32.0] - 2021-07-16
 
 ### Changed

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -87,7 +87,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")
 	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool. Defaults to false.")
-	cmd.Flags().Float32Var(&f.AzureSpotMaxPrice, flagAzureSpotMaxPrice, 0, "Max hourly price in USD to pay for one spot VM. If not set than on demand pricing is used as the max value.")
+	cmd.Flags().Float32Var(&f.AzureSpotVMsMaxPrice, flagAzureSpotVMsMaxPrice, 0, "Max hourly price in USD to pay for one spot VM on Azure. If not set, the on-demand price is used as the limit.")
 
 	// Common.
 	cmd.Flags().StringSliceVar(&f.AvailabilityZones, flagAvailabilityZones, []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -21,7 +21,9 @@ const (
 	flagUseAlikeInstanceTypes               = "use-alike-instance-types"
 
 	// Azure only.
-	flagAzureVMSize = "azure-vm-size"
+	flagAzureVMSize       = "azure-vm-size"
+	flagAzureUseSpotVMs   = "azure-spot-vms"
+	flagAzureSpotMaxPrice = "azure-spot-max-price"
 
 	// Common.
 	flagAvailabilityZones = "availability-zones"
@@ -52,7 +54,9 @@ type flag struct {
 	UseAlikeInstanceTypes               bool
 
 	// Azure only.
-	AzureVMSize string
+	AzureVMSize       string
+	AzureUseSpotVms   bool
+	AzureSpotMaxPrice float32
 
 	// Common.
 	AvailabilityZones []string
@@ -82,6 +86,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")
+	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool.")
+	cmd.Flags().Float32Var(&f.AzureSpotMaxPrice, flagAzureSpotMaxPrice, 0, "Max hourly price in USD to pay for one spot VM.")
 
 	// Common.
 	cmd.Flags().StringSliceVar(&f.AvailabilityZones, flagAvailabilityZones, []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -81,8 +81,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AWSInstanceType, flagAWSInstanceType, "m5.xlarge", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'.")
 	cmd.Flags().StringVar(&f.MachineDeploymentSubnet, flagMachineDeploymentSubnet, "", "Subnet used for the Node Pool.")
 	cmd.Flags().IntVar(&f.OnDemandBaseCapacity, flagOnDemandBaseCapacity, 0, "Number of base capacity for On demand instance distribution. Default is 0. Only available on AWS.")
-	cmd.Flags().IntVar(&f.OnDemandPercentageAboveBaseCapacity, flagOnDemandPercentageAboveBaseCapacity, 100, "Percentage above base capacity for On demand instance distribution. Default is 100. Only available on Azure.")
-	cmd.Flags().BoolVar(&f.UseAlikeInstanceTypes, flagUseAlikeInstanceTypes, false, "Whether to use similar instances types as a fallback. Only available on Azure.")
+	cmd.Flags().IntVar(&f.OnDemandPercentageAboveBaseCapacity, flagOnDemandPercentageAboveBaseCapacity, 100, "Percentage above base capacity for On demand instance distribution. Default is 100. Only available on AWS.")
+	cmd.Flags().BoolVar(&f.UseAlikeInstanceTypes, flagUseAlikeInstanceTypes, false, "Whether to use similar instances types as a fallback. Only available on AWS.")
 
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -21,8 +21,8 @@ const (
 	flagUseAlikeInstanceTypes               = "use-alike-instance-types"
 
 	// Azure only.
-	flagAzureVMSize       = "azure-vm-size"
-	flagAzureUseSpotVMs   = "azure-spot-vms"
+	flagAzureVMSize          = "azure-vm-size"
+	flagAzureUseSpotVMs      = "azure-spot-vms"
 	flagAzureSpotVMsMaxPrice = "azure-spot-vms-max-price"
 
 	// Common.
@@ -54,8 +54,8 @@ type flag struct {
 	UseAlikeInstanceTypes               bool
 
 	// Azure only.
-	AzureVMSize       string
-	AzureUseSpotVms   bool
+	AzureVMSize          string
+	AzureUseSpotVms      bool
 	AzureSpotVMsMaxPrice float32
 
 	// Common.

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -56,7 +56,7 @@ type flag struct {
 	// Azure only.
 	AzureVMSize       string
 	AzureUseSpotVms   bool
-	AzureSpotMaxPrice float32
+	AzureSpotVMsMaxPrice float32
 
 	// Common.
 	AvailabilityZones []string

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -23,7 +23,7 @@ const (
 	// Azure only.
 	flagAzureVMSize       = "azure-vm-size"
 	flagAzureUseSpotVMs   = "azure-spot-vms"
-	flagAzureSpotMaxPrice = "azure-spot-max-price"
+	flagAzureSpotVMsMaxPrice = "azure-spot-vms-max-price"
 
 	// Common.
 	flagAvailabilityZones = "availability-zones"

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -80,9 +80,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// AWS only.
 	cmd.Flags().StringVar(&f.AWSInstanceType, flagAWSInstanceType, "m5.xlarge", "EC2 instance type to use for workers, e. g. 'm5.2xlarge'.")
 	cmd.Flags().StringVar(&f.MachineDeploymentSubnet, flagMachineDeploymentSubnet, "", "Subnet used for the Node Pool.")
-	cmd.Flags().IntVar(&f.OnDemandBaseCapacity, flagOnDemandBaseCapacity, 0, "Number of base capacity for On demand instance distribution. Default is 0.")
-	cmd.Flags().IntVar(&f.OnDemandPercentageAboveBaseCapacity, flagOnDemandPercentageAboveBaseCapacity, 100, "Percentage above base capacity for On demand instance distribution. Default is 100.")
-	cmd.Flags().BoolVar(&f.UseAlikeInstanceTypes, flagUseAlikeInstanceTypes, false, "Whether to use similar instances types as a fallback.")
+	cmd.Flags().IntVar(&f.OnDemandBaseCapacity, flagOnDemandBaseCapacity, 0, "Number of base capacity for On demand instance distribution. Default is 0. Only available on AWS.")
+	cmd.Flags().IntVar(&f.OnDemandPercentageAboveBaseCapacity, flagOnDemandPercentageAboveBaseCapacity, 100, "Percentage above base capacity for On demand instance distribution. Default is 100. Only available on Azure.")
+	cmd.Flags().BoolVar(&f.UseAlikeInstanceTypes, flagUseAlikeInstanceTypes, false, "Whether to use similar instances types as a fallback. Only available on Azure.")
 
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -86,7 +86,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")
-	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool. Defaults to false.")
+	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool. Defaults to false. Only available on Azure.")
 	cmd.Flags().Float32Var(&f.AzureSpotVMsMaxPrice, flagAzureSpotVMsMaxPrice, 0, "Max hourly price in USD to pay for one spot VM on Azure. If not set, the on-demand price is used as the limit.")
 
 	// Common.

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -86,8 +86,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	// Azure only.
 	cmd.Flags().StringVar(&f.AzureVMSize, flagAzureVMSize, "Standard_D4s_v3", "Azure VM size to use for workers, e.g. 'Standard_D4s_v3'.")
-	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool.")
-	cmd.Flags().Float32Var(&f.AzureSpotMaxPrice, flagAzureSpotMaxPrice, 0, "Max hourly price in USD to pay for one spot VM.")
+	cmd.Flags().BoolVar(&f.AzureUseSpotVms, flagAzureUseSpotVMs, false, "Whether to use Spot VMs for this Node Pool. Defaults to false.")
+	cmd.Flags().Float32Var(&f.AzureSpotMaxPrice, flagAzureSpotMaxPrice, 0, "Max hourly price in USD to pay for one spot VM. If not set than on demand pricing is used as the max value.")
 
 	// Common.
 	cmd.Flags().StringSliceVar(&f.AvailabilityZones, flagAvailabilityZones, []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -77,13 +77,15 @@ func WriteAzureTemplate(out io.Writer, config NodePoolCRsConfig) error {
 func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachinePool {
 	var spot *v1alpha3.SpotVMOptions
 	if config.AzureUseSpotVms {
-		var maxPrice *resource.Quantity
+		var maxPrice resource.Quantity
 		if config.AzureSpotMaxPrice > 0 {
-			maxPriceScalar := resource.MustParse(fmt.Sprintf("%f", config.AzureSpotMaxPrice))
-			maxPrice = &maxPriceScalar
+			maxPrice = resource.MustParse(fmt.Sprintf("%f", config.AzureSpotMaxPrice))
+
+		} else {
+			maxPrice = resource.MustParse("-1")
 		}
 		spot = &v1alpha3.SpotVMOptions{
-			MaxPrice: maxPrice,
+			MaxPrice: &maxPrice,
 		}
 	}
 

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -19,7 +19,9 @@ type NodePoolCRsConfig struct {
 	UseAlikeInstanceTypes               bool
 
 	// Azure only.
-	VMSize string
+	VMSize            string
+	AzureUseSpotVms   bool
+	AzureSpotMaxPrice float32
 
 	// Common.
 	FileName          string

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -54,6 +54,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			ClusterID:                           r.flag.ClusterID,
 			Description:                         r.flag.NodepoolName,
 			VMSize:                              r.flag.AzureVMSize,
+			AzureUseSpotVms:                     r.flag.AzureUseSpotVms,
+			AzureSpotMaxPrice:                   r.flag.AzureSpotMaxPrice,
 			MachineDeploymentSubnet:             r.flag.MachineDeploymentSubnet,
 			NodesMax:                            r.flag.NodesMax,
 			NodesMin:                            r.flag.NodesMin,

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -55,7 +55,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Description:                         r.flag.NodepoolName,
 			VMSize:                              r.flag.AzureVMSize,
 			AzureUseSpotVms:                     r.flag.AzureUseSpotVms,
-			AzureSpotMaxPrice:                   r.flag.AzureSpotMaxPrice,
+			AzureSpotMaxPrice:                   r.flag.AzureSpotVMsMaxPrice,
 			MachineDeploymentSubnet:             r.flag.MachineDeploymentSubnet,
 			NodesMax:                            r.flag.NodesMax,
 			NodesMin:                            r.flag.NodesMin,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/372

This PR allows creating node pools with azure spot VMs