### PR TITLE
Make `--release` flag mandatory in the template cluster/nodepool subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Disable version caching for the `selfupdate` command, so you will always get the latest version right after it's released.
+- Make the `--release` flag mandatory in the `template cluster` and `template nodepool` subcommands.
 
 ## [1.52.0] - 2021-11-23
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -78,7 +78,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs.")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization (deprecated).")
-	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release. If not given, this remains empty for defaulting to the most recent one via the Management API.")
+	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Workload cluster label.")
 
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
@@ -201,8 +201,7 @@ func (f *flag) Validate() error {
 		}
 	}
 
-	// Validate release version for non-aws clusters.
-	if f.Provider != key.ProviderAWS && f.Release == "" {
+	if f.Release == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
 	}
 

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -116,7 +116,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().StringVar(&f.Owner, flagOwner, "", "Workload cluster owner organization.")
-	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release. If not given, this remains empty to match the workload cluster version via the Management API.")
+	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
 
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
 	_ = cmd.Flags().MarkHidden(flagEKS)
@@ -217,6 +217,10 @@ func (f *flag) Validate() error {
 
 		f.Organization = f.Owner
 		f.Owner = ""
+	}
+
+	if f.Release == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagRelease)
 	}
 
 	{


### PR DESCRIPTION
These flags are necessary in order to determine if the command should create CAPI or GS templates.

We cannot use defaulting because:
- In order to default the `--release` flag in the `template nodepool` command, we need to fetch the WC and get the version from there. This is a problem when the cluster doesn't exist, because users can no longer create templates for both clusters and node pools at the same time, which is necessary for GitOps.
- Defaulting the flag in the `template cluster` command is possible by fetching the latest active release from the API, but I believe it would be confusing to have the flag optional for clusters, but not for node pools

That being said, this PR makes the flag mandatory for both `template cluster` and `template nodepool`