### PR TITLE
Make the `login` command work even if opening the browser fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Update the Dockerfile to include kuebctl v1.19 and be based on Alpine v3.14.1.
 
+### Fixed
+
+- Make the `login` command continue to work even if opening the default browser fails.
+
 ## [1.35.0] - 2021-08-11
 
 ### Changed
@@ -68,8 +72,8 @@ If you are upgrading from an earlier releases, apply these changes to migrate an
 
 ### Added
 
-- Add templating using CAPA upstream templates for clusters in release version `v20.0.0` on AWS. 
-- Add templating using CAPA upstream templates for machinepools in release version `v20.0.0` on AWS. 
+- Add templating using CAPA upstream templates for clusters in release version `v20.0.0` on AWS.
+- Add templating using CAPA upstream templates for machinepools in release version `v20.0.0` on AWS.
 - Add optional `--release` flag to nodepool templating so that the new functionality can be used for CAPA versions.
 
 ### Fixed

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -86,7 +86,7 @@ func handleAuth(ctx context.Context, out io.Writer, errOut io.Writer, i *install
 	// redirect the user to the local web server we'll create next.
 	err = open.Run(authURL)
 	if err != nil {
-		fmt.Fprintf(errOut, "%s\n\n", color.RedString("Couldn't open the default browser. Please access the URL above to continue logging in."))
+		fmt.Fprintf(errOut, "%s\n\n", color.YellowString("Couldn't open the default browser. Please access the URL above to continue logging in."))
 	}
 
 	// Create a local web server, for fetching all the authentication data from

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -178,7 +178,7 @@ func (r *runner) loginWithURL(ctx context.Context, path string) error {
 		fmt.Fprint(r.stdout, color.YellowString("Note: deriving Management API URL from web UI URL: %s\n", i.K8sApiURL))
 	}
 
-	authResult, err := handleAuth(ctx, r.stdout, i, r.flag.ClusterAdmin)
+	authResult, err := handleAuth(ctx, r.stdout, r.stderr, i, r.flag.ClusterAdmin)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
The `login` command fails if opening the default browser fails. With this PR, if that happens, we print a message to the console and we keep the auth proxy running, so the user could open the URL by themselves and continue the authentication process.