### PR TITLE
Default release version in the template cluster/nodepool subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Use latest active release version as default in the `template cluster` command.
+- Use the workload cluster's release version as default in the `template nodepool` command.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Use latest active release version as default in the `template cluster` command.
+
 ### Changed
 
 - Disable version caching for the `selfupdate` command, so you will always get the latest version right after it's released.

--- a/cmd/template/cluster/error.go
+++ b/cmd/template/cluster/error.go
@@ -21,3 +21,12 @@ var invalidFlagError = &microerror.Error{
 func IsInvalidFlag(err error) bool {
 	return microerror.Cause(err) == invalidFlagError
 }
+
+var failedToDetermineLatestReleaseError = &microerror.Error{
+	Kind: "failedToDetermineLatestReleaseError",
+}
+
+// IsFailedToDetermineLatestRelease asserts failedToDetermineLatestReleaseError.
+func IsFailedToDetermineLatestRelease(err error) bool {
+	return microerror.Cause(err) == failedToDetermineLatestReleaseError
+}

--- a/cmd/template/nodepool/error.go
+++ b/cmd/template/nodepool/error.go
@@ -21,3 +21,12 @@ var invalidFlagError = &microerror.Error{
 func IsInvalidFlag(err error) bool {
 	return microerror.Cause(err) == invalidFlagError
 }
+
+var clusterNotFoundError = &microerror.Error{
+	Kind: "clusterNotFoundError",
+}
+
+// IsClusterNotFound asserts clusterNotFoundError.
+func IsClusterNotFound(err error) bool {
+	return microerror.Cause(err) == clusterNotFoundError
+}

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -60,6 +60,7 @@ func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		OnDemandPercentageAboveBaseCapacity: config.OnDemandPercentageAboveBaseCapacity,
 		Owner:                               config.Organization,
 		UseAlikeInstanceTypes:               config.UseAlikeInstanceTypes,
+		ReleaseVersion:                      config.ReleaseVersion,
 	}
 
 	crs, err := aws.NewNodePoolCRs(crsConfig)

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -180,6 +180,7 @@ func newAzureMachinePoolCR(config NodePoolCRsConfig) *expcapzv1alpha3.AzureMachi
 				capiv1alpha3.ClusterLabelName: config.ClusterName,
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Organization,
+				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 		},
 		Spec: expcapzv1alpha3.AzureMachinePoolSpec{

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -66,6 +66,7 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 				capiv1alpha3.ClusterLabelName: config.ClusterName,
 				label.MachinePool:             config.NodePoolID,
 				label.Organization:            config.Organization,
+				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 			Annotations: map[string]string{
 				annotation.MachinePoolName: config.Description,

--- a/cmd/template/nodepool/runner_test.go
+++ b/cmd/template/nodepool/runner_test.go
@@ -1,0 +1,136 @@
+package nodepool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
+)
+
+func Test_getWorkloadCluster(t *testing.T) {
+	testCases := []struct {
+		name         string
+		wcNamespace  string
+		wcName       string
+		wcProvider   string
+		storage      []runtime.Object
+		errorMatcher func(error) bool
+	}{
+		{
+			name:        "case 0: with existing cluster",
+			wcNamespace: "org-test",
+			wcName:      "test-wc",
+			wcProvider:  "aws",
+			storage: []runtime.Object{
+				newCAPICluster("org-test", "test-wc"),
+				newAWSCluster("org-test", "test-wc"),
+			},
+		},
+		{
+			name:        "case 1: with non-existing cluster",
+			wcNamespace: "org-test",
+			wcName:      "some-test-wc",
+			wcProvider:  "aws",
+			storage: []runtime.Object{
+				newCAPICluster("org-test", "test-wc"),
+				newAWSCluster("org-test", "test-wc"),
+			},
+			errorMatcher: IsClusterNotFound,
+		},
+		{
+			name:        "case 2: with no given namespace, existing cluster",
+			wcNamespace: "",
+			wcName:      "test-wc",
+			wcProvider:  "aws",
+			storage: []runtime.Object{
+				newCAPICluster("org-test", "test-wc"),
+				newAWSCluster("org-test", "test-wc"),
+				newCAPICluster("org-test", "test-wc2"),
+				newAWSCluster("org-test", "test-wc2"),
+			},
+		},
+		{
+			name:        "case 3: with no given namespace, non-existing cluster",
+			wcNamespace: "",
+			wcName:      "test-wc",
+			wcProvider:  "aws",
+			storage: []runtime.Object{
+				newCAPICluster("org-test2", "test-wc3"),
+				newAWSCluster("org-test2", "test-wc3"),
+				newCAPICluster("org-test", "test-wc2"),
+				newAWSCluster("org-test", "test-wc2"),
+			},
+			errorMatcher: IsClusterNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			clusterService := cluster.NewFakeService(tc.storage)
+
+			wc, err := getWorkloadCluster(ctx, clusterService, tc.wcNamespace, tc.wcName, tc.wcProvider)
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
+				}
+
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if wc == nil {
+				t.Fatalf("unexpected nil cluster")
+			}
+		})
+	}
+}
+
+func newCAPICluster(namespace, name string) *capiv1alpha3.Cluster {
+	c := &capiv1alpha3.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Labels: map[string]string{
+				label.ReleaseVersion:          "1.2.3",
+				label.Organization:            "some-org",
+				capiv1alpha3.ClusterLabelName: name,
+			},
+		},
+	}
+
+	return c
+}
+
+func newAWSCluster(namespace, name string) *infrastructurev1alpha3.AWSCluster {
+	c := &infrastructurev1alpha3.AWSCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			Labels: map[string]string{
+				label.ReleaseVersion:          "1.2.3",
+				label.Organization:            "some-org",
+				label.Cluster:                 name,
+				capiv1alpha3.ClusterLabelName: name,
+			},
+		},
+	}
+
+	return c
+}


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C02EVLE9W/p1637762623395000

The `--release` flag was accidentally made required by some internal change. This PR makes sure we always have a default value:
- for `template cluster`, we use the latest active release in the MC
- for `template nodepool`, we use the workload cluster's release version

**BONUS:** We now validate if the cluster exists when running `template nodepool`.