### PR TITLE
Allow providing Kubernetes API URLs with prefixes to the login command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow providing Kubernetes API URLs with prefixes to the `login` command.
+
 ## [1.38.0] - 2021-09-08
 
 ### Added
@@ -28,9 +32,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Added `aws-cluster-namespace` flag for nodepools to override the standard namespace to support nodepool creation for 
+- Added `aws-cluster-namespace` flag for nodepools to override the standard namespace to support nodepool creation for
   upgraded >v16.0.0 clusters that remain in the default namespace.
-- Added support to generate templates for CAPZ clusters and node pools. 
+- Added support to generate templates for CAPZ clusters and node pools.
 
 ## [1.36.0] - 2021-08-26
 

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -21,6 +21,8 @@ const (
 	UrlTypeHappa
 )
 
+var k8sApiURLRegexp = regexp.MustCompile(fmt.Sprintf("([^.]*)%s.*$", k8sApiUrlPrefix))
+
 func GetUrlType(u string) int {
 	switch {
 	case isHappaUrl(u):
@@ -33,8 +35,6 @@ func GetUrlType(u string) int {
 }
 
 func isK8sApiUrl(u string) bool {
-	k8sApiURLRegexp, _ := regexp.Compile(fmt.Sprintf("^([^.]*)%s.*$", k8sApiUrlPrefix))
-
 	return k8sApiURLRegexp.MatchString(u)
 }
 
@@ -44,7 +44,7 @@ func isHappaUrl(u string) bool {
 
 func getBasePath(u string) (string, error) {
 	// Add https scheme if it doesn't exist.
-	urlRegexp, _ := regexp.Compile("^http(s)?://.*$")
+	urlRegexp := regexp.MustCompile("^http(s)?://.*$")
 	if matched := urlRegexp.MatchString(u); !matched {
 		u = fmt.Sprintf("https://%s", u)
 	}
@@ -56,7 +56,7 @@ func getBasePath(u string) (string, error) {
 
 	switch GetUrlType(path.Host) {
 	case UrlTypeK8sApi:
-		return path.Host, nil
+		return k8sApiURLRegexp.FindString(path.Host), nil
 	case UrlTypeHappa:
 		basePath := strings.Replace(path.Host, fmt.Sprintf("%s.", happaUrlPrefix), "", -1)
 		return basePath, nil

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -44,9 +44,9 @@ func Test_getBasePath(t *testing.T) {
 			errorMatcher: IsUnknownUrlType,
 		},
 		{
-			name:         "case 5: using giant swarm api url",
-			url:          "https://api.g8s.test.eu-west-1.aws.coolio.com",
-			errorMatcher: IsUnknownUrlType,
+			name:           "case 5: using giant swarm api url",
+			url:            "https://api.g8s.test.eu-west-1.aws.coolio.com",
+			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
 		},
 	}
 


### PR DESCRIPTION
Depends on https://github.com/giantswarm/config/pull/434

This makes the `login` command smarter by allowing the usage of Kubernetes API URLs with prefixes. This fixes login on the `viking` installation.