### PR TITLE
Set description annotation for azure cluster CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Set `cluster.giantswarm.io/description` label for `Cluster` CR in template generation command on Azure.
+- Set `cluster.giantswarm.io/description` annotation for `Cluster` CR in template generation command on Azure.
 
 ## [1.37.0] - 2021-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `cluster.giantswarm.io/description` label for `Cluster` CR in template generation command on Azure.
+
 ## [1.37.0] - 2021-09-03
 
 ### Changed

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -45,6 +45,7 @@ func WriteCAPZTemplate(out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
 	data := struct {
+		Description       string
 		KubernetesVersion string
 		Name              string
 		Namespace         string
@@ -52,6 +53,7 @@ func WriteCAPZTemplate(out io.Writer, config ClusterCRsConfig) error {
 		Version           string
 		VMSize            string
 	}{
+		Description:       config.Description,
 		KubernetesVersion: "v1.19.9",
 		Name:              config.Name,
 		Namespace:         key.OrganizationNamespaceFromName(config.Owner),

--- a/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
@@ -1,13 +1,14 @@
 apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
+  annotations:
+    "cluster.giantswarm.io/description": "{{ .Description }}"
   labels:
     "release.giantswarm.io/version": "{{ .Version }}"
     "giantswarm.io/cluster": "{{ .Name }}"
     "cluster.x-k8s.io/cluster-name": "{{ .Name }}"
     "giantswarm.io/organization": "{{ .Owner }}"
     "cluster.x-k8s.io/watch-filter": "capi"
-    "cluster.giantswarm.io/description": "{{ .Description }}"
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:

--- a/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
@@ -7,6 +7,7 @@ metadata:
     "cluster.x-k8s.io/cluster-name": "{{ .Name }}"
     "giantswarm.io/organization": "{{ .Owner }}"
     "cluster.x-k8s.io/watch-filter": "capi"
+    "cluster.giantswarm.io/description": "{{ .Description }}"
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:


### PR DESCRIPTION
This PR sets the `cluster.giantswarm.io/description` annotation for `Cluster` CR in template generation command on Azure.