### PR TITLE
Make the login `--organization` flag optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make the `--organization` flag optional when using the `login` command with a workload cluster. The cluster will be searched in all the organization namespaces that the user has access to.
+
 ## [1.46.0] - 2021-11-09
 
 ### Added
@@ -19,7 +23,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.
 - Move AWS Cluster templating from `apiextensions`
 - Move AWS Node Pool templating from `apiextensions`
-- Make the `--organization` flag optional when using the `login` command with a workload cluster. The cluster will be searched in all the organization namespaces that the user has access to.
 
 ## [1.45.0] - 2021-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Usa CAPI templates for all releases from `v20.0.0-alpha1` onwards, to include alpha and beta releases.
 - Move AWS Cluster templating from `apiextensions`
 - Move AWS Node Pool templating from `apiextensions`
+- Make the `--organization` flag optional when using the `login` command with a workload cluster. The cluster will be searched in all the organization namespaces that the user has access to.
 
 ## [1.45.0] - 2021-10-26
 

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -208,3 +208,12 @@ var multipleClustersFoundError = &microerror.Error{
 func IsMultipleClustersFound(err error) bool {
 	return microerror.Cause(err) == multipleClustersFoundError
 }
+
+var insufficientPermissionsError = &microerror.Error{
+	Kind: "insufficientPermissionsError",
+}
+
+// IsInsufficientPermissions asserts insufficientPermissionsError.
+func IsInsufficientPermissions(err error) bool {
+	return microerror.Cause(err) == insufficientPermissionsError
+}

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -190,3 +190,21 @@ var releaseNotFoundError = &microerror.Error{
 func IsReleaseNotFound(err error) bool {
 	return microerror.Cause(err) == releaseNotFoundError
 }
+
+var noOrganizationsError = &microerror.Error{
+	Kind: "noOrganizationsError",
+}
+
+// IsNoOrganizations asserts noOrganizationsError.
+func IsNoOrganizations(err error) bool {
+	return microerror.Cause(err) == noOrganizationsError
+}
+
+var multipleClustersFoundError = &microerror.Error{
+	Kind: "multipleClustersFoundError",
+}
+
+// IsMultipleClustersFound asserts multipleClustersFoundError.
+func IsMultipleClustersFound(err error) bool {
+	return microerror.Cause(err) == multipleClustersFoundError
+}

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -3,7 +3,6 @@ package login
 import (
 	"fmt"
 
-	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -46,9 +45,5 @@ func (f *flag) Init(cmd *cobra.Command) {
 }
 
 func (f *flag) Validate() error {
-	if len(f.WCName) > 0 && len(f.WCOrganization) < 1 {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty when --%s is provided.", flagWCOrganization, flagWCName)
-	}
-
 	return nil
 }

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -341,14 +341,29 @@ func (r *runner) createClusterClientCert(ctx context.Context) error {
 		}
 	}
 
-	orgNamespace, err := getOrganizationNamespace(ctx, organizationService, r.flag.WCOrganization)
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	var c *cluster.Cluster
+	{
+		if len(r.flag.WCOrganization) > 0 {
+			orgNamespace, err := getOrganizationNamespace(ctx, organizationService, r.flag.WCOrganization)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 
-	c, err := fetchCluster(ctx, clusterService, provider, orgNamespace, r.flag.WCName)
-	if err != nil {
-		return microerror.Mask(err)
+			c, err = findCluster(ctx, clusterService, organizationService, provider, r.flag.WCName, orgNamespace)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		} else {
+			orgNamespaces, err := getAllOrganizationNamespaces(ctx, organizationService)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			c, err = findCluster(ctx, clusterService, organizationService, provider, r.flag.WCName, orgNamespaces...)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
 	}
 
 	releaseVersion, err := getClusterReleaseVersion(c, provider)

--- a/pkg/data/domain/cluster/aws.go
+++ b/pkg/data/domain/cluster/aws.go
@@ -6,6 +6,7 @@ import (
 	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,9 @@ func (s *Service) getAllAWS(ctx context.Context, namespace string) (Resource, er
 	{
 		clusterCollection := &infrastructurev1alpha3.AWSClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, clusterCollection, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else if len(clusterCollection.Items) == 0 {
 			return nil, microerror.Mask(noResourcesError)
@@ -36,7 +39,9 @@ func (s *Service) getAllAWS(ctx context.Context, namespace string) (Resource, er
 	clusters := &capiv1alpha3.ClusterList{}
 	{
 		err = s.client.K8sClient.CtrlClient().List(ctx, clusters, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else if len(clusters.Items) == 0 {
 			return nil, microerror.Mask(noResourcesError)
@@ -80,7 +85,9 @@ func (s *Service) getByNameAWS(ctx context.Context, name, namespace string) (Res
 		}
 		crs := &capiv1alpha3.ClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
@@ -90,7 +97,9 @@ func (s *Service) getByNameAWS(ctx context.Context, name, namespace string) (Res
 				label.Cluster: name,
 			}
 			err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
-			if err != nil {
+			if apierrors.IsForbidden(err) {
+				return nil, microerror.Mask(insufficientPermissionsError)
+			} else if err != nil {
 				return nil, microerror.Mask(err)
 			}
 
@@ -112,7 +121,9 @@ func (s *Service) getByNameAWS(ctx context.Context, name, namespace string) (Res
 		}
 		crs := &infrastructurev1alpha3.AWSClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 

--- a/pkg/data/domain/cluster/azure.go
+++ b/pkg/data/domain/cluster/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -19,7 +20,9 @@ func (s *Service) getAllAzure(ctx context.Context, namespace string) (Resource, 
 	{
 		clusterCollection := &capzv1alpha3.AzureClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, clusterCollection, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else if len(clusterCollection.Items) == 0 {
 			return nil, microerror.Mask(noResourcesError)
@@ -35,7 +38,9 @@ func (s *Service) getAllAzure(ctx context.Context, namespace string) (Resource, 
 	clusters := &capiv1alpha3.ClusterList{}
 	{
 		err = s.client.K8sClient.CtrlClient().List(ctx, clusters, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		} else if len(clusters.Items) == 0 {
 			return nil, microerror.Mask(noResourcesError)
@@ -82,7 +87,9 @@ func (s *Service) getByNameAzure(ctx context.Context, name, namespace string) (R
 	{
 		crs := &capiv1alpha3.ClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
@@ -100,7 +107,9 @@ func (s *Service) getByNameAzure(ctx context.Context, name, namespace string) (R
 	{
 		crs := &capzv1alpha3.AzureClusterList{}
 		err = s.client.K8sClient.CtrlClient().List(ctx, crs, labelSelector, inNamespace)
-		if err != nil {
+		if apierrors.IsForbidden(err) {
+			return nil, microerror.Mask(insufficientPermissionsError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 

--- a/pkg/data/domain/cluster/error.go
+++ b/pkg/data/domain/cluster/error.go
@@ -39,3 +39,12 @@ var invalidProviderError = &microerror.Error{
 func IsInvalidProvider(err error) bool {
 	return microerror.Cause(err) == invalidProviderError
 }
+
+var insufficientPermissionsError = &microerror.Error{
+	Kind: "insufficientPermissionsError",
+}
+
+// IsInsufficientPermissions asserts insufficientPermissionsError.
+func IsInsufficientPermissions(err error) bool {
+	return microerror.Cause(err) == insufficientPermissionsError
+}

--- a/pkg/data/domain/organization/error.go
+++ b/pkg/data/domain/organization/error.go
@@ -21,3 +21,12 @@ var notFoundError = &microerror.Error{
 func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
+
+var noResourcesError = &microerror.Error{
+	Kind: "noResourcesError",
+}
+
+// IsNoResources asserts noResourcesError.
+func IsNoResources(err error) bool {
+	return microerror.Cause(err) == noResourcesError
+}


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/541

This PR makes the `--organization` flag optional when using the `login` command with a workload cluster.
If the `--organization` flag is provided, everything works like before, but if it isn't provided, then:
* we fetch all organizations
* we get the namespaces from their status fields
* we look for a cluster with the given name (`--workload-cluster` flag) in each organization namespace
* if we don't have access to one of the namespaces, we just skip it
* if we only find one, we're good to go
* if we find multiple or none, we throw errors

## Preview

<details>
<summary>Cluster not found</summary>

![image](https://user-images.githubusercontent.com/13508038/140784487-55336e33-cb19-42a3-b3bc-89186af6ff09.png)

</details>

<details>
<summary>Not enough permissions to get the cluster in the given organization</summary>

![image](https://user-images.githubusercontent.com/13508038/140784565-45a60ff3-7851-4605-ba00-6e3b487d9ca7.png)

</details>

<details>
<summary>Multiple clusters with the same name</summary>

![image](https://user-images.githubusercontent.com/13508038/140784601-fba97378-84d8-4ee8-8802-076eedb063ee.png)

</details>