### PR TITLE
aws-capa-add-cp-label

### DIFF
--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -272,6 +272,7 @@ func newAWSMachineTemplateFromUnstructured(config ClusterCRsConfig, o unstructur
 			return nil, microerror.Mask(err)
 		}
 		awsmachinetemplate.Spec.Template.Spec.IAMInstanceProfile = key.GetControlPlaneInstanceProfile(config.ClusterID)
+		// we need to label so capa-iam-controller knows this is  control-plane awsmachinetemplate and it has to create IAM for it
 		awsmachinetemplate.Labels["cluster.x-k8s.io/role"] = "control-plane"
 	}
 	return &awsmachinetemplate, nil

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -272,6 +272,7 @@ func newAWSMachineTemplateFromUnstructured(config ClusterCRsConfig, o unstructur
 			return nil, microerror.Mask(err)
 		}
 		awsmachinetemplate.Spec.Template.Spec.IAMInstanceProfile = key.GetControlPlaneInstanceProfile(config.ClusterID)
+		awsmachinetemplate.Labels["cluster.x-k8s.io/role"] = "control-plane"
 	}
 	return &awsmachinetemplate, nil
 }


### PR DESCRIPTION
unfortunately `awsMachineTemplate`  for CP from clustercrl do not have any label that would differentiate from any other `awsmachinetemplate` and this could be an issue for `capa-iam-controller` which reconciles them and creates IAM roles based on the CRs, 

With this, I can later adjust `capa-iam-controller` to only create AIM roles for CRs with this label