### PR TITLE
Use controller cilent configured with kubeconfig instead of inCluster config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Fix a problem with fetching Catalog CRs in `validate apps`.
+- Fixing a problem where the function to fetch the SSH secret to generate the templates was using `inCluster` config ignoring the kubeconfig.
 
 ## [1.43.0] - 2021-10-13
 

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -16,7 +16,7 @@ func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, out io.W
 
 	var sshSSOPublicKey string
 	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey()
+		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -21,7 +21,7 @@ func WriteCAPZTemplate(ctx context.Context, client k8sclient.Interface, out io.W
 
 	var sshSSOPublicKey string
 	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey()
+		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
 	"text/template"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -25,11 +27,11 @@ import (
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
-func WriteAzureTemplate(out io.Writer, config NodePoolCRsConfig) error {
+func WriteAzureTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {
 	var err error
 
 	if key.IsCAPZVersion(config.ReleaseVersion) {
-		err = WriteCAPZTemplate(out, config)
+		err = WriteCAPZTemplate(ctx, client, out, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -43,12 +45,12 @@ func WriteAzureTemplate(out io.Writer, config NodePoolCRsConfig) error {
 	return nil
 }
 
-func WriteCAPZTemplate(out io.Writer, config NodePoolCRsConfig) error {
+func WriteCAPZTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {
 	var err error
 
 	var sshSSOPublicKey string
 	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey()
+		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/template/nodepool/provider/capa.go
+++ b/cmd/template/nodepool/provider/capa.go
@@ -57,7 +57,7 @@ func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, out io.W
 
 	var sshSSOPublicKey string
 	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey()
+		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -115,7 +115,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 	case key.ProviderAzure:
-		err = provider.WriteAzureTemplate(output, config)
+		err = provider.WriteAzureTemplate(ctx, c.K8sClient, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
The function that reads the `Secret` to feed the SSH key into the templates was using the `inCluster` configuration when run inside a k8s cluster, ignoring the passed kubeconfig.

I changed the code so that the function receives a client already configured from the entry point.