### PR TITLE
template cluster: in flags, replace ID with NAME and replace NAME with DESCRIPTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- `template cluster` (breaking): deprecated the `--cluster-id` flag. The `--name` flag changed purpose to set the cluster's unique identifier. The `--description` flag has been added to set the user-friendly description.
+
 ## [1.33.0] - 2021-07-19
 
 ### Added

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -132,15 +132,13 @@ func (f *flag) Validate() error {
 
 		return nil
 	}
-	// Validate name for non-aws clusters.
-	if f.Provider != key.ProviderAWS && f.Name == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagName)
-	}
+
 	if f.PodsCIDR != "" {
 		if !validateCIDR(f.PodsCIDR) {
 			return microerror.Maskf(invalidFlagError, "--%s must be a valid CIDR", flagPodsCIDR)
 		}
 	}
+
 	if f.Owner == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagOwner)
 	}

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -63,8 +63,8 @@ func WriteCAPATemplate(out io.Writer, config ClusterCRsConfig) error {
 
 	crLabels := map[string]string{
 		label.ReleaseVersion:            config.ReleaseVersion,
-		label.Cluster:                   config.ClusterID,
-		capiv1alpha3.ClusterLabelName:   config.ClusterID,
+		label.Cluster:                   config.Name,
+		capiv1alpha3.ClusterLabelName:   config.Name,
 		label.Organization:              config.Owner,
 		"cluster.x-k8s.io/watch-filter": "capi"}
 
@@ -137,7 +137,7 @@ func WriteGSAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
 	crsConfig := v1alpha2.ClusterCRsConfig{
-		ClusterID: config.ClusterID,
+		ClusterID: config.Name,
 
 		ExternalSNAT:   config.ExternalSNAT,
 		MasterAZ:       config.ControlPlaneAZ,
@@ -207,7 +207,7 @@ func getCAPAClusterTemplate(config ClusterCRsConfig) (client.Template, error) {
 	}
 
 	templateOptions := client.GetClusterTemplateOptions{
-		ClusterName:       config.ClusterID,
+		ClusterName:       config.Name,
 		TargetNamespace:   key.OrganizationNamespaceFromName(config.Owner),
 		KubernetesVersion: "v1.19.9",
 		ProviderRepositorySource: &client.ProviderRepositorySourceOptions{
@@ -248,7 +248,7 @@ func newAWSClusterFromUnstructured(config ClusterCRsConfig, o unstructured.Unstr
 			return nil, microerror.Mask(err)
 		}
 		awscluster.Spec.IdentityRef = &capav1alpha3.AWSIdentityReference{
-			Name: config.ClusterID,
+			Name: config.Name,
 			Kind: capav1alpha3.ClusterRoleIdentityKind}
 
 		for _, az := range config.ControlPlaneAZ {
@@ -271,7 +271,7 @@ func newAWSMachineTemplateFromUnstructured(config ClusterCRsConfig, o unstructur
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		awsmachinetemplate.Spec.Template.Spec.IAMInstanceProfile = key.GetControlPlaneInstanceProfile(config.ClusterID)
+		awsmachinetemplate.Spec.Template.Spec.IAMInstanceProfile = key.GetControlPlaneInstanceProfile(config.Name)
 		// we need to label so capa-iam-controller knows this is  control-plane awsmachinetemplate and it has to create IAM for it
 		awsmachinetemplate.Labels["cluster.x-k8s.io/role"] = "control-plane"
 	}
@@ -285,7 +285,7 @@ func newAWSClusterRoleIdentity(config ClusterCRsConfig) *capav1alpha3.AWSCluster
 			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.ClusterID,
+			Name:      config.Name,
 			Namespace: key.OrganizationNamespaceFromName(config.Owner),
 		},
 		Spec: capav1alpha3.AWSClusterRoleIdentitySpec{

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -74,25 +74,25 @@ func newAzureClusterCR(config ClusterCRsConfig) *capzv1alpha3.AzureCluster {
 			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.ClusterID,
+			Name:      config.Name,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                 config.ClusterID,
-				capiv1alpha3.ClusterLabelName: config.ClusterID,
+				label.Cluster:                 config.Name,
+				capiv1alpha3.ClusterLabelName: config.Name,
 				label.Organization:            config.Owner,
 				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 		},
 		Spec: capzv1alpha3.AzureClusterSpec{
-			ResourceGroup: config.ClusterID,
+			ResourceGroup: config.Name,
 			NetworkSpec: capzv1alpha3.NetworkSpec{
 				APIServerLB: capzv1alpha3.LoadBalancerSpec{
-					Name: fmt.Sprintf("%s-%s-%s", config.ClusterID, "API", "PublicLoadBalancer"),
+					Name: fmt.Sprintf("%s-%s-%s", config.Name, "API", "PublicLoadBalancer"),
 					SKU:  "Standard",
 					Type: "Public",
 					FrontendIPs: []capzv1alpha3.FrontendIP{
 						{
-							Name: fmt.Sprintf("%s-%s-%s-%s", config.ClusterID, "API", "PublicLoadBalancer", "Frontend"),
+							Name: fmt.Sprintf("%s-%s-%s-%s", config.Name, "API", "PublicLoadBalancer", "Frontend"),
 						},
 					},
 				},
@@ -115,11 +115,11 @@ func newAzureMasterMachineCR(config ClusterCRsConfig) *capzv1alpha3.AzureMachine
 			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-master-%d", config.ClusterID, 0),
+			Name:      fmt.Sprintf("%s-master-%d", config.Name, 0),
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                             config.ClusterID,
-				capiv1alpha3.ClusterLabelName:             config.ClusterID,
+				label.Cluster:                             config.Name,
+				capiv1alpha3.ClusterLabelName:             config.Name,
 				capiv1alpha3.MachineControlPlaneLabelName: "true",
 				label.Organization:                        config.Owner,
 				label.ReleaseVersion:                      config.ReleaseVersion,

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -16,9 +16,9 @@ type ClusterCRsConfig struct {
 
 	// Common.
 	FileName       string
-	ClusterID      string
 	ControlPlaneAZ []string
 	Description    string
+	Name           string
 	Owner          string
 	ReleaseVersion string
 	Labels         map[string]string
@@ -32,11 +32,11 @@ func newCAPIV1Alpha3ClusterCR(config ClusterCRsConfig, infrastructureRef *corev1
 			APIVersion: "cluster.x-k8s.io/v1alpha3",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.ClusterID,
+			Name:      config.Name,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                 config.ClusterID,
-				capiv1alpha3.ClusterLabelName: config.ClusterID,
+				label.Cluster:                 config.Name,
+				capiv1alpha3.ClusterLabelName: config.Name,
 				label.Organization:            config.Owner,
 				label.ReleaseVersion:          config.ReleaseVersion,
 			},

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -59,11 +59,11 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	{
 		config = provider.ClusterCRsConfig{
 			FileName:           clusterCRFileName,
-			ClusterID:          r.flag.ClusterID,
 			ControlPlaneAZ:     r.flag.ControlPlaneAZ,
 			ControlPlaneSubnet: r.flag.ControlPlaneSubnet,
 			ExternalSNAT:       r.flag.ExternalSNAT,
-			Description:        r.flag.Name,
+			Description:        r.flag.Description,
+			Name:               r.flag.Name,
 			Owner:              r.flag.Owner,
 			PodsCIDR:           r.flag.PodsCIDR,
 			ReleaseVersion:     r.flag.Release,
@@ -74,8 +74,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			config.ControlPlaneAZ = r.flag.MasterAZ
 		}
 
-		if config.ClusterID == "" {
-			config.ClusterID = id.Generate()
+		if config.Name == "" {
+			config.Name = id.Generate()
 		}
 
 		// Remove leading 'v' from release flag input.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18247

This changes flags for `kubectl gs template cluster` to account for the change

- What was the cluster name is now called the cluster's description
- What was the cluster ID is not called the cluster name

The `--cluster-id` flag is deprecated, however it's value will be transferred to the name.

**Breaking**: The flag `--name` used to set the user-friendly description. It is now setting the unique name. For setting the user-friendly description, the flag `--description` has been added.

The `--name` flag is no longer required. Also the `--description` flag is not required.

### Before

```nohighlight
Flags:
      --cluster-id string             User-defined cluster ID.
...
      --name string                   Workload cluster name.
...
```

### After

```nohighlight
Flags:
...
      --description string            User-friendly description of the cluster's purpose (formerly called name).
...
      --name string                   Unique identifier of the cluster (formerly called ID).
...
```

Note that the deprecated `--cluster-id` flag is not listed when using `--help`.
