### PR TITLE
Add tags to enable `cluster autoscaler` to Azure Node Pool template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add tags to enable `cluster autoscaler` to Azure Node Pool template.
+
 ### Fixed
 
 - Set `cluster.giantswarm.io/description` annotation for `Cluster` CR in template generation command on Azure.

--- a/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
@@ -10,6 +10,9 @@ metadata:
     "release.giantswarm.io/version": "{{ .Version }}"
     "giantswarm.io/organization": "{{ .Owner }}"
 spec:
+  additionalTags:
+    "cluster-autoscaler-enabled": "true"
+    "cluster-autoscaler-name": "{{ .ClusterName }}"
   identity: SystemAssigned
   location: ""
   strategy:


### PR DESCRIPTION
This PR adds 2 tags to Azure Machine Pools, needed to enable cluster autoscaler in CAPZ clusters.
