### PR TITLE
capa-fix-eks

### DIFF
--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -64,7 +64,7 @@ func WriteCAPAEKSTemplate(ctx context.Context, client k8sclient.Interface, out i
 		ReleaseVersion    string
 	}{
 		Description:       config.Description,
-		KubernetesVersion: "v1.19.9",
+		KubernetesVersion: "v1.21",
 		Name:              config.Name,
 		Namespace:         key.OrganizationNamespaceFromName(config.Organization),
 		Organization:      config.Organization,

--- a/cmd/template/cluster/provider/templates/aws/aws_managed_control_plane.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/aws/aws_managed_control_plane.yaml.tmpl
@@ -15,6 +15,7 @@ spec:
   identityRef:
     kind: AWSClusterRoleIdentity
     name: {{ .Name }}
+  eksClusterName: {{ .Name }}
   region: ""
   sshKeyName: ""
   version: {{ .KubernetesVersion }}


### PR DESCRIPTION
Fix version for the EKS, you cannot specify patch version as EKS automatically decides for you
Fix eksCLusterName to match the cluster name, otherwise the default will cause issues with the subnet tags and result is that controller manager cannot find subnets for creating ELBs