### PR TITLE
Validate --certificate-ttl flag of login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Validate `--certificate-ttl` flag of the `login` command.
+
 ## [1.48.1] - 2021-11-11
 
 ### Fixed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -51,9 +51,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 func (f *flag) Validate() error {
 	// Validate ttl flag
-	_, err := time.ParseDuration(f.WCCertTTL)
+	ttlFlag, err := time.ParseDuration(f.WCCertTTL)
 	if err != nil {
 		return microerror.Maskf(invalidFlagError, `--%s is not a valid duration. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`, flagWCCertTTL)
+	}
+	if ttlFlag <= 0 {
+		return microerror.Maskf(invalidFlagError, `--%s cannot be negative or zero.`, flagWCCertTTL)
 	}
 
 	return nil


### PR DESCRIPTION
I was trying to create a WC kubeconfig with a TTL of one day by setting the `--certificate-ttl` flag to `1d`. The value is then used in a `CertConfig` CR, but cert-operator cannot parse the `1d` string. (Not a valid time unit for `time.ParseDuration`). kubectl-gs just timed out waiting for cert-operator to create the credential.

This PR checks the given value by executing `time.ParseDuration`.