### PR TITLE
`get catalogs`: Adapt output table terminology for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- In the `get catalogs` command output, rename the colum `APP VERSION` to `UPSTREAM VERSION` and change the column order.
+
 ## [1.42.1] - 2021-10-08
 
 ### Fixed

--- a/cmd/get/catalogs/printer.go
+++ b/cmd/get/catalogs/printer.go
@@ -66,8 +66,8 @@ func getAppCatalogEntryRow(ace applicationv1alpha1.AppCatalogEntry) metav1.Table
 		Cells: []interface{}{
 			ace.Spec.Catalog.Name,
 			ace.Spec.AppName,
-			ace.Spec.AppVersion,
 			ace.Spec.Version,
+			ace.Spec.AppVersion,
 			output.TranslateTimestampSince(ace.CreationTimestamp),
 		},
 	}
@@ -80,8 +80,8 @@ func getCatalogEntryTable(catalogResource *catalogdata.Catalog) *metav1.Table {
 	table.ColumnDefinitions = []metav1.TableColumnDefinition{
 		{Name: "Catalog", Type: "string"},
 		{Name: "App Name", Type: "string"},
-		{Name: "App Version", Type: "string"},
 		{Name: "Version", Type: "string"},
+		{Name: "Upstream Version", Type: "string"},
 		{Name: "Created", Type: "string"},
 	}
 


### PR DESCRIPTION
This PR changes the output table for the `get catalogs` command by renaming `APP VERSION` to `UPSTREAM VERSION` and moving it to the 4th position, behind `VERSION`.

The term "app version" is quite problematic if a user thinks of the Giant Swarm app platform app as _the app_. If the `VERSION` column shows the version of that app, then what does the `APP VERSION` column show?

In the web UI we already changed the terminology to "upstream version" (or, where the space allows it, "includes upstream version").

## Before

```nohighlight
CATALOG                 APP NAME                            APP VERSION      VERSION        CREATED
giantswarm-playground   actions-runner-controller           0.11.2           0.1.0          61d
giantswarm-playground   akv2k8s                             1.3.0            0.1.0          9d
giantswarm-playground   alfred-app                          0.3.0            v0.2.0         37d
giantswarm-playground   app-mesh-app                        0.3.0            0.4.0          350d
giantswarm-playground   app-updater-app                     0.1.0            0.3.0          73d
giantswarm-playground   aws-ebs-csi-driver-app              1.0.0            2.0.0          156d
...
```

## After

```nohighlight
CATALOG                 APP NAME                            VERSION           UPSTREAM VERSION   CREATED
giantswarm-playground   actions-runner-controller           0.1.0             0.11.2             261d
giantswarm-playground   akv2k8s                             0.1.0             1.3.0              9d
giantswarm-playground   alfred-app                          v0.2.0            0.3.0              38d
giantswarm-playground   app-mesh-app                        0.4.0             0.3.0              350d
giantswarm-playground   app-updater-app                     0.3.0             0.1.0              73d
giantswarm-playground   aws-ebs-csi-driver-app              2.0.0             1.0.0              157d
```