### PR TITLE
Strip ':443' suffix when requesting a client certificate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Strip ':443' suffix when requesting a client certificate.
+
 ## [1.50.0] - 2021-11-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Strip ':443' suffix when requesting a client certificate.
+- Strip ':<port>' suffix when requesting a client certificate.
 
 ## [1.50.0] - 2021-11-17
 

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -460,5 +460,5 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess) (string, error) 
 
 	clusterServer, _ := kubeconfig.GetClusterServer(config, config.CurrentContext)
 
-	return strings.TrimPrefix(clusterServer, "https://g8s."), nil
+	return strings.TrimSuffix(strings.TrimPrefix(clusterServer, "https://g8s."), ":443"), nil
 }

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -461,8 +461,6 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess) (string, error) 
 
 	clusterServer, _ := kubeconfig.GetClusterServer(config, config.CurrentContext)
 
-	fmt.Println(clusterServer)
-
 	// Ensure any trailing ports are trimmed.
 	reg := regexp.MustCompile(`:[0-9]+$`)
 	clusterServer = reg.ReplaceAllString(clusterServer, "")

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
@@ -460,5 +461,11 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess) (string, error) 
 
 	clusterServer, _ := kubeconfig.GetClusterServer(config, config.CurrentContext)
 
-	return strings.TrimSuffix(strings.TrimPrefix(clusterServer, "https://g8s."), ":443"), nil
+	fmt.Println(clusterServer)
+
+	// Ensure any trailing ports are trimmed.
+	reg := regexp.MustCompile(`:[0-9]+$`)
+	clusterServer = reg.ReplaceAllString(clusterServer, "")
+
+	return strings.TrimPrefix(clusterServer, "https://g8s."), nil
 }


### PR DESCRIPTION
When creating a kubeconfig on gorilla, for some reason the requested hostname was including the port number at the end and thus failing.

This PR strips the port from the string to make kubectl-gs login work