### PR TITLE
get clusters: replace ID with name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- `get clusters`: The output table header `ID` has been renamed to `NAME`.
+
 ## [1.33.0] - 2021-07-19
 
 ### Added

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	name  = "clusters <cluster-id>"
+	name  = "clusters <cluster-name>"
 	alias = "cluster"
 
 	shortDescription = "Display one or many clusters"
@@ -23,7 +23,7 @@ const (
 
 Output columns:
 
-- ID: Unique identifier of the cluster.
+- NAME: Unique identifier of the cluster.
 - CREATED: Date and time of the Cluster CR creation.
 - CONDITION: Latest condition reported for the cluster. Can be "CREATING", "CREATED", "UPDATING", "UPDATED", "DELETING".
 - RELEASE: Workload cluster release used by the cluster.
@@ -33,7 +33,7 @@ Output columns:
 	examples = `  # List all clusters you have access to
   kubectl gs get clusters
   
-  # Get one specific cluster by its ID
+  # Get one specific cluster by its name
   kubectl gs get clusters f83ir`
 )
 

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -14,7 +14,7 @@ func GetAWSTable(clusterResource cluster.Resource) *metav1.Table {
 	table := &metav1.Table{}
 
 	table.ColumnDefinitions = []metav1.TableColumnDefinition{
-		{Name: "ID", Type: "string"},
+		{Name: "Name", Type: "string"},
 		{Name: "Created", Type: "string", Format: "date-time"},
 		{Name: "Condition", Type: "string"},
 		{Name: "Release", Type: "string"},

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -15,7 +15,7 @@ func GetAzureTable(clusterResource cluster.Resource) *metav1.Table {
 	table := &metav1.Table{}
 
 	table.ColumnDefinitions = []metav1.TableColumnDefinition{
-		{Name: "ID", Type: "string"},
+		{Name: "Name", Type: "string"},
 		{Name: "Created", Type: "string", Format: "date-time"},
 		{Name: "Condition", Type: "string"},
 		{Name: "Release", Type: "string"},

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -70,7 +70,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 		{
 			if len(args) > 0 {
-				options.ID = strings.ToLower(args[0])
+				options.Name = strings.ToLower(args[0])
 			}
 
 			if r.flag.AllNamespaces {
@@ -85,7 +85,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 		resource, err = r.service.Get(ctx, options)
 		if cluster.IsNotFound(err) {
-			return microerror.Maskf(notFoundError, fmt.Sprintf("A cluster with ID '%s' cannot be found.\n", options.ID))
+			return microerror.Maskf(notFoundError, fmt.Sprintf("A cluster with name '%s' cannot be found.\n", options.Name))
 		} else if cluster.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
 			r.printNoResourcesOutput()
 

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
@@ -1,4 +1,4 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 1sad2   2021-01-02 15:04:32 +0000 UTC   n/a         12.0.0    test           test cluster 1
 2a03f   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    test           test cluster 2
 asd29   2021-01-02 15:04:32 +0000 UTC   CREATED     10.5.0    test           test cluster 3

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
@@ -1,4 +1,4 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 1sad2   2021-01-02 15:04:32 +0000 UTC   n/a         12.0.0    test           test cluster 1
 2a03f   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    test           test cluster 2
 asd29   2021-01-02 15:04:32 +0000 UTC   CREATED     10.5.0    test           test cluster 3

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
@@ -1,2 +1,2 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 f930q   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
@@ -1,2 +1,2 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 f930q   2021-01-02 15:04:32 +0000 UTC   CREATED     11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
+++ b/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
@@ -1,2 +1,2 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 f930q   2021-01-02 15:04:32 +0000 UTC   n/a         11.0.0    some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_clusters.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters.golden
@@ -1,3 +1,3 @@
-ID      CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
+NAME    CREATED                         CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
 1sad2   2021-01-01 15:04:32 +0000 UTC   n/a         10.5.0    some-org       test cluster 3
 f930q   2021-01-02 15:04:32 +0000 UTC   n/a         11.0.0    some-other     test cluster 4

--- a/pkg/data/domain/cluster/aws.go
+++ b/pkg/data/domain/cluster/aws.go
@@ -68,11 +68,11 @@ func (s *Service) getAllAWS(ctx context.Context, namespace string) (Resource, er
 	return clusterCollection, nil
 }
 
-func (s *Service) getByIdAWS(ctx context.Context, id, namespace string) (Resource, error) {
+func (s *Service) getByNameAWS(ctx context.Context, name, namespace string) (Resource, error) {
 	var err error
 
 	labelSelector := runtimeClient.MatchingLabels{
-		label.Cluster: id,
+		label.Cluster: name,
 	}
 	inNamespace := runtimeClient.InNamespace(namespace)
 

--- a/pkg/data/domain/cluster/azure.go
+++ b/pkg/data/domain/cluster/azure.go
@@ -69,11 +69,11 @@ func (s *Service) getAllAzure(ctx context.Context, namespace string) (Resource, 
 	return clusterCollection, nil
 }
 
-func (s *Service) getByIdAzure(ctx context.Context, id, namespace string) (Resource, error) {
+func (s *Service) getByNameAzure(ctx context.Context, name, namespace string) (Resource, error) {
 	var err error
 
 	labelSelector := runtimeClient.MatchingLabels{
-		capiv1alpha3.ClusterLabelName: id,
+		capiv1alpha3.ClusterLabelName: name,
 	}
 	inNamespace := runtimeClient.InNamespace(namespace)
 

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -12,8 +12,8 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error)
 	var resource Resource
 	var err error
 
-	if len(options.ID) > 0 {
-		resource, err = s.getById(ctx, options.Provider, options.ID, options.Namespace)
+	if len(options.Name) > 0 {
+		resource, err = s.getByName(ctx, options.Provider, options.Name, options.Namespace)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -27,20 +27,20 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error)
 	return resource, nil
 }
 
-func (s *Service) getById(ctx context.Context, provider, id, namespace string) (Resource, error) {
+func (s *Service) getByName(ctx context.Context, provider, name, namespace string) (Resource, error) {
 	var err error
 
 	var cluster Resource
 	{
 		switch provider {
 		case key.ProviderAWS:
-			cluster, err = s.getByIdAWS(ctx, id, namespace)
+			cluster, err = s.getByNameAWS(ctx, name, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
 		case key.ProviderAzure:
-			cluster, err = s.getByIdAzure(ctx, id, namespace)
+			cluster, err = s.getByNameAzure(ctx, name, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/pkg/data/domain/cluster/spec.go
+++ b/pkg/data/domain/cluster/spec.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GetOptions struct {
-	ID        string
+	Name      string
 	Provider  string
 	Namespace string
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18247

This changes the output of the command to replace `ID` with `NAME`.