### PR TITLE
Let users override their kubectl config using flags in the login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Allow using `ServiceAccount` tokens for creating workload cluster certificates.
+- Let users override their kubectl config using flags in the `login` command.
 
 ## [1.47.0] - 2021-11-09
 

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -42,6 +42,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf("How long the client certificate should live for. Requires --%s.", flagWCName))
 
 	f.config = genericclioptions.NewConfigFlags(true)
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+
+	_ = cmd.Flags().MarkHidden("namespace")
 }
 
 func (f *flag) Validate() error {


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/535

This PR adds kubectl context-specific flags to the `login` command. This allows customizing everything, from the context, token or cluster, to the whole kubectl config.