### PR TITLE
Move AWS Cluster templating from apiextensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Find `Cluster` resources on AWS based on the `giantswarm.io/cluster` label if the `cluster.x-k8s.io/cluster-name` label does not yield results.
+- Add `cluster.x-k8s.io/cluster-name` label to AWS Cluster templates
 
 ### Changed
 
 - Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.
+- Move AWS Cluster templating from `apiextensions`
 
 ## [1.45.0] - 2021-10-26
 

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -6,11 +6,11 @@ import (
 	"text/template"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider/templates/aws"
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
@@ -47,7 +47,7 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 func WriteGSAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 	var err error
 
-	crsConfig := v1alpha3.ClusterCRsConfig{
+	crsConfig := aws.ClusterCRsConfig{
 		ClusterID: config.Name,
 
 		ExternalSNAT:   config.ExternalSNAT,
@@ -59,7 +59,7 @@ func WriteGSAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 		Labels:         config.Labels,
 	}
 
-	crs, err := v1alpha3.NewClusterCRs(crsConfig)
+	crs, err := aws.NewClusterCRs(crsConfig)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -113,7 +113,7 @@ func WriteGSAWSTemplate(out io.Writer, config ClusterCRsConfig) error {
 	return nil
 }
 
-func moveCRsToOrgNamespace(crs v1alpha3.ClusterCRs, organization string) v1alpha3.ClusterCRs {
+func moveCRsToOrgNamespace(crs aws.ClusterCRs, organization string) aws.ClusterCRs {
 	crs.Cluster.SetNamespace(key.OrganizationNamespaceFromName(organization))
 	crs.Cluster.Spec.InfrastructureRef.Namespace = key.OrganizationNamespaceFromName(organization)
 	crs.AWSCluster.SetNamespace(key.OrganizationNamespaceFromName(organization))

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -1,0 +1,235 @@
+package aws
+
+import (
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v3/pkg/id"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+)
+
+const (
+	defaultMasterInstanceType = "m5.xlarge"
+	kindAWSCluster            = "AWSCluster"
+	kindAWSControlPlane       = "AWSControlPlane"
+	kindG8sControlPlane       = "G8sControlPlane"
+)
+
+// +k8s:deepcopy-gen=false
+
+type ClusterCRsConfig struct {
+	ClusterID         string
+	ControlPlaneID    string
+	Credential        string
+	Domain            string
+	ExternalSNAT      bool
+	MasterAZ          []string
+	Description       string
+	PodsCIDR          string
+	Owner             string
+	Region            string
+	ReleaseComponents map[string]string
+	ReleaseVersion    string
+	Labels            map[string]string
+	NetworkPool       string
+}
+
+// +k8s:deepcopy-gen=false
+
+type ClusterCRs struct {
+	Cluster         *apiv1alpha3.Cluster
+	AWSCluster      *v1alpha3.AWSCluster
+	G8sControlPlane *v1alpha3.G8sControlPlane
+	AWSControlPlane *v1alpha3.AWSControlPlane
+}
+
+func NewClusterCRs(config ClusterCRsConfig) (ClusterCRs, error) {
+	// Default some essentials in case certain information are not given. E.g.
+	// the workload cluster ID may be provided by the user.
+	{
+		if config.ClusterID == "" {
+			config.ClusterID = id.Generate()
+		}
+		if config.ControlPlaneID == "" {
+			config.ControlPlaneID = id.Generate()
+		}
+	}
+
+	awsClusterCR := newAWSClusterCR(config)
+	clusterCR := newClusterCR(awsClusterCR, config)
+	awsControlPlaneCR := newAWSControlPlaneCR(config)
+	g8sControlPlaneCR := newG8sControlPlaneCR(awsControlPlaneCR, config)
+
+	crs := ClusterCRs{
+		Cluster:         clusterCR,
+		AWSCluster:      awsClusterCR,
+		G8sControlPlane: g8sControlPlaneCR,
+		AWSControlPlane: awsControlPlaneCR,
+	}
+
+	return crs, nil
+}
+
+func newAWSClusterCR(c ClusterCRsConfig) *v1alpha3.AWSCluster {
+	awsClusterCR := &v1alpha3.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kindAWSCluster,
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.ClusterID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io/",
+			},
+			Labels: map[string]string{
+				label.AWSOperatorVersion:     c.ReleaseComponents["aws-operator"],
+				label.Cluster:                c.ClusterID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+				apiv1alpha3.ClusterLabelName: c.ClusterID,
+			},
+		},
+		Spec: v1alpha3.AWSClusterSpec{
+			Cluster: v1alpha3.AWSClusterSpecCluster{
+				Description: c.Description,
+				DNS: v1alpha3.AWSClusterSpecClusterDNS{
+					Domain: c.Domain,
+				},
+				OIDC: v1alpha3.AWSClusterSpecClusterOIDC{},
+			},
+			Provider: v1alpha3.AWSClusterSpecProvider{
+				CredentialSecret: v1alpha3.AWSClusterSpecProviderCredentialSecret{
+					Name:      c.Credential,
+					Namespace: "giantswarm",
+				},
+				Pods: v1alpha3.AWSClusterSpecProviderPods{
+					CIDRBlock:    c.PodsCIDR,
+					ExternalSNAT: &c.ExternalSNAT,
+				},
+				Nodes: v1alpha3.AWSClusterSpecProviderNodes{
+					NetworkPool: c.NetworkPool,
+				},
+				Region: c.Region,
+			},
+		},
+	}
+
+	// Single master node
+	if len(c.MasterAZ) == 1 {
+		awsClusterCR.Spec.Provider.Master = v1alpha3.AWSClusterSpecProviderMaster{
+			AvailabilityZone: c.MasterAZ[0],
+			InstanceType:     defaultMasterInstanceType,
+		}
+	}
+
+	return awsClusterCR
+}
+
+func newAWSControlPlaneCR(c ClusterCRsConfig) *v1alpha3.AWSControlPlane {
+	return &v1alpha3.AWSControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kindAWSControlPlane,
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.ControlPlaneID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io/",
+			},
+			Labels: map[string]string{
+				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
+				label.Cluster:            c.ClusterID,
+				label.ControlPlane:       c.ControlPlaneID,
+				label.Organization:       c.Owner,
+				label.ReleaseVersion:     c.ReleaseVersion,
+			},
+		},
+		Spec: v1alpha3.AWSControlPlaneSpec{
+			AvailabilityZones: c.MasterAZ,
+			InstanceType:      defaultMasterInstanceType,
+		},
+	}
+}
+
+func newClusterCR(obj *v1alpha3.AWSCluster, c ClusterCRsConfig) *apiv1alpha3.Cluster {
+	clusterLabels := map[string]string{}
+	{
+		for key, value := range c.Labels {
+			clusterLabels[key] = value
+		}
+
+		gsLabels := map[string]string{
+			label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],
+			label.Cluster:                c.ClusterID,
+			apiv1alpha3.ClusterLabelName: c.ClusterID,
+			label.Organization:           c.Owner,
+			label.ReleaseVersion:         c.ReleaseVersion,
+		}
+
+		for key, value := range gsLabels {
+			clusterLabels[key] = value
+		}
+	}
+
+	clusterCR := &apiv1alpha3.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.ClusterID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/clusters.cluster.x-k8s.io/",
+			},
+			Labels: clusterLabels,
+		},
+		Spec: apiv1alpha3.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: obj.TypeMeta.APIVersion,
+				Kind:       obj.TypeMeta.Kind,
+				Name:       obj.GetName(),
+				Namespace:  obj.GetNamespace(),
+			},
+		},
+	}
+
+	return clusterCR
+}
+
+func newG8sControlPlaneCR(obj *v1alpha3.AWSControlPlane, c ClusterCRsConfig) *v1alpha3.G8sControlPlane {
+	return &v1alpha3.G8sControlPlane{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kindG8sControlPlane,
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.ControlPlaneID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io/",
+			},
+			Labels: map[string]string{
+				label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],
+				label.Cluster:                c.ClusterID,
+				label.ControlPlane:           c.ControlPlaneID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+			},
+		},
+		Spec: v1alpha3.G8sControlPlaneSpec{
+			Replicas: len(c.MasterAZ),
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: obj.TypeMeta.APIVersion,
+				Kind:       obj.TypeMeta.Kind,
+				Name:       obj.GetName(),
+				Namespace:  obj.GetNamespace(),
+			},
+		},
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19683
This PR adds the `cluster-name` label for cluster templates on AWS.
It also moves the AWS cluster templating function over from `apiextensions` to reduce dependencies.

When creating a pull request for `kubectl-gs`, please consider:

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
- Add a user-friendly description of your change to `CHANGELOG.md`.
- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.
