### PR TITLE
Find Cluster resources on AWS based on the giantswarm.io/cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Find `Cluster` resources on AWS based on the `giantswarm.io/cluster` label if the `cluster.x-k8s.io/cluster-name` label does not yield results.
+
 ### Changed
 
 - Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19683
Especially older clusters on AWS might not have the upstream `cluster-name` label so I added an extra check.

When creating a pull request for `kubectl-gs`, please consider:

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
- Add a user-friendly description of your change to `CHANGELOG.md`.
- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.
