### PR TITLE
login: add flag --callback-port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- `kubectl gs login` now offers the flag `--callback-port` to specify the port number the OIDC callback server on localhost should use.
+
 ### Changed
 
 - Update the Dockerfile to include kuebctl v1.19 and be based on Alpine v3.14.1.

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -40,7 +40,7 @@ var (
 )
 
 // handleAuth executes the OIDC authentication against an installation's authentication provider.
-func handleAuth(ctx context.Context, out io.Writer, i *installation.Installation, clusterAdmin bool) (oidc.UserInfo, error) {
+func handleAuth(ctx context.Context, out io.Writer, i *installation.Installation, clusterAdmin bool, port int) (oidc.UserInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, authResultTimeout)
 	defer cancel()
 
@@ -48,6 +48,7 @@ func handleAuth(ctx context.Context, out io.Writer, i *installation.Installation
 	var authProxy *callbackserver.CallbackServer
 	{
 		config := callbackserver.Config{
+			Port:        port,
 			RedirectURI: authCallbackPath,
 		}
 		authProxy, err = callbackserver.New(config)

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -5,16 +5,19 @@ import (
 )
 
 const (
-	flagClusterAdmin = "cluster-admin"
-	flagInternalAPI  = "internal-api"
+	flagClusterAdmin   = "cluster-admin"
+	flagInternalAPI    = "internal-api"
+	callbackServerPort = "callback-port"
 )
 
 type flag struct {
-	ClusterAdmin bool
-	InternalAPI  bool
+	CallbackServerPort int
+	ClusterAdmin       bool
+	InternalAPI        bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&f.CallbackServerPort, callbackServerPort, 0, "TCP port to use by the OIDC callback server. If not specified, a free port will be selected randomly.")
 	cmd.Flags().BoolVar(&f.ClusterAdmin, flagClusterAdmin, false, "Login with cluster-admin access.")
 	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
 }

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -178,7 +178,7 @@ func (r *runner) loginWithURL(ctx context.Context, path string) error {
 		fmt.Fprint(r.stdout, color.YellowString("Note: deriving Management API URL from web UI URL: %s\n", i.K8sApiURL))
 	}
 
-	authResult, err := handleAuth(ctx, r.stdout, i, r.flag.ClusterAdmin)
+	authResult, err := handleAuth(ctx, r.stdout, i, r.flag.ClusterAdmin, r.flag.CallbackServerPort)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
With this PR, `kubectl gs login` offers the flag `--callback-port` to specify the port number the OIDC callback server on localhost should use.

Example:

```nohighlight
$ kubectl gs login talos --callback-port 8085
```