### PR TITLE
Add flag for running the login command with a cluster in the default namespace

### DIFF
--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -14,11 +14,12 @@ const (
 	flagInternalAPI    = "internal-api"
 	callbackServerPort = "callback-port"
 
-	flagWCName          = "workload-cluster"
-	flagWCOrganization  = "organization"
-	flagWCCertGroups    = "certificate-group"
-	flagWCCertTTL       = "certificate-ttl"
-	flagWCSelfContained = "self-contained"
+	flagWCName              = "workload-cluster"
+	flagWCOrganization      = "organization"
+	flagWCCertGroups        = "certificate-group"
+	flagWCCertTTL           = "certificate-ttl"
+	flagWCSelfContained     = "self-contained"
+	flagWCInsecureNamespace = "insecure-namespace"
 )
 
 type flag struct {
@@ -26,11 +27,12 @@ type flag struct {
 	ClusterAdmin       bool
 	InternalAPI        bool
 
-	WCName          string
-	WCOrganization  string
-	WCCertGroups    []string
-	WCCertTTL       string
-	WCSelfContained string
+	WCName              string
+	WCOrganization      string
+	WCCertGroups        []string
+	WCCertTTL           string
+	WCSelfContained     string
+	WCInsecureNamespace bool
 
 	config genericclioptions.RESTClientGetter
 }
@@ -45,10 +47,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&f.WCCertGroups, flagWCCertGroups, nil, fmt.Sprintf("RBAC group name to be encoded into the X.509 field \"O\". Requires --%s.", flagWCName))
 	cmd.Flags().StringVar(&f.WCSelfContained, flagWCSelfContained, "", fmt.Sprintf("Create a self-contained kubectl config with embedded credentials and write it to this path. Requires --%s.", flagWCName))
 	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf(`How long the client certificate should live for. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Requires --%s.`, flagWCName))
+	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
 	f.config = genericclioptions.NewConfigFlags(true)
 	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
 
+	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")
 }
 

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -376,26 +376,28 @@ func (r *runner) createClusterClientCert(ctx context.Context) error {
 
 	var c *cluster.Cluster
 	{
+		var namespaces []string
 		if len(r.flag.WCOrganization) > 0 {
 			orgNamespace, err := getOrganizationNamespace(ctx, organizationService, r.flag.WCOrganization)
 			if err != nil {
 				return microerror.Mask(err)
 			}
 
-			c, err = findCluster(ctx, clusterService, organizationService, provider, r.flag.WCName, orgNamespace)
-			if err != nil {
-				return microerror.Mask(err)
-			}
+			namespaces = append(namespaces, orgNamespace)
 		} else {
-			orgNamespaces, err := getAllOrganizationNamespaces(ctx, organizationService)
+			namespaces, err = getAllOrganizationNamespaces(ctx, organizationService)
 			if err != nil {
 				return microerror.Mask(err)
 			}
+		}
 
-			c, err = findCluster(ctx, clusterService, organizationService, provider, r.flag.WCName, orgNamespaces...)
-			if err != nil {
-				return microerror.Mask(err)
-			}
+		if r.flag.WCInsecureNamespace {
+			namespaces = append(namespaces, "default")
+		}
+
+		c, err = findCluster(ctx, clusterService, organizationService, provider, r.flag.WCName, namespaces...)
+		if err != nil {
+			return microerror.Mask(err)
 		}
 	}
 


### PR DESCRIPTION
This is only for GS staff, as this has been quite an annoying issue for on-call people: not being able to create client certificates for clusters that have not been migrated to organization namespaces.

This PR allows looking for a cluster in the `default` namespace if using the hidden `--insecure-namespace` flag