### PR TITLE
Update cluster templating error messages for name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Make the `login` command be able to start a new authentication flow if one of the tokens of an existing authentication provider are not present.
+- Update cluster templating error messages for `--name` flag to use correct terminology
 
 ## [1.39.0] - 2021-09-10
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -103,24 +103,24 @@ func (f *flag) Validate() error {
 
 	if f.Name != "" {
 		if len(f.Name) != key.IDLength {
-			return microerror.Maskf(invalidFlagError, "--%s must be length of %d", flagClusterIDDeprecated, key.IDLength)
+			return microerror.Maskf(invalidFlagError, "--%s must be length of %d", flagName, key.IDLength)
 		}
 
 		matchedLettersOnly, err := regexp.MatchString("^[a-z]+$", f.Name)
 		if err == nil && matchedLettersOnly {
 			// strings is letters only, which we avoid
-			return microerror.Maskf(invalidFlagError, "--%s must contain at least one number", flagClusterIDDeprecated)
+			return microerror.Maskf(invalidFlagError, "--%s must contain at least one number", flagName)
 		}
 
 		matchedNumbersOnly, err := regexp.MatchString("^[0-9]+$", f.Name)
 		if err == nil && matchedNumbersOnly {
 			// strings is numbers only, which we avoid
-			return microerror.Maskf(invalidFlagError, "--%s must contain at least one digit", flagClusterIDDeprecated)
+			return microerror.Maskf(invalidFlagError, "--%s must contain at least one digit", flagName)
 		}
 
 		matched, err := regexp.MatchString("^[a-z][a-z0-9]+$", f.Name)
 		if err == nil && !matched {
-			return microerror.Maskf(invalidFlagError, "--%s must only contain alphanumeric characters, and start with a letter", flagClusterIDDeprecated)
+			return microerror.Maskf(invalidFlagError, "--%s must only contain alphanumeric characters, and start with a letter", flagName)
 		}
 
 		if f.ControlPlaneSubnet != "" {

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -103,7 +103,7 @@ func (f *flag) Validate() error {
 
 	if f.Name != "" {
 		if len(f.Name) != key.IDLength {
-			return microerror.Maskf(invalidFlagError, "--%s must be length of %d", flagName, key.IDLength)
+			return microerror.Maskf(invalidFlagError, "--%s must be of length %d", flagName, key.IDLength)
 		}
 
 		matchedLettersOnly, err := regexp.MatchString("^[a-z]+$", f.Name)
@@ -115,7 +115,7 @@ func (f *flag) Validate() error {
 		matchedNumbersOnly, err := regexp.MatchString("^[0-9]+$", f.Name)
 		if err == nil && matchedNumbersOnly {
 			// strings is numbers only, which we avoid
-			return microerror.Maskf(invalidFlagError, "--%s must contain at least one digit", flagName)
+			return microerror.Maskf(invalidFlagError, "--%s must contain at least one letter", flagName)
 		}
 
 		matched, err := regexp.MatchString("^[a-z][a-z0-9]+$", f.Name)


### PR DESCRIPTION
The error messages for templating a cluster are updated to use the `name` flag, replacing the deprecated `cluster-id` flag. The term 'digit' was also incorrectly used to refer to a letter, and has been changed accordingly.