### PR TITLE
Use CAPI templates for all releases which name starts with v20.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Usa CAPI templates for all releases that start with `v20.0.0`, to include alpha and beta releases.
+
 ## [1.45.0] - 2021-10-26
 
 ### Added

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -125,12 +125,12 @@ func GetNodeInstanceProfile(machinePoolID string, clusterID string) string {
 // IsCAPAVersion returns whether a given GS Release Version is based on the CAPI/CAPA projects
 // TODO: make this a >= comparison
 func IsCAPAVersion(version string) bool {
-	return version == "20.0.0"
+	return strings.HasPrefix(version, "20.0.0")
 }
 
 // IsCAPZVersion returns whether a given GS Release Version is based on the CAPI/CAPZ projects
 func IsCAPZVersion(version string) bool {
-	return version == "20.0.0"
+	return strings.HasPrefix(version, "20.0.0")
 }
 
 // IsOrgNamespaceVersion returns whether a given AWS GS Release Version is based on clusters in Org Namespace


### PR DESCRIPTION
SIG-Product has decided that the first GS CAPI release will be called `v20.0.0-alpha`. Anticipating that it could be renamed in the future, I relaxed the check so that everything works as long as the release name starts with `v20.0.0`.