### PR TITLE
Addressing throttling to generate templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Throttling for generating CAPI templates.
+- Fix a problem where the template subcommands would be slower than expected because of obsolete API requests.
 
 ## [1.42.0] - 2021-10-07
 

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -11,10 +11,8 @@ import (
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiyaml "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
@@ -105,7 +103,7 @@ func runMutation(ctx context.Context, client k8sclient.Interface, templateData i
 			return microerror.Mask(err)
 		}
 		// Mapping needed for the dynamic client.
-		mapping, err := findGVR(mapper, gvk, dc)
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -154,8 +152,4 @@ func runMutation(ctx context.Context, client k8sclient.Interface, templateData i
 		}
 	}
 	return nil
-}
-
-func findGVR(mapper *restmapper.DeferredDiscoveryRESTMapper, gvk *schema.GroupVersionKind, dc *discovery.DiscoveryClient) (*meta.RESTMapping, error) {
-	return mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }


### PR DESCRIPTION
When creating a pull request for `kubectl-gs`, please consider:

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
- Add a user-friendly description of your change to `CHANGELOG.md`.
- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.