### PR TITLE
Nodepool nodes are labeled with nodepool id on AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Nodepool nodes are labeled with nodepool id on AWS using `giantswarm.io/machine-pool`.
+
 ## [1.40.0] - 2021-09-24
 
 ### Added
 
-- Nodepool nodes are labeled with nodepool id on Azure.
+- Nodepool nodes are labeled with nodepool id on Azure using `giantswarm.io/machine-pool`.
 
 ### Changed
 

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -326,6 +327,10 @@ func newKubeadmConfigFromUnstructured(sshSSOPubKey string, sshdConfig string, o 
 				Groups: &groups,
 				Shell:  &shell,
 			},
+		}
+		kubeadmConfig.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{
+			"cloud-provider": "aws",
+			"node-labels":    fmt.Sprintf("giantswarm.io/machine-pool=%s", o.GetName()),
 		}
 	}
 

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"text/template"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
-	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -330,7 +330,7 @@ func newKubeadmConfigFromUnstructured(sshSSOPubKey string, sshdConfig string, o 
 		}
 		kubeadmConfig.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{
 			"cloud-provider": "aws",
-			"node-labels":    fmt.Sprintf("giantswarm.io/machine-pool=%s", o.GetName()),
+			"node-labels":    fmt.Sprintf("%s=%s", label.MachinePool, o.GetName()),
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/giantswarm/apiextensions/v3 v3.33.0
 	github.com/giantswarm/app/v5 v5.3.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0
+	github.com/giantswarm/k8smetadata v0.3.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/micrologger v0.5.0
 	github.com/google/go-cmp v0.5.6


### PR DESCRIPTION
This is a follow up of https://github.com/giantswarm/kubectl-gs/pull/481 since the label was missing from nodes on AWS.

[Our docs say](https://docs.giantswarm.io/advanced/node-pools/#assigning-workloads) that we use the label `giantswarm.io/machine-deployment` on AWS but `giantswarm.io/machine-pool` on Azure. This label can be anything that we want, so I'd suggest to use the same on all providers. This PR uses `giantswarm.io/machine-pool` as that's the value we are already using on Azure, and it makes explicit that we are using CAPI `MachinePools` under the hood. What do you think?