### PR TITLE
Let users use SA tokens for creating WC client certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow using `ServiceAccount` tokens for creating workload cluster certificates.
+
 ## [1.47.0] - 2021-11-09
 
 ### Added

--- a/pkg/kubeconfig/auth.go
+++ b/pkg/kubeconfig/auth.go
@@ -4,6 +4,45 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+type AuthType int
+
+const (
+	AuthTypeUnknown AuthType = iota
+	AuthTypeServiceAccount
+	AuthTypeAuthProvider
+	AuthTypeClientCertificate
+)
+
+func GetAuthType(config *clientcmdapi.Config, contextName string) AuthType {
+	if contextName == "" {
+		return AuthTypeUnknown
+	}
+
+	currentContext, exists := config.Contexts[contextName]
+	if !exists {
+		return AuthTypeUnknown
+	}
+
+	authInfo, exists := config.AuthInfos[currentContext.AuthInfo]
+	if !exists {
+		return AuthTypeUnknown
+	}
+
+	switch {
+	case len(authInfo.Token) > 0:
+		return AuthTypeServiceAccount
+	case authInfo.AuthProvider != nil:
+		return AuthTypeAuthProvider
+	case len(authInfo.ClientCertificate) > 0:
+	case len(authInfo.ClientCertificateData) > 0:
+	case len(authInfo.ClientKey) > 0:
+	case len(authInfo.ClientKeyData) > 0:
+		return AuthTypeClientCertificate
+	}
+
+	return AuthTypeUnknown
+}
+
 // GetAuthProvider fetches the authentication provider from kubeconfig,
 // for a desired context name.
 func GetAuthProvider(config *clientcmdapi.Config, contextName string) (*clientcmdapi.AuthProviderConfig, bool) {

--- a/pkg/kubeconfig/cluster.go
+++ b/pkg/kubeconfig/cluster.go
@@ -1,0 +1,23 @@
+package kubeconfig
+
+import (
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func GetClusterServer(config *clientcmdapi.Config, contextName string) (string, bool) {
+	if contextName == "" {
+		return "", false
+	}
+
+	currentContext, exists := config.Contexts[contextName]
+	if !exists {
+		return "", false
+	}
+
+	cluster, exists := config.Clusters[currentContext.Cluster]
+	if !exists {
+		return "", false
+	}
+
+	return cluster.Server, true
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/535

With the changes in this PR, users can now use `ServiceAccount` tokens for users in the `kubectl` config file, and create workload cluster client certificates.