### PR TITLE
template nodepool: adapt flags for name and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- `template nodepool`:
+  - Deprecated the `--cluster-id` flag, added the `--cluster-name` flag as a replacement.
+  - Deprecated the `-nodepool-name` flag, add the `--description` flag as a replacement.
+
 ## [1.33.0] - 2021-07-19
 
 ### Added

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -96,7 +96,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// Common.
 	cmd.Flags().StringSliceVar(&f.AvailabilityZones, flagAvailabilityZones, []string{}, "List of availability zones to use, instead of setting a number. Use comma to separate values.")
 	cmd.Flags().StringVar(&f.ClusterIDDeprecated, flagClusterIDDeprecated, "", "Cluster ID (deprecated).")
-	cmd.Flags().StringVar(&f.ClusterName, flagClusterName, "", "Name of the Cluster to add the node pool to.")
+	cmd.Flags().StringVar(&f.ClusterName, flagClusterName, "", "Name of the cluster to add the node pool to.")
 	cmd.Flags().StringVar(&f.NodepoolNameDeprecated, flagNodepoolNameDeprecated, "", "Node pool description (deprecated).")
 	cmd.Flags().StringVar(&f.Description, flagDescription, "", "User-friendly description of the node pool's purpose.")
 	cmd.Flags().IntVar(&f.NodesMax, flagNodesMax, maxNodes, fmt.Sprintf("Maximum number of worker nodes for the node pool. (default %d)", maxNodes))

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -62,9 +62,9 @@ func WriteCAPATemplate(out io.Writer, config NodePoolCRsConfig) error {
 		o.SetName(config.NodePoolID)
 		o.SetLabels(map[string]string{
 			label.ReleaseVersion:            config.ReleaseVersion,
-			label.Cluster:                   config.ClusterID,
+			label.Cluster:                   config.ClusterName,
 			label.MachinePool:               config.NodePoolID,
-			capiv1alpha3.ClusterLabelName:   config.ClusterID,
+			capiv1alpha3.ClusterLabelName:   config.ClusterName,
 			label.Organization:              config.Owner,
 			"cluster.x-k8s.io/watch-filter": "capi",
 		})
@@ -113,7 +113,7 @@ func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 	crsConfig := v1alpha2.NodePoolCRsConfig{
 		AvailabilityZones:                   config.AvailabilityZones,
 		AWSInstanceType:                     config.AWSInstanceType,
-		ClusterID:                           config.ClusterID,
+		ClusterID:                           config.ClusterName,
 		Description:                         config.Description,
 		MachineDeploymentID:                 config.NodePoolID,
 		NodesMax:                            config.NodesMax,
@@ -169,7 +169,7 @@ func getCAPANodepoolTemplate(config NodePoolCRsConfig) (client.Template, error) 
 	}
 
 	templateOptions := client.GetClusterTemplateOptions{
-		ClusterName:       config.ClusterID,
+		ClusterName:       config.ClusterName,
 		TargetNamespace:   key.OrganizationNamespaceFromName(config.Owner),
 		KubernetesVersion: "v1.19.9",
 		ProviderRepositorySource: &client.ProviderRepositorySourceOptions{
@@ -213,7 +213,7 @@ func newAWSMachinePoolFromUnstructured(config NodePoolCRsConfig, o unstructured.
 
 		awsmachinepool.Spec.AvailabilityZones = config.AvailabilityZones
 		awsmachinepool.Spec.AWSLaunchTemplate.InstanceType = config.AWSInstanceType
-		awsmachinepool.Spec.AWSLaunchTemplate.IamInstanceProfile = key.GetNodeInstanceProfile(config.NodePoolID, config.ClusterID)
+		awsmachinepool.Spec.AWSLaunchTemplate.IamInstanceProfile = key.GetNodeInstanceProfile(config.NodePoolID, config.ClusterName)
 		awsmachinepool.Spec.MinSize = int32(config.NodesMin)
 		awsmachinepool.Spec.MaxSize = int32(config.NodesMax)
 		onDemandBaseCapacity := int64(config.OnDemandBaseCapacity)

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -98,8 +98,8 @@ func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachi
 			Name:      config.NodePoolID,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                 config.ClusterID,
-				capiv1alpha3.ClusterLabelName: config.ClusterID,
+				label.Cluster:                 config.ClusterName,
+				capiv1alpha3.ClusterLabelName: config.ClusterName,
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
 			},

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -27,7 +27,7 @@ type NodePoolCRsConfig struct {
 	FileName          string
 	NodePoolID        string
 	AvailabilityZones []string
-	ClusterID         string
+	ClusterName       string
 	Description       string
 	NodesMax          int
 	NodesMin          int
@@ -47,8 +47,8 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 			Name:      config.NodePoolID,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                 config.ClusterID,
-				capiv1alpha3.ClusterLabelName: config.ClusterID,
+				label.Cluster:                 config.ClusterName,
+				capiv1alpha3.ClusterLabelName: config.ClusterName,
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Owner,
 			},
@@ -57,12 +57,12 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 			},
 		},
 		Spec: expcapiv1alpha3.MachinePoolSpec{
-			ClusterName:    config.ClusterID,
+			ClusterName:    config.ClusterName,
 			Replicas:       toInt32Ptr(int32(config.NodesMin)),
 			FailureDomains: config.AvailabilityZones,
 			Template: capiv1alpha3.MachineTemplateSpec{
 				Spec: capiv1alpha3.MachineSpec{
-					ClusterName:       config.ClusterID,
+					ClusterName:       config.ClusterName,
 					InfrastructureRef: *infrastructureRef,
 					Bootstrap: capiv1alpha3.Bootstrap{
 						ConfigRef: bootstrapConfigRef,
@@ -85,8 +85,8 @@ func newSparkCR(config NodePoolCRsConfig) *corev1alpha1.Spark {
 			Name:      config.NodePoolID,
 			Namespace: config.Namespace,
 			Labels: map[string]string{
-				label.Cluster:                 config.ClusterID,
-				capiv1alpha3.ClusterLabelName: config.ClusterID,
+				label.Cluster:                 config.ClusterName,
+				capiv1alpha3.ClusterLabelName: config.ClusterName,
 			},
 		},
 		Spec: corev1alpha1.SparkSpec{},

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -51,8 +51,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		config = provider.NodePoolCRsConfig{
 			AWSInstanceType:                     r.flag.AWSInstanceType,
 			FileName:                            nodePoolCRFileName,
-			ClusterID:                           r.flag.ClusterID,
-			Description:                         r.flag.NodepoolName,
+			ClusterName:                         r.flag.ClusterName,
+			Description:                         r.flag.Description,
 			VMSize:                              r.flag.AzureVMSize,
 			AzureUseSpotVms:                     r.flag.AzureUseSpotVms,
 			AzureSpotMaxPrice:                   r.flag.AzureSpotVMsMaxPrice,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18247

This changes the flags for the `kubectl gs template nodepool` command to

- deprecate the `--cluster-id` flag, add the `--cluster-name` flag as a replacement
- deprecate the `-nodepool-name` flag, add the `--description` flag as a replacement

Both old flags are still supported.

### Before

```nohighlight
Flags:
...
      --cluster-id string                              Workload cluster ID.
  -h, --help                                           help for nodepool
      --nodepool-name string                           NodepoolName or purpose description of the node pool. (default "Unnamed node pool")
...
```

### After

```nohighlight
Flags:
...
      --cluster-name string                            Name of the Cluster to add the node pool to.
      --description string                             User-friendly description of the node pool's purpose.
...
```

Deprecated flags are not shown in the `--help` output.