### PR TITLE
Add PR template for kubectl-gs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 When creating a pull request for `kubectl-gs`, please consider:
 
-- Provide a link to the issue, and please describe the goal you are trying to accomplish into this description.
+- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
 - SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
 - Add a user-friendly description of your change to `CHANGELOG.md`.
 - Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.


### PR DESCRIPTION
This PR adds a pull request template to the repo, so that the text below the line will appear in every new PR:

---

When creating a pull request for `kubectl-gs`, please consider:

- Provide a link to the issue, and please describe the goal you are trying to accomplish into this description.
- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
- Add a user-friendly description of your change to `CHANGELOG.md`.
- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.
