### PR TITLE
get nodepools: replace ID with name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- `get nodepools`: the `--cluster-id` flag is now deprecated, replaced with `--cluster-name`. Output column headers have been renamed from `ID` to `NAME` and from `CLUSTER ID` to `CLUSTER NAME`.
+
 ## [1.33.0] - 2021-07-19
 
 ### Added

--- a/cmd/get/nodepools/command.go
+++ b/cmd/get/nodepools/command.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	name  = "nodepools [nodepool-id]"
+	name  = "nodepools [nodepool-name]"
 	alias = "nodepool"
 
 	shortDescription = "Display one or many node pools"
@@ -23,8 +23,8 @@ const (
 
 Output columns:
 
-- ID: Unique identifier of the node pool.
-- CLUSTER ID: Unique identifier of the cluster that the node pool belongs to.
+- NAME: Unique identifier of the node pool.
+- CLUSTER NAME: Unique identifier of the cluster that the node pool belongs to.
 - CREATED: Date and time of the node pool CR creation.
 - CONDITION: Latest condition reported for the node pool.
 - NODES MIN/MAX: Node pool autoscaler settings (if supported).
@@ -35,7 +35,7 @@ Output columns:
 	examples = `  # List all node pools you have access to
   kubectl gs get nodepools
 
-  # Get one specific nodepool by its ID
+  # Get one specific nodepool by its name
   kubectl gs get nodepool 3f01a`
 )
 

--- a/cmd/get/nodepools/flag.go
+++ b/cmd/get/nodepools/flag.go
@@ -6,13 +6,15 @@ import (
 )
 
 const (
-	flagAllNamespaces = "all-namespaces"
-	flagClusterID     = "cluster-id"
+	flagAllNamespaces       = "all-namespaces"
+	flagClusterIDDeprecated = "cluster-id"
+	flagClusterName         = "cluster-name"
 )
 
 type flag struct {
-	AllNamespaces bool
-	ClusterID     string
+	AllNamespaces       bool
+	ClusterIDDeprecated string
+	ClusterName         string
 
 	config genericclioptions.RESTClientGetter
 	print  *genericclioptions.PrintFlags
@@ -20,7 +22,11 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&f.AllNamespaces, flagAllNamespaces, "A", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().StringVarP(&f.ClusterID, flagClusterID, "c", "", "If present, list the node pools that belong to the given workload cluster.")
+	cmd.Flags().StringVarP(&f.ClusterIDDeprecated, flagClusterIDDeprecated, "", "", "Set this to a cluster name to only show this cluster's node pools")
+	cmd.Flags().StringVarP(&f.ClusterName, flagClusterName, "c", "", "Only show node pools of the cluster with this name")
+
+	// TODO: remove by ~ December 2021
+	_ = cmd.Flags().MarkDeprecated(flagClusterIDDeprecated, "use --cluster-name instead")
 
 	f.config = genericclioptions.NewConfigFlags(true)
 	f.print = genericclioptions.NewPrintFlags("")
@@ -32,5 +38,11 @@ func (f *flag) Init(cmd *cobra.Command) {
 }
 
 func (f *flag) Validate() error {
+	// Apply --clsuter-id value to --cluster-name
+	// TODO: remove by ~ December 2021
+	if f.ClusterIDDeprecated != "" && f.ClusterName == "" {
+		f.ClusterName = f.ClusterIDDeprecated
+	}
+
 	return nil
 }

--- a/cmd/get/nodepools/printer.go
+++ b/cmd/get/nodepools/printer.go
@@ -15,7 +15,7 @@ import (
 )
 
 type PrintOptions struct {
-	ID string
+	Name string
 }
 
 func (r *runner) printOutput(npResource nodepool.Resource) error {

--- a/cmd/get/nodepools/printer_test.go
+++ b/cmd/get/nodepools/printer_test.go
@@ -251,19 +251,19 @@ func Test_printOutput(t *testing.T) {
 	}
 }
 
-func newAWSMachineDeployment(id, clusterID, created, release, description string, nodesMin, nodesMax int) *infrastructurev1alpha2.AWSMachineDeployment {
+func newAWSMachineDeployment(name, clusterName, created, release, description string, nodesMin, nodesMax int) *infrastructurev1alpha2.AWSMachineDeployment {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	n := &infrastructurev1alpha2.AWSMachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              id,
+			Name:              name,
 			Namespace:         "default",
 			CreationTimestamp: metav1.NewTime(parsedCreationDate),
 			Labels: map[string]string{
-				label.MachineDeployment: id,
+				label.MachineDeployment: name,
 				label.ReleaseVersion:    release,
 				label.Organization:      "giantswarm",
-				label.Cluster:           clusterID,
+				label.Cluster:           clusterName,
 			},
 		},
 		Spec: infrastructurev1alpha2.AWSMachineDeploymentSpec{
@@ -286,7 +286,7 @@ func newAWSMachineDeployment(id, clusterID, created, release, description string
 	return n
 }
 
-func newCAPIv1alpha2MachineDeployment(id, clusterID, created, release string, nodesDesired, nodesReady int) *capiv1alpha2.MachineDeployment {
+func newCAPIv1alpha2MachineDeployment(name, clusterName, created, release string, nodesDesired, nodesReady int) *capiv1alpha2.MachineDeployment {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	n := &capiv1alpha2.MachineDeployment{
@@ -295,14 +295,14 @@ func newCAPIv1alpha2MachineDeployment(id, clusterID, created, release string, no
 			Kind:       "MachineDeployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              id,
+			Name:              name,
 			Namespace:         "default",
 			CreationTimestamp: metav1.NewTime(parsedCreationDate),
 			Labels: map[string]string{
-				label.MachineDeployment: id,
+				label.MachineDeployment: name,
 				label.ReleaseVersion:    release,
 				label.Organization:      "giantswarm",
-				label.Cluster:           clusterID,
+				label.Cluster:           clusterName,
 			},
 		},
 		Status: capiv1alpha2.MachineDeploymentStatus{
@@ -314,9 +314,9 @@ func newCAPIv1alpha2MachineDeployment(id, clusterID, created, release string, no
 	return n
 }
 
-func newAWSNodePool(id, clusterID, created, release, description string, nodesMin, nodesMax, nodesDesired, nodesReady int) *nodepool.Nodepool {
-	awsMD := newAWSMachineDeployment(id, clusterID, created, release, description, nodesMin, nodesMax)
-	md := newCAPIv1alpha2MachineDeployment(id, clusterID, created, release, nodesDesired, nodesReady)
+func newAWSNodePool(name, clusterName, created, release, description string, nodesMin, nodesMax, nodesDesired, nodesReady int) *nodepool.Nodepool {
+	awsMD := newAWSMachineDeployment(name, clusterName, created, release, description, nodesMin, nodesMax)
+	md := newCAPIv1alpha2MachineDeployment(name, clusterName, created, release, nodesDesired, nodesReady)
 
 	np := &nodepool.Nodepool{
 		MachineDeployment:    md,
@@ -326,7 +326,7 @@ func newAWSNodePool(id, clusterID, created, release, description string, nodesMi
 	return np
 }
 
-func newAzureMachinePool(id, clusterID, created, release string) *capzexpv1alpha3.AzureMachinePool {
+func newAzureMachinePool(name, clusterName, created, release string) *capzexpv1alpha3.AzureMachinePool {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	n := &capzexpv1alpha3.AzureMachinePool{
@@ -335,14 +335,14 @@ func newAzureMachinePool(id, clusterID, created, release string) *capzexpv1alpha
 			Kind:       "AzureMachinePool",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              id,
+			Name:              name,
 			Namespace:         "org-giantswarm",
 			CreationTimestamp: metav1.NewTime(parsedCreationDate),
 			Labels: map[string]string{
-				label.MachinePool:             id,
+				label.MachinePool:             name,
 				label.ReleaseVersion:          release,
 				label.Organization:            "giantswarm",
-				capiv1alpha3.ClusterLabelName: clusterID,
+				capiv1alpha3.ClusterLabelName: clusterName,
 			},
 		},
 	}
@@ -350,7 +350,7 @@ func newAzureMachinePool(id, clusterID, created, release string) *capzexpv1alpha
 	return n
 }
 
-func newCAPIexpv1alpha3MachinePool(id, clusterID, created, release, description string, nodesDesired, nodesReady, nodesMin, nodesMax int) *capiexpv1alpha3.MachinePool {
+func newCAPIexpv1alpha3MachinePool(name, clusterName, created, release, description string, nodesDesired, nodesReady, nodesMin, nodesMax int) *capiexpv1alpha3.MachinePool {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	n := &capiexpv1alpha3.MachinePool{
@@ -359,14 +359,14 @@ func newCAPIexpv1alpha3MachinePool(id, clusterID, created, release, description 
 			Kind:       "MachinePool",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              id,
+			Name:              name,
 			Namespace:         "org-giantswarm",
 			CreationTimestamp: metav1.NewTime(parsedCreationDate),
 			Labels: map[string]string{
-				label.MachinePool:             id,
+				label.MachinePool:             name,
 				label.ReleaseVersion:          release,
 				label.Organization:            "giantswarm",
-				capiv1alpha3.ClusterLabelName: clusterID,
+				capiv1alpha3.ClusterLabelName: clusterName,
 			},
 			Annotations: map[string]string{
 				annotation.NodePoolMinSize: fmt.Sprintf("%d", nodesMin),
@@ -383,9 +383,9 @@ func newCAPIexpv1alpha3MachinePool(id, clusterID, created, release, description 
 	return n
 }
 
-func newAzureNodePool(id, clusterID, created, release, description string, nodesMin, nodesMax, nodesDesired, nodesReady int) *nodepool.Nodepool {
-	azureMP := newAzureMachinePool(id, clusterID, created, release)
-	mp := newCAPIexpv1alpha3MachinePool(id, clusterID, created, release, description, nodesMin, nodesMax, nodesDesired, nodesReady)
+func newAzureNodePool(name, clusterName, created, release, description string, nodesMin, nodesMax, nodesDesired, nodesReady int) *nodepool.Nodepool {
+	azureMP := newAzureMachinePool(name, clusterName, created, release)
+	mp := newCAPIexpv1alpha3MachinePool(name, clusterName, created, release, description, nodesMin, nodesMax, nodesDesired, nodesReady)
 
 	np := &nodepool.Nodepool{
 		MachinePool:      mp,

--- a/cmd/get/nodepools/provider/aws.go
+++ b/cmd/get/nodepools/provider/aws.go
@@ -16,8 +16,8 @@ import (
 func GetAWSTable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {
 	table := &metav1.Table{
 		ColumnDefinitions: []metav1.TableColumnDefinition{
-			{Name: "ID", Type: "string"},
-			{Name: "Cluster ID", Type: "string"},
+			{Name: "Name", Type: "string"},
+			{Name: "Cluster Name", Type: "string"},
 			{Name: "Created", Type: "string", Format: "date-time"},
 			{Name: "Condition", Type: "string"},
 			{Name: "Nodes Min/Max", Type: "string"},
@@ -31,18 +31,18 @@ func GetAWSTable(npResource nodepool.Resource, capabilities *feature.Service) *m
 	case *nodepool.Nodepool:
 		table.Rows = append(table.Rows, getAWSNodePoolRow(*n, capabilities))
 	case *nodepool.Collection:
-		// Sort ASC by Cluster ID.
+		// Sort ASC by Cluster name.
 		sort.Slice(n.Items, func(i, j int) bool {
-			var iClusterID, jClusterID string
+			var iClusterName, jClusterName string
 
 			if n.Items[i].MachineDeployment != nil && n.Items[i].MachineDeployment.Labels != nil {
-				iClusterID = key.ClusterID(n.Items[i].MachineDeployment)
+				iClusterName = key.ClusterID(n.Items[i].MachineDeployment)
 			}
 			if n.Items[j].MachineDeployment != nil && n.Items[j].MachineDeployment.Labels != nil {
-				jClusterID = key.ClusterID(n.Items[j].MachineDeployment)
+				jClusterName = key.ClusterID(n.Items[j].MachineDeployment)
 			}
 
-			return strings.Compare(iClusterID, jClusterID) > 0
+			return strings.Compare(iClusterName, jClusterName) > 0
 		})
 		for _, nodePool := range n.Items {
 			table.Rows = append(table.Rows, getAWSNodePoolRow(nodePool, capabilities))

--- a/cmd/get/nodepools/provider/azure.go
+++ b/cmd/get/nodepools/provider/azure.go
@@ -17,8 +17,8 @@ import (
 func GetAzureTable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {
 	table := &metav1.Table{
 		ColumnDefinitions: []metav1.TableColumnDefinition{
-			{Name: "ID", Type: "string"},
-			{Name: "Cluster ID", Type: "string"},
+			{Name: "Name", Type: "string"},
+			{Name: "Cluster Name", Type: "string"},
 			{Name: "Created", Type: "string", Format: "date-time"},
 			{Name: "Condition", Type: "string"},
 			{Name: "Nodes Min/Max", Type: "string"},
@@ -32,18 +32,18 @@ func GetAzureTable(npResource nodepool.Resource, capabilities *feature.Service) 
 	case *nodepool.Nodepool:
 		table.Rows = append(table.Rows, getAzureNodePoolRow(*n, capabilities))
 	case *nodepool.Collection:
-		// Sort ASC by Cluster ID.
+		// Sort ASC by Cluster name.
 		sort.Slice(n.Items, func(i, j int) bool {
-			var iClusterID, jClusterID string
+			var iClusterName, jClusterName string
 
 			if n.Items[i].MachinePool != nil && n.Items[i].MachinePool.Labels != nil {
-				iClusterID = n.Items[i].MachinePool.Labels[capiv1alpha3.ClusterLabelName]
+				iClusterName = n.Items[i].MachinePool.Labels[capiv1alpha3.ClusterLabelName]
 			}
 			if n.Items[j].MachinePool != nil && n.Items[j].MachinePool.Labels != nil {
-				jClusterID = n.Items[j].MachinePool.Labels[capiv1alpha3.ClusterLabelName]
+				jClusterName = n.Items[j].MachinePool.Labels[capiv1alpha3.ClusterLabelName]
 			}
 
-			return strings.Compare(iClusterID, jClusterID) > 0
+			return strings.Compare(iClusterName, jClusterName) > 0
 		})
 
 		for _, nodePool := range n.Items {

--- a/cmd/get/nodepools/runner.go
+++ b/cmd/get/nodepools/runner.go
@@ -66,12 +66,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var resource nodepool.Resource
 	{
 		options := nodepool.GetOptions{
-			Provider:  r.provider,
-			ClusterID: r.flag.ClusterID,
+			Provider:    r.provider,
+			ClusterName: r.flag.ClusterName,
 		}
 		{
 			if len(args) > 0 {
-				options.ID = strings.ToLower(args[0])
+				options.Name = strings.ToLower(args[0])
 			}
 
 			if r.flag.AllNamespaces {
@@ -86,7 +86,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 		resource, err = r.service.Get(ctx, options)
 		if nodepool.IsNotFound(err) {
-			return microerror.Maskf(notFoundError, fmt.Sprintf("A node pool with ID '%s' cannot be found.\n", options.ID))
+			return microerror.Maskf(notFoundError, fmt.Sprintf("A node pool with name '%s' cannot be found.\n", options.Name))
 		} else if nodepool.IsNoResources(err) && output.IsOutputDefault(r.flag.print.OutputFormat) {
 			r.printNoResourcesOutput()
 

--- a/cmd/get/nodepools/runner_test.go
+++ b/cmd/get/nodepools/runner_test.go
@@ -26,7 +26,7 @@ func Test_run(t *testing.T) {
 		name               string
 		storage            []runtime.Object
 		args               []string
-		clusterID          string
+		clusterName        string
 		expectedGoldenFile string
 		errorMatcher       func(error) bool
 	}{
@@ -48,7 +48,7 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_get_nodepools_empty_storage.golden",
 		},
 		{
-			name: "case 2: get nodepool by id",
+			name: "case 2: get nodepool by name",
 			storage: []runtime.Object{
 				newCAPIv1alpha2MachineDeployment("1sad2", "s921a", "2021-01-02T15:04:32Z", "10.5.0", 2, 1),
 				newAWSMachineDeployment("1sad2", "s921a", "2021-01-01T15:04:32Z", "10.5.0", "test nodepool 3", 1, 3),
@@ -59,13 +59,13 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_get_nodepool_by_id.golden",
 		},
 		{
-			name:         "case 3: get nodepool by id, with empty storage",
+			name:         "case 3: get nodepool by name, with empty storage",
 			storage:      nil,
 			args:         []string{"f930q"},
 			errorMatcher: IsNotFound,
 		},
 		{
-			name: "case 4: get nodepool by id, with no infrastructure ref",
+			name: "case 4: get nodepool by name, with no infrastructure ref",
 			storage: []runtime.Object{
 				newCAPIv1alpha2MachineDeployment("1sad2", "s921a", "2021-01-02T15:04:32Z", "10.5.0", 2, 1),
 				newAWSMachineDeployment("1sad2", "s921a", "2021-01-01T15:04:32Z", "10.5.0", "test nodepool 3", 1, 3),
@@ -75,7 +75,7 @@ func Test_run(t *testing.T) {
 			errorMatcher: IsNotFound,
 		},
 		{
-			name: "case 5: get nodepools by cluster id",
+			name: "case 5: get nodepools by cluster name",
 			storage: []runtime.Object{
 				newCAPIv1alpha2MachineDeployment("1sad2", "s921a", "2021-01-02T15:04:32Z", "10.5.0", 2, 1),
 				newAWSMachineDeployment("1sad2", "s921a", "2021-01-01T15:04:32Z", "10.5.0", "test nodepool 3", 1, 3),
@@ -85,11 +85,11 @@ func Test_run(t *testing.T) {
 				newAWSMachineDeployment("9f012", "29sa0", "2021-01-02T15:04:32Z", "9.0.0", "test nodepool 5", 1, 1),
 			},
 			args:               nil,
-			clusterID:          "s921a",
+			clusterName:        "s921a",
 			expectedGoldenFile: "run_get_nodepool_by_cluster_id.golden",
 		},
 		{
-			name: "case 6: get nodepools by id and cluster id",
+			name: "case 6: get nodepools by name and cluster name",
 			storage: []runtime.Object{
 				newCAPIv1alpha2MachineDeployment("1sad2", "s921a", "2021-01-02T15:04:32Z", "10.5.0", 2, 1),
 				newAWSMachineDeployment("1sad2", "s921a", "2021-01-01T15:04:32Z", "10.5.0", "test nodepool 3", 1, 3),
@@ -99,21 +99,21 @@ func Test_run(t *testing.T) {
 				newAWSMachineDeployment("9f012", "29sa0", "2021-01-02T15:04:32Z", "9.0.0", "test nodepool 5", 1, 1),
 			},
 			args:               []string{"f930q"},
-			clusterID:          "s921a",
+			clusterName:        "s921a",
 			expectedGoldenFile: "run_get_nodepool_by_id_and_cluster_id.golden",
 		},
 		{
-			name:               "case 7: get nodepools by cluster id, with empty storage",
+			name:               "case 7: get nodepools by cluster name, with empty storage",
 			storage:            nil,
 			args:               nil,
-			clusterID:          "s921a",
+			clusterName:        "s921a",
 			expectedGoldenFile: "run_get_nodepool_by_cluster_id_empty_storage.golden",
 		},
 		{
-			name:         "case 8: get nodepools by id and cluster id, with empty storage",
+			name:         "case 8: get nodepools by name and cluster name, with empty storage",
 			storage:      nil,
 			args:         []string{"f930q"},
-			clusterID:    "s921a",
+			clusterName:  "s921a",
 			errorMatcher: IsNotFound,
 		},
 	}
@@ -124,9 +124,9 @@ func Test_run(t *testing.T) {
 
 			fakeKubeConfig := kubeconfig.CreateFakeKubeConfig()
 			flag := &flag{
-				print:     genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault),
-				config:    genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig),
-				ClusterID: tc.clusterID,
+				print:       genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault),
+				config:      genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig),
+				ClusterName: tc.clusterName,
 			}
 			out := new(bytes.Buffer)
 			runner := &runner{

--- a/cmd/get/nodepools/testdata/print_list_of_aws_nodepools_table_output.golden
+++ b/cmd/get/nodepools/testdata/print_list_of_aws_nodepools_table_output.golden
@@ -1,7 +1,7 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-1sad2   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               2             test nodepool 1
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         3/3             3               1             test nodepool 4
-asd29   s0a10        2021-01-02 15:04:32 +0000 UTC   n/a         10/10           10              10            test nodepool 3
-2f0as   s00sn        2021-01-02 15:04:32 +0000 UTC   n/a         2/5             5               5             test nodepool 6
-2a03f   3a0d1        2021-01-02 15:04:32 +0000 UTC   n/a         3/10            5               2             test nodepool 2
-9f012   29sa0        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             1               1             test nodepool 5
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+1sad2   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               2             test nodepool 1
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         3/3             3               1             test nodepool 4
+asd29   s0a10          2021-01-02 15:04:32 +0000 UTC   n/a         10/10           10              10            test nodepool 3
+2f0as   s00sn          2021-01-02 15:04:32 +0000 UTC   n/a         2/5             5               5             test nodepool 6
+2a03f   3a0d1          2021-01-02 15:04:32 +0000 UTC   n/a         3/10            5               2             test nodepool 2
+9f012   29sa0          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             1               1             test nodepool 5

--- a/cmd/get/nodepools/testdata/print_list_of_azure_nodepools_table_output.golden
+++ b/cmd/get/nodepools/testdata/print_list_of_azure_nodepools_table_output.golden
@@ -1,7 +1,7 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-1sad2   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             1               3             test nodepool 1
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               3             test nodepool 4
-asd29   s0a10        2021-01-02 15:04:32 +0000 UTC   n/a         10/10           10              10            test nodepool 3
-2f0as   s00sn        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             2               5             test nodepool 6
-2a03f   3a0d1        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               10            test nodepool 2
-9f012   29sa0        2021-01-02 15:04:32 +0000 UTC   n/a         1/1             0               3             test nodepool 5
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+1sad2   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             1               3             test nodepool 1
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               3             test nodepool 4
+asd29   s0a10          2021-01-02 15:04:32 +0000 UTC   n/a         10/10           10              10            test nodepool 3
+2f0as   s00sn          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             2               5             test nodepool 6
+2a03f   3a0d1          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               10            test nodepool 2
+9f012   29sa0          2021-01-02 15:04:32 +0000 UTC   n/a         1/1             0               3             test nodepool 5

--- a/cmd/get/nodepools/testdata/print_single_aws_nodepool_table_output.golden
+++ b/cmd/get/nodepools/testdata/print_single_aws_nodepool_table_output.golden
@@ -1,2 +1,2 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         3/3             3               1             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         3/3             3               1             test nodepool 4

--- a/cmd/get/nodepools/testdata/print_single_azure_nodepool_table_output.golden
+++ b/cmd/get/nodepools/testdata/print_single_azure_nodepool_table_output.golden
@@ -1,2 +1,2 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               3             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         n/a             3               3             test nodepool 4

--- a/cmd/get/nodepools/testdata/run_get_nodepool_by_cluster_id.golden
+++ b/cmd/get/nodepools/testdata/run_get_nodepool_by_cluster_id.golden
@@ -1,3 +1,3 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-1sad2   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               1             test nodepool 3
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+1sad2   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               1             test nodepool 3
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4

--- a/cmd/get/nodepools/testdata/run_get_nodepool_by_id.golden
+++ b/cmd/get/nodepools/testdata/run_get_nodepool_by_id.golden
@@ -1,2 +1,2 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4

--- a/cmd/get/nodepools/testdata/run_get_nodepool_by_id_and_cluster_id.golden
+++ b/cmd/get/nodepools/testdata/run_get_nodepool_by_id_and_cluster_id.golden
@@ -1,2 +1,2 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4

--- a/cmd/get/nodepools/testdata/run_get_nodepools.golden
+++ b/cmd/get/nodepools/testdata/run_get_nodepools.golden
@@ -1,3 +1,3 @@
-ID      CLUSTER ID   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
-1sad2   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               1             test nodepool 3
-f930q   s921a        2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4
+NAME    CLUSTER NAME   CREATED                         CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
+1sad2   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         1/3             2               1             test nodepool 3
+f930q   s921a          2021-01-02 15:04:32 +0000 UTC   n/a         5/8             6               6             test nodepool 4

--- a/pkg/data/domain/nodepool/common.go
+++ b/pkg/data/domain/nodepool/common.go
@@ -12,13 +12,13 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error)
 	var resource Resource
 	var err error
 
-	if len(options.ID) > 0 {
-		resource, err = s.getById(ctx, options.Provider, options.ID, options.Namespace, options.ClusterID)
+	if len(options.Name) > 0 {
+		resource, err = s.getByName(ctx, options.Provider, options.Name, options.Namespace, options.ClusterName)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	} else {
-		resource, err = s.getAll(ctx, options.Provider, options.Namespace, options.ClusterID)
+		resource, err = s.getAll(ctx, options.Provider, options.Namespace, options.ClusterName)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -27,19 +27,19 @@ func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error)
 	return resource, nil
 }
 
-func (s *Service) getById(ctx context.Context, provider, id, namespace, clusterID string) (Resource, error) {
+func (s *Service) getByName(ctx context.Context, provider, name, namespace, clusterName string) (Resource, error) {
 	var err error
 
 	var np Resource
 	{
 		switch provider {
 		case key.ProviderAWS:
-			np, err = s.getByIdAWS(ctx, id, namespace, clusterID)
+			np, err = s.getByIdAWS(ctx, name, namespace, clusterName)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
 		case key.ProviderAzure:
-			np, err = s.getByIdAzure(ctx, id, namespace, clusterID)
+			np, err = s.getByIdAzure(ctx, name, namespace, clusterName)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/pkg/data/domain/nodepool/spec.go
+++ b/pkg/data/domain/nodepool/spec.go
@@ -12,10 +12,10 @@ import (
 )
 
 type GetOptions struct {
-	ID        string
-	ClusterID string
-	Provider  string
-	Namespace string
+	Name        string
+	ClusterName string
+	Provider    string
+	Namespace   string
 }
 
 type Interface interface {


### PR DESCRIPTION
Towards giantswarm/giantswarm#18247

This changes the `kubectl gs get nodepools` command to deprecate the `--cluster-id` flag, to be replaced with `--cluster-name` and adapt the output column headers.

### Before

```nohighlights
Output columns:

- ID: Unique identifier of the node pool.
- CLUSTER ID: Unique identifier of the cluster that the node pool belongs to.
...

Usage:
  kubectl gs get nodepools [nodepool-id] [flags]

...

Flags:
...
  -c, --cluster-id string              If present, list the node pools that belong to the given workload cluster.
...
```

### After

```nohighlights
Output columns:

- NAME: Unique identifier of the node pool.
- CLUSTER NAME: Unique identifier of the cluster that the node pool belongs to.
...

Usage:
  kubectl gs get nodepools [nodepool-name] [flags]

...

Flags:
  -c, --cluster-name string            Only show node pools of the cluster with this name
...
```