### PR TITLE
make org-namespace the default for AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use org-namespace for AWS Clusters by default
+
 ## [1.41.0] - 2021-10-04
 
 ### Added

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -141,7 +141,7 @@ func IsOrgNamespaceVersion(version string) bool {
 	// see https://github.com/giantswarm/aws-admission-controller/blob/ef83d90fc856fbc0484bec967064834c0b8d2c1e/pkg/aws/v1alpha3/cluster/mutate_cluster.go#L191-L202
 	// so as soon as the latest version is >=16.0.0 we are going to need the org-namespace as default here.
 	if version == "" {
-		return false
+		return true
 	}
 	OrgNamespaceVersion, _ := semver.New(FirstAWSOrgNamespaceRelease)
 	releaseVersion, _ := semver.New(version)


### PR DESCRIPTION
V16.0.0 is out. This means that it will be the default release in case the user does not specify it. Therefore we have to use the org-namespace by default as we decided for v16 and onward.