### PR TITLE
Use CAPI templates for all releases from v20.0.0-alpha1 onwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Usa CAPI templates for all releases that start with `v20.0.0`, to include alpha and beta releases.
+- Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.
 
 ## [1.45.0] - 2021-10-26
 

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -17,7 +17,7 @@ import (
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
-	if key.IsCAPAVersion(config.ReleaseVersion) {
+	if key.IsCAPIVersion(config.ReleaseVersion) {
 		if config.EKS {
 			err = WriteCAPAEKSTemplate(ctx, client, out, config)
 			if err != nil {

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -27,7 +27,7 @@ const (
 func WriteAzureTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
-	if key.IsCAPZVersion(config.ReleaseVersion) {
+	if key.IsCAPIVersion(config.ReleaseVersion) {
 		err = WriteCAPZTemplate(ctx, client, out, config)
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -18,7 +18,7 @@ import (
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {
 	var err error
 
-	if key.IsCAPAVersion(config.ReleaseVersion) {
+	if key.IsCAPIVersion(config.ReleaseVersion) {
 		if config.EKS {
 			err = WriteCAPAEKSTemplate(ctx, client, out, config)
 			if err != nil {

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -30,7 +30,7 @@ import (
 func WriteAzureTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {
 	var err error
 
-	if key.IsCAPZVersion(config.ReleaseVersion) {
+	if key.IsCAPIVersion(config.ReleaseVersion) {
 		err = WriteCAPZTemplate(ctx, client, out, config)
 		if err != nil {
 			return microerror.Mask(err)

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -51,6 +51,7 @@ const (
 const (
 	// FirstOrgNamespaceRelease is the first GS release that creates Clusters in Org Namespaces by default
 	FirstAWSOrgNamespaceRelease = "16.0.0"
+	FirstCAPIRelease            = "20.0.0-alpha1"
 )
 
 func BastionResourceName(clusterName string) string {
@@ -122,15 +123,11 @@ func GetNodeInstanceProfile(machinePoolID string, clusterID string) string {
 	return fmt.Sprintf("nodes-%s-%s", machinePoolID, clusterID)
 }
 
-// IsCAPAVersion returns whether a given GS Release Version is based on the CAPI/CAPA projects
-// TODO: make this a >= comparison
-func IsCAPAVersion(version string) bool {
-	return strings.HasPrefix(version, "20.0.0")
-}
-
-// IsCAPZVersion returns whether a given GS Release Version is based on the CAPI/CAPZ projects
-func IsCAPZVersion(version string) bool {
-	return strings.HasPrefix(version, "20.0.0")
+// IsCAPIVersion returns whether a given GS Release Version uses the CAPI projects
+func IsCAPIVersion(version string) bool {
+	capiVersion, _ := semver.New(FirstCAPIRelease)
+	releaseVersion, _ := semver.New(version)
+	return releaseVersion.GE(*capiVersion)
 }
 
 // IsOrgNamespaceVersion returns whether a given AWS GS Release Version is based on clusters in Org Namespace


### PR DESCRIPTION
Applying suggestions after merging https://github.com/giantswarm/kubectl-gs/pull/537#issuecomment-957465456