### PR TITLE
'template organization': add --output flag

### DIFF
--- a/cmd/template/organization/flag.go
+++ b/cmd/template/organization/flag.go
@@ -6,15 +6,18 @@ import (
 )
 
 const (
-	flagName = "name"
+	flagName   = "name"
+	flagOutput = "output"
 )
 
 type flag struct {
-	Name string
+	Name   string
+	Output string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Organization name.")
+	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for the resulting manifest. (default: stdout)")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/organization/runner.go
+++ b/cmd/template/organization/runner.go
@@ -42,10 +42,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		Name: r.flag.Name,
 	}
 
-	var output *os.File
+	var outputWriter io.Writer
 	{
 		if r.flag.Output == "" {
-			output = os.Stdout
+			outputWriter = r.stdout
 		} else {
 			f, err := os.Create(r.flag.Output)
 			if err != nil {
@@ -53,7 +53,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			}
 			defer f.Close()
 
-			output = f
+			outputWriter = f
 		}
 	}
 
@@ -67,7 +67,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
-	_, err = fmt.Fprint(output, string(organizationCRYaml))
+	_, err = fmt.Fprint(outputWriter, string(organizationCRYaml))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/organization/runner_test.go
+++ b/cmd/template/organization/runner_test.go
@@ -32,7 +32,8 @@ func TestRunner_Run(t *testing.T) {
 		{
 			name: "",
 			flag: &flag{
-				Name: "example",
+				Name:   "example",
+				Output: "",
 			},
 			expectedGoldenFile: "run_with_name.golden",
 		},


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18906

This PR adds the `--output` flag, which is present in the other `template` subcommands for specifying the file output, to the `template organization` subcommand.