### PR TITLE
Add URL login support for ServiceAccount tokens in the `login` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add the ability of executing the management cluster login part of the `login` command with a `ServiceAccount` token.
+
 ## [1.50.1] - 2021-11-17
 
 ### Fixed

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -1,0 +1,159 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/fatih/color"
+	"github.com/giantswarm/microerror"
+	"github.com/skratchdot/open-golang/open"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/giantswarm/kubectl-gs/cmd/login/template"
+	"github.com/giantswarm/kubectl-gs/pkg/callbackserver"
+	"github.com/giantswarm/kubectl-gs/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/pkg/oidc"
+)
+
+const (
+	clientID = "zQiFLUnrTFQwrybYzeY53hWWfhOKWRAU"
+
+	oidcCallbackURL  = "http://localhost"
+	oidcCallbackPath = "/oauth/callback"
+
+	customerConnectorID   = "customer"
+	giantswarmConnectorID = "giantswarm"
+
+	oidcResultTimeout = 1 * time.Minute
+)
+
+var (
+	oidcScopes = [...]string{gooidc.ScopeOpenID, "profile", "email", "groups", "offline_access", "audience:server:client_id:dex-k8s-authenticator"}
+)
+
+// handleOIDC executes the OIDC authentication against an installation's authentication provider.
+func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *installation.Installation, clusterAdmin bool, port int) (authInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, oidcResultTimeout)
+	defer cancel()
+
+	var err error
+	var authProxy *callbackserver.CallbackServer
+	{
+		config := callbackserver.Config{
+			Port:        port,
+			RedirectURI: oidcCallbackPath,
+		}
+		authProxy, err = callbackserver.New(config)
+		if err != nil {
+			return authInfo{}, microerror.Mask(err)
+		}
+	}
+
+	oidcConfig := oidc.Config{
+		ClientID:    clientID,
+		Issuer:      i.AuthURL,
+		RedirectURL: fmt.Sprintf("%s:%d%s", oidcCallbackURL, authProxy.Port(), oidcCallbackPath),
+		AuthScopes:  oidcScopes[:],
+	}
+	auther, err := oidc.New(ctx, oidcConfig)
+	if err != nil {
+		return authInfo{}, microerror.Mask(err)
+	}
+
+	// select dex connector_id based on clusterAdmin value
+	var connectorID string
+	{
+		if clusterAdmin {
+			connectorID = giantswarmConnectorID
+		} else {
+			connectorID = customerConnectorID
+		}
+	}
+
+	authURL := auther.GetAuthURL(connectorID)
+
+	fmt.Fprintf(out, "\n%s\n", color.YellowString("Your browser should now be opening this URL:"))
+	fmt.Fprintf(out, "%s\n\n", authURL)
+
+	// Open the authorization url in the user's browser, which will eventually
+	// redirect the user to the local web server we'll create next.
+	err = open.Run(authURL)
+	if err != nil {
+		fmt.Fprintf(errOut, "%s\n\n", color.YellowString("Couldn't open the default browser. Please access the URL above to continue logging in."))
+	}
+
+	// Create a local web server, for fetching all the authentication data from
+	// the authentication provider.
+	p, err := authProxy.Run(ctx, handleOIDCCallback(ctx, auther))
+	if callbackserver.IsTimedOut(err) {
+		return authInfo{}, microerror.Maskf(authResponseTimedOutError, "failed to get an authentication response on time")
+	} else if err != nil {
+		return authInfo{}, microerror.Mask(err)
+	}
+
+	var authResult authInfo
+	{
+		user, ok := p.(oidc.UserInfo)
+		if !ok {
+			return authInfo{}, microerror.Mask(invalidAuthResult)
+		}
+
+		authResult.username = user.Username
+		authResult.token = user.IDToken
+		authResult.refreshToken = user.RefreshToken
+		authResult.clientID = clientID
+	}
+
+	return authResult, nil
+}
+
+// handleOIDCCallback is the callback executed after the authentication response was
+// received from the authentication provider.
+func handleOIDCCallback(ctx context.Context, a *oidc.Authenticator) func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	return func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+		res, err := a.HandleIssuerResponse(ctx, r.URL.Query().Get("state"), r.URL.Query().Get("code"))
+		if err != nil {
+			failureTemplate, tErr := template.GetFailedHTMLTemplateReader()
+			if tErr != nil {
+				return oidc.UserInfo{}, microerror.Mask(tErr)
+			}
+
+			w.Header().Set("Content-Type", "text/html")
+			http.ServeContent(w, r, "", time.Time{}, failureTemplate)
+
+			return oidc.UserInfo{}, microerror.Mask(err)
+		}
+
+		successTemplate, err := template.GetSuccessHTMLTemplateReader()
+		if err != nil {
+			return oidc.UserInfo{}, microerror.Mask(err)
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		http.ServeContent(w, r, "", time.Time{}, successTemplate)
+
+		return res, nil
+	}
+}
+
+func validateOIDCProvider(provider *clientcmdapi.AuthProviderConfig) error {
+	if len(provider.Config[ClientID]) < 1 || len(provider.Config[Issuer]) < 1 {
+		return microerror.Mask(invalidAuthConfigurationError)
+	}
+
+	if len(provider.Config[IDToken]) < 1 || len(provider.Config[RefreshToken]) < 1 {
+		return microerror.Mask(newLoginRequiredError)
+	}
+
+	_, err := url.ParseRequestURI(provider.Config[Issuer])
+	if err != nil {
+		return microerror.Mask(invalidAuthConfigurationError)
+	}
+
+	return nil
+}

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
@@ -80,7 +81,12 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 	} else {
-		err = r.loginWithURL(ctx, installationIdentifier, true)
+		var tokenOverride string
+		if c, ok := r.flag.config.(*genericclioptions.ConfigFlags); ok && c.BearerToken != nil && len(*c.BearerToken) > 0 {
+			tokenOverride = *c.BearerToken
+		}
+
+		err = r.loginWithURL(ctx, installationIdentifier, true, tokenOverride)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -118,7 +124,7 @@ func (r *runner) tryToReuseExistingContext(ctx context.Context, isCreatingClient
 			if IsNewLoginRequired(err) {
 				issuer := authProvider.Config[Issuer]
 
-				err = r.loginWithURL(ctx, issuer, false)
+				err = r.loginWithURL(ctx, issuer, false, "")
 				if err != nil {
 					return microerror.Mask(err)
 				}
@@ -180,7 +186,7 @@ func (r *runner) loginWithKubeContextName(ctx context.Context, contextName strin
 			authProvider, _ := kubeconfig.GetAuthProvider(config, contextName)
 			issuer := authProvider.Config[Issuer]
 
-			err = r.loginWithURL(ctx, issuer, false)
+			err = r.loginWithURL(ctx, issuer, false, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -225,7 +231,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 			authProvider, _ := kubeconfig.GetAuthProvider(config, contextName)
 			issuer := authProvider.Config[Issuer]
 
-			err = r.loginWithURL(ctx, issuer, false)
+			err = r.loginWithURL(ctx, issuer, false, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -249,7 +255,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 
 // loginWithURL performs the OIDC login into an installation's
 // k8s api with a happa/k8s api URL.
-func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool) error {
+func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool, tokenOverride string) error {
 	i, err := installation.New(ctx, path)
 	if installation.IsUnknownUrlType(err) {
 		return microerror.Maskf(unknownUrlError, "'%s' is not a valid Giant Swarm Management API URL. Please check the spelling.\nIf not sure, pass the web UI URL of the installation or the installation handle as an argument instead.", path)
@@ -261,9 +267,20 @@ func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool)
 		fmt.Fprint(r.stdout, color.YellowString("Note: deriving Management API URL from web UI URL: %s\n", i.K8sApiURL))
 	}
 
-	authResult, err := handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ClusterAdmin, r.flag.CallbackServerPort)
-	if err != nil {
-		return microerror.Mask(err)
+	var authResult authInfo
+	{
+		if len(tokenOverride) > 0 {
+			authResult = authInfo{
+				username: "automation",
+				token:    tokenOverride,
+			}
+		} else {
+			authResult, err = handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ClusterAdmin, r.flag.CallbackServerPort)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+		}
 	}
 
 	// Store kubeconfig and CA certificate.


### PR DESCRIPTION
This PR adds the ability of executing the MC login part of the `login` command with a `ServiceAccount` token (using the `--token` flag). This is very useful in automation, so you don't have to hard-code MC login information.

This allows doing a WC login in automation using a really short command, like
```
kubectl gs login https://g8s.mymc.gigantic.io \
--token <SA-TOKEN> \
--workload-cluster <CLUSTER-NAME> \
--certificate-group some-group
```
without needing any pre-existing `kubectl` context.