### PR TITLE
Start a new auth flow if the refresh token or the id token are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make the `login` command be able to start a new authentication flow if one of the tokens of an existing authentication provider are not present.
+
 ## [1.39.0] - 2021-09-10
 
 ### Added

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -92,6 +92,15 @@ func IsInvalidAuthConfiguration(err error) bool {
 	return microerror.Cause(err) == invalidAuthConfigurationError
 }
 
+var newLoginRequiredError = &microerror.Error{
+	Kind: "newLoginRequiredError",
+}
+
+// IsNewLoginRequired asserts newLoginRequiredError.
+func IsNewLoginRequired(err error) bool {
+	return microerror.Cause(err) == newLoginRequiredError
+}
+
 var authResponseTimedOutError = &microerror.Error{
 	Kind: "authResponseTimedOutError",
 }


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18285

Fairly straightforward. If the refresh token or ID token are missing, we execute the authentication flow again, since we still have the K8s API URL and the installation codename stored.