### PR TITLE
Add namespaceConfig to template app command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--namespace-annotations` and `--namespace-labels` flags to `template app` command to allow users to
+  specify the `namespaceConfig` of the generated `App` CR.
+
 ## [1.33.0] - 2021-07-19
 
 ### Added

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -3,30 +3,37 @@ package app
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/pkg/annotations"
+	"github.com/giantswarm/kubectl-gs/pkg/labels"
 )
 
 const (
-	flagAppName           = "app-name"
-	flagCatalog           = "catalog"
-	flagCluster           = "cluster"
-	flagDefaultingEnabled = "defaulting-enabled"
-	flagName              = "name"
-	flagNamespace         = "namespace"
-	flagUserConfigMap     = "user-configmap"
-	flagUserSecret        = "user-secret"
-	flagVersion           = "version"
+	flagAppName                    = "app-name"
+	flagCatalog                    = "catalog"
+	flagCluster                    = "cluster"
+	flagDefaultingEnabled          = "defaulting-enabled"
+	flagName                       = "name"
+	flagNamespace                  = "namespace"
+	flagNamespaceConfigAnnotations = "namespace-annotations"
+	flagNamespaceConfigLabels      = "namespace-labels"
+	flagUserConfigMap              = "user-configmap"
+	flagUserSecret                 = "user-secret"
+	flagVersion                    = "version"
 )
 
 type flag struct {
-	AppName           string
-	Catalog           string
-	Cluster           string
-	DefaultingEnabled bool
-	Name              string
-	Namespace         string
-	flagUserConfigMap string
-	flagUserSecret    string
-	Version           string
+	AppName                        string
+	Catalog                        string
+	Cluster                        string
+	DefaultingEnabled              bool
+	Name                           string
+	Namespace                      string
+	Version                        string
+	flagNamespaceConfigAnnotations []string
+	flagNamespaceConfigLabels      []string
+	flagUserConfigMap              string
+	flagUserSecret                 string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -39,6 +46,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
 	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user secrets YAML file.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")
+	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigAnnotations, flagNamespaceConfigAnnotations, nil, "Namespace configuration annotations in form key=value.")
+	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigLabels, flagNamespaceConfigLabels, nil, "Namespace configuration labels in form key=value.")
 }
 
 func (f *flag) Validate() error {
@@ -56,6 +65,16 @@ func (f *flag) Validate() error {
 	}
 	if f.Version == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagVersion)
+	}
+
+	_, err := labels.Parse(f.flagNamespaceConfigLabels)
+	if err != nil {
+		return microerror.Maskf(invalidFlagError, "--%s must contain valid label definitions (%s)", flagNamespaceConfigLabels, err)
+	}
+
+	_, err = annotations.Parse(f.flagNamespaceConfigAnnotations)
+	if err != nil {
+		return microerror.Maskf(invalidFlagError, "--%s must contain valid annotation definitions (%s)", flagNamespaceConfigAnnotations, err)
 	}
 
 	return nil

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -13,6 +13,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/annotations"
+	"github.com/giantswarm/kubectl-gs/pkg/labels"
 	templateapp "github.com/giantswarm/kubectl-gs/pkg/template/app"
 )
 
@@ -100,6 +102,18 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 	}
+
+	namespaceAnnotations, err := annotations.Parse(r.flag.flagNamespaceConfigAnnotations)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	appConfig.NamespaceConfigAnnotations = namespaceAnnotations
+
+	namespaceLabels, err := labels.Parse(r.flag.flagNamespaceConfigLabels)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	appConfig.NamespaceConfigLabels = namespaceLabels
 
 	appCRYaml, err := templateapp.NewAppCR(appConfig)
 	if err != nil {

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
-	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
+	"github.com/giantswarm/kubectl-gs/pkg/labels"
 )
 
 const (
@@ -151,7 +151,7 @@ func (f *flag) Validate() error {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
 	}
 
-	_, err = clusterlabels.Parse(f.Label)
+	_, err = labels.Parse(f.Label)
 	if err != nil {
 		return microerror.Maskf(invalidFlagError, "--%s must contain valid label definitions (%s)", flagLabel, err)
 	}

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/pkg/clusterlabels"
+	"github.com/giantswarm/kubectl-gs/pkg/labels"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
@@ -81,7 +81,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		// Remove leading 'v' from release flag input.
 		config.ReleaseVersion = strings.TrimLeft(config.ReleaseVersion, "v")
 
-		config.Labels, err = clusterlabels.Parse(r.flag.Label)
+		config.Labels, err = labels.Parse(r.flag.Label)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,0 +1,38 @@
+package annotations
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Source https://github.com/kubernetes/apimachinery/blob/v0.21.3/pkg/api/validation/objectmeta.go#L36
+// Licensed under Apache-2.0
+const totalAnnotationSizeLimitB int = 256 * (1 << 10) // 256 kB
+
+// Logic partially lifted from https://github.com/kubernetes/apimachinery/blob/v0.21.3/pkg/api/validation/objectmeta.go#L47-L60
+// Licensed under Apache-2.0
+func Parse(rawAnnotations []string) (map[string]string, error) {
+	annotations := map[string]string{}
+	var totalSize int64
+
+	for _, annotationSpec := range rawAnnotations {
+		parts := strings.Split(annotationSpec, "=")
+		if len(parts) != 2 {
+			return nil, microerror.Maskf(invalidAnnotationSpecError, annotationSpec)
+		}
+		if errs := validation.IsQualifiedName(strings.ToLower(parts[0])); len(errs) != 0 {
+			return nil, microerror.Maskf(invalidAnnotationKeyError, "%q: %s", annotationSpec, strings.Join(errs, ";"))
+		}
+		annotations[parts[0]] = parts[1]
+		totalSize += (int64)(len(parts[0])) + (int64)(len(parts[1]))
+	}
+
+	if totalSize > (int64)(totalAnnotationSizeLimitB) {
+		return nil, microerror.Maskf(annotationsTooBigError, "Annotations exceed size limit of %d bytes", totalAnnotationSizeLimitB)
+	}
+
+	return annotations, nil
+}

--- a/pkg/annotations/error.go
+++ b/pkg/annotations/error.go
@@ -1,0 +1,27 @@
+package annotations
+
+import "github.com/giantswarm/microerror"
+
+var invalidAnnotationSpecError = &microerror.Error{
+	Kind: "invalidAnnotationSpecError",
+}
+
+func IsInvalidAnnotationSpec(err error) bool {
+	return microerror.Cause(err) == invalidAnnotationSpecError
+}
+
+var invalidAnnotationKeyError = &microerror.Error{
+	Kind: "invalidAnnotationKeyError",
+}
+
+func IsInvalidAnnotationKey(err error) bool {
+	return microerror.Cause(err) == invalidAnnotationKeyError
+}
+
+var annotationsTooBigError = &microerror.Error{
+	Kind: "invalidAnnotationValueError",
+}
+
+func IsAnnotationsTooBigError(err error) bool {
+	return microerror.Cause(err) == annotationsTooBigError
+}

--- a/pkg/labels/error.go
+++ b/pkg/labels/error.go
@@ -1,4 +1,4 @@
-package clusterlabels
+package labels
 
 import "github.com/giantswarm/microerror"
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,4 +1,4 @@
-package clusterlabels
+package labels
 
 import (
 	"strings"

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -10,15 +10,17 @@ import (
 )
 
 type Config struct {
-	AppName                 string
-	Catalog                 string
-	Cluster                 string
-	DefaultingEnabled       bool
-	Name                    string
-	Namespace               string
-	UserConfigConfigMapName string
-	UserConfigSecretName    string
-	Version                 string
+	AppName                    string
+	Catalog                    string
+	Cluster                    string
+	DefaultingEnabled          bool
+	Name                       string
+	Namespace                  string
+	NamespaceConfigAnnotations map[string]string
+	NamespaceConfigLabels      map[string]string
+	UserConfigConfigMapName    string
+	UserConfigSecretName       string
+	Version                    string
 }
 
 type SecretConfig struct {
@@ -72,6 +74,10 @@ func NewAppCR(config Config) ([]byte, error) {
 			},
 			UserConfig: userConfig,
 			Version:    config.Version,
+			NamespaceConfig: applicationv1alpha1.AppSpecNamespaceConfig{
+				Annotations: config.NamespaceConfigAnnotations,
+				Labels:      config.NamespaceConfigLabels,
+			},
 		},
 	}
 
@@ -165,7 +171,9 @@ func printAppCR(appCR *v1alpha1.App, defaultingEnabled bool) ([]byte, error) {
 	}
 
 	delete(spec, "install")
-	delete(spec, "namespaceConfig")
+	if len(appCR.Spec.NamespaceConfig.Annotations) == 0 && len(appCR.Spec.NamespaceConfig.Labels) == 0 {
+		delete(spec, "namespaceConfig")
+	}
 
 	if defaultingEnabled {
 		delete(spec, "config")


### PR DESCRIPTION
This PR adds two new flags to the `template app` command to enable users to specify annotations and labels for the `namespaceConfig` in an `App` CR.

The flags are named `--namespace-labels` and `--namespace-annotations`

Once approved, Related docs PR https://github.com/giantswarm/docs/pull/1058

Example call

```
$ kubectl gs template app \
  --app-name app-name \
  --catalog catalog \
  --cluster cluster \
  --name name \
  --namespace namespace \
  --version version \
  --namespace-labels wurst=kaese \
  --namespace-annotations swag=cool \
  --namespace-labels mega=nice,very=cool
---
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: name
  namespace: cluster
spec:
  catalog: catalog
  kubeConfig:
    inCluster: false
  name: name
  namespace: namespace
  namespaceConfig:
    annotations:
      swag: cool
    labels:
      mega: nice
      very: cool
      wurst: kaese
  version: version

```