### PR TITLE
Disable version caching for the `selfupdate` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable version caching for the `selfupdate` command, so you will always get the latest version right after it's released.
+
 ## [1.52.0] - 2021-11-23
 
 ### Changed

--- a/cmd/selfupdate/runner.go
+++ b/cmd/selfupdate/runner.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/selfupdate"
 
 	"github.com/giantswarm/kubectl-gs/pkg/project"
@@ -47,11 +46,6 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		config := selfupdate.Config{
 			CurrentVersion: project.Version(),
 			RepositoryURL:  project.Source(),
-		}
-
-		config.CacheDir, err = key.GetCacheDir()
-		if err != nil {
-			return microerror.Mask(err)
 		}
 
 		updaterService, err = selfupdate.New(config)


### PR DESCRIPTION
Our self-updating logic caches the latest version for an hour before checking for new versions again. This is useful because we check for updates when any command runs. However, the version shouldn't be cached when running the `selfupdate` command, as users should be able to get the latest version right away.