### PR TITLE
add cluster-name label to all aws resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Find `Cluster` resources on AWS based on the `giantswarm.io/cluster` label if the `cluster.x-k8s.io/cluster-name` label does not yield results.
-- Add `cluster.x-k8s.io/cluster-name` label to AWS Cluster templates
+- Add `cluster.x-k8s.io/cluster-name` label to all CRs created by AWS Cluster and Nodepol templating.
 
 ### Changed
 
 - Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.
 - Move AWS Cluster templating from `apiextensions`
+- Move AWS Node Pool templating from `apiextensions`
 
 ## [1.45.0] - 2021-10-26
 

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -142,11 +142,12 @@ func newAWSControlPlaneCR(c ClusterCRsConfig) *v1alpha3.AWSControlPlane {
 				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
-				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
-				label.Cluster:            c.ClusterID,
-				label.ControlPlane:       c.ControlPlaneID,
-				label.Organization:       c.Owner,
-				label.ReleaseVersion:     c.ReleaseVersion,
+				label.AWSOperatorVersion:     c.ReleaseComponents["aws-operator"],
+				label.Cluster:                c.ClusterID,
+				label.ControlPlane:           c.ControlPlaneID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+				apiv1alpha3.ClusterLabelName: c.ClusterID,
 			},
 		},
 		Spec: v1alpha3.AWSControlPlaneSpec{
@@ -220,6 +221,7 @@ func newG8sControlPlaneCR(obj *v1alpha3.AWSControlPlane, c ClusterCRsConfig) *v1
 				label.ControlPlane:           c.ControlPlaneID,
 				label.Organization:           c.Owner,
 				label.ReleaseVersion:         c.ReleaseVersion,
+				apiv1alpha3.ClusterLabelName: c.ClusterID,
 			},
 		},
 		Spec: v1alpha3.G8sControlPlaneSpec{

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -5,13 +5,13 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/kubectl-gs/cmd/template/nodepool/provider/templates/aws"
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
@@ -48,7 +48,7 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 	var err error
 
-	crsConfig := v1alpha3.NodePoolCRsConfig{
+	crsConfig := aws.NodePoolCRsConfig{
 		AvailabilityZones:                   config.AvailabilityZones,
 		AWSInstanceType:                     config.AWSInstanceType,
 		ClusterID:                           config.ClusterName,
@@ -62,7 +62,7 @@ func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		UseAlikeInstanceTypes:               config.UseAlikeInstanceTypes,
 	}
 
-	crs, err := v1alpha3.NewNodePoolCRs(crsConfig)
+	crs, err := aws.NewNodePoolCRs(crsConfig)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -114,7 +114,7 @@ func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 	return nil
 }
 
-func moveCRsToNamespace(crs v1alpha3.NodePoolCRs, namespace string) v1alpha3.NodePoolCRs {
+func moveCRsToNamespace(crs aws.NodePoolCRs, namespace string) aws.NodePoolCRs {
 	crs.MachineDeployment.SetNamespace(namespace)
 	crs.MachineDeployment.Spec.Template.Spec.InfrastructureRef.Namespace = namespace
 	crs.AWSMachineDeployment.SetNamespace(namespace)

--- a/cmd/template/nodepool/provider/templates/aws/nodepool.go
+++ b/cmd/template/nodepool/provider/templates/aws/nodepool.go
@@ -1,0 +1,150 @@
+package aws
+
+import (
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
+	"github.com/giantswarm/apiextensions/v3/pkg/id"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+)
+
+const (
+	kindAWSMachineDeployment = "AWSMachineDeployment"
+)
+
+// +k8s:deepcopy-gen=false
+
+type NodePoolCRsConfig struct {
+	AvailabilityZones                   []string
+	AWSInstanceType                     string
+	ClusterID                           string
+	MachineDeploymentID                 string
+	Description                         string
+	NodesMax                            int
+	NodesMin                            int
+	OnDemandBaseCapacity                int
+	OnDemandPercentageAboveBaseCapacity int
+	Owner                               string
+	ReleaseComponents                   map[string]string
+	ReleaseVersion                      string
+	UseAlikeInstanceTypes               bool
+}
+
+// +k8s:deepcopy-gen=false
+
+type NodePoolCRs struct {
+	MachineDeployment    *apiv1alpha3.MachineDeployment
+	AWSMachineDeployment *v1alpha3.AWSMachineDeployment
+}
+
+func NewNodePoolCRs(config NodePoolCRsConfig) (NodePoolCRs, error) {
+	// Default some essentials in case certain information are not given. E.g.
+	// the workload cluster ID may be provided by the user.
+	{
+		if config.ClusterID == "" {
+			config.ClusterID = id.Generate()
+		}
+		if config.MachineDeploymentID == "" {
+			config.MachineDeploymentID = id.Generate()
+		}
+	}
+
+	awsMachineDeploymentCR := newAWSMachineDeploymentCR(config)
+	machineDeploymentCR := newMachineDeploymentCR(awsMachineDeploymentCR, config)
+
+	crs := NodePoolCRs{
+		MachineDeployment:    machineDeploymentCR,
+		AWSMachineDeployment: awsMachineDeploymentCR,
+	}
+
+	return crs, nil
+}
+
+func newAWSMachineDeploymentCR(c NodePoolCRsConfig) *v1alpha3.AWSMachineDeployment {
+	return &v1alpha3.AWSMachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kindAWSMachineDeployment,
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.MachineDeploymentID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io/",
+			},
+			Labels: map[string]string{
+				label.AWSOperatorVersion:     c.ReleaseComponents["aws-operator"],
+				label.Cluster:                c.ClusterID,
+				label.MachineDeployment:      c.MachineDeploymentID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+				apiv1alpha3.ClusterLabelName: c.ClusterID,
+			},
+		},
+		Spec: v1alpha3.AWSMachineDeploymentSpec{
+			NodePool: v1alpha3.AWSMachineDeploymentSpecNodePool{
+				Description: c.Description,
+				Machine: v1alpha3.AWSMachineDeploymentSpecNodePoolMachine{
+					DockerVolumeSizeGB:  100,
+					KubeletVolumeSizeGB: 100,
+				},
+				Scaling: v1alpha3.AWSMachineDeploymentSpecNodePoolScaling{
+					Max: c.NodesMax,
+					Min: c.NodesMin,
+				},
+			},
+			Provider: v1alpha3.AWSMachineDeploymentSpecProvider{
+				AvailabilityZones: c.AvailabilityZones,
+				Worker: v1alpha3.AWSMachineDeploymentSpecProviderWorker{
+					InstanceType:          c.AWSInstanceType,
+					UseAlikeInstanceTypes: c.UseAlikeInstanceTypes,
+				},
+				InstanceDistribution: v1alpha3.AWSMachineDeploymentSpecInstanceDistribution{
+					OnDemandBaseCapacity:                c.OnDemandBaseCapacity,
+					OnDemandPercentageAboveBaseCapacity: &c.OnDemandPercentageAboveBaseCapacity,
+				},
+			},
+		},
+	}
+}
+
+func newMachineDeploymentCR(obj *v1alpha3.AWSMachineDeployment, c NodePoolCRsConfig) *apiv1alpha3.MachineDeployment {
+	return &apiv1alpha3.MachineDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineDeployment",
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.MachineDeploymentID,
+			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/machinedeployments.cluster.x-k8s.io/",
+			},
+			Labels: map[string]string{
+				label.Cluster:                c.ClusterID,
+				label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],
+				label.MachineDeployment:      c.MachineDeploymentID,
+				label.Organization:           c.Owner,
+				label.ReleaseVersion:         c.ReleaseVersion,
+				apiv1alpha3.ClusterLabelName: c.ClusterID,
+			},
+		},
+		Spec: apiv1alpha3.MachineDeploymentSpec{
+			ClusterName: c.ClusterID,
+			Template: apiv1alpha3.MachineTemplateSpec{
+				Spec: apiv1alpha3.MachineSpec{
+					ClusterName: c.ClusterID,
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: obj.TypeMeta.APIVersion,
+						Kind:       obj.TypeMeta.Kind,
+						Name:       obj.GetName(),
+						Namespace:  obj.GetNamespace(),
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19683
This PR adds the `cluster-name` label to all AWS cluster and nodepool resources. It also moves the nodepool templating function over from `apiextensions` to reduce dependencies.

When creating a pull request for `kubectl-gs`, please consider:

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
- Add a user-friendly description of your change to `CHANGELOG.md`.
- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.
