### PR TITLE
Nodepool nodes are labeled with nodepool id on Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Nodepool nodes are labeled with nodepool id on Azure.
+
 ### Changed
 
 - Update the `template cluster` command to add CAPI defaults and validation using the management cluster API.

--- a/cmd/template/nodepool/provider/templates/azure/kubeadm_config.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/kubeadm_config.yaml.tmpl
@@ -24,4 +24,5 @@ spec:
         azure-container-registry-config: /etc/kubernetes/azure.json
         cloud-config: /etc/kubernetes/azure.json
         cloud-provider: azure
+        node-labels: giantswarm.io/machine-pool={{ .Name }}
       name: '{{ `{{ ds.meta_data["local_hostname"] }}` }}'


### PR DESCRIPTION
When creating a nodepool we normally want to label its nodes with the nodepool id so that later we can assign workload to it.
With this change Azure nodepools will be labeled using the label

```
giantswarm.io/machine-pool=a1b2c
```

This is [the label that we mention in our docs](https://docs.giantswarm.io/advanced/node-pools/#assigning-workloads).