### PR TITLE
Label MachinePool and AzureMachinePool with giantswarm.io/machine-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- `MachinePool` and `AzureMachinePool` are labeled with the `giantswarm.io/machine-pool` label.
+
 ## [1.40.0] - 2021-09-24
 
 ### Added

--- a/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
@@ -9,6 +9,7 @@ metadata:
     "giantswarm.io/cluster": {{ .ClusterName }}
     "release.giantswarm.io/version": "{{ .Version }}"
     "giantswarm.io/organization": "{{ .Organization }}"
+    "giantswarm.io/machine-pool": "{{ .Name }}"
 spec:
   additionalTags:
     "cluster-autoscaler-enabled": "{{ if eq .MinSize .MaxSize }}false{{else}}true{{end}}"

--- a/cmd/template/nodepool/provider/templates/azure/machine_pool.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/machine_pool.yaml.tmpl
@@ -11,6 +11,7 @@ metadata:
     "giantswarm.io/cluster": {{ .ClusterName }}
     "release.giantswarm.io/version": "{{ .Version }}"
     "giantswarm.io/organization": "{{ .Organization }}"
+    "giantswarm.io/machine-pool": "{{ .Name }}"
 spec:
   clusterName: {{ .ClusterName }}
   replicas: {{ .Replicas }}


### PR DESCRIPTION
I see that we are labeling our nodepool CRs with this label on AWS, so for consistency sake, I'm doing the same on Azure.