### PR TITLE
`kubectl gs login`: set .spec.versionBundle.Version in CertConfig resource

### DIFF
--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -81,6 +81,9 @@ func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error)
 				Organizations:       config.groups,
 				TTL:                 config.ttl,
 			},
+			VersionBundle: corev1alpha1.CertConfigSpecVersionBundle{
+				Version: config.certOperatorVersion,
+			},
 		},
 	}
 


### PR DESCRIPTION
As I learned from our [docs](https://docs.giantswarm.io/ui-api/management-api/crd/certconfigs.core.giantswarm.io/#v1alpha1-.spec.versionBundle), the CertConfig CRD has a `.spec.versionBundle.version` attribute which specifies the cert-operator version to use. So I'm adding the field here.