### PR TITLE
When generating a kubeconfig, look for the generated secret in all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Fix CRD API version for EKS infrastcture ref in cluster CR template. 
 
+### Changed
+
+- When generating a kubeconfig, look for the generated secret in org namespace and fallback to default namespace to support legacy Azure clusters.
+
 ## [1.53.0] - 2021-11-29
 
 ### Changed

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -110,13 +110,11 @@ func createCert(ctx context.Context, clientCertService clientcert.Interface, con
 // fetchCredential tries to fetch the client certificate credential
 // for a couple of times, until the resource is fetched, or until the timeout is reached.
 func fetchCredential(ctx context.Context, provider string, clientCertService clientcert.Interface, clientCert *clientcert.ClientCert) (*corev1.Secret, error) {
-	credentialNamespace := determineCredentialNamespace(clientCert, provider)
-
 	var secret *corev1.Secret
 	var err error
 
 	o := func() error {
-		secret, err = clientCertService.GetCredential(ctx, credentialNamespace, clientCert.CertConfig.Name)
+		secret, err = clientCertService.GetCredential(ctx, clientCert.CertConfig.GetNamespace(), clientCert.CertConfig.Name)
 		if clientcert.IsNotFound(err) {
 			// Client certificate credential has not been created yet, try again until it is.
 			return microerror.Mask(err)
@@ -297,14 +295,6 @@ func getAllOrganizationNamespaces(ctx context.Context, organizationService organ
 	}
 
 	return namespaces, nil
-}
-
-func determineCredentialNamespace(clientCert *clientcert.ClientCert, provider string) string {
-	if provider == key.ProviderAzure {
-		return metav1.NamespaceDefault
-	}
-
-	return clientCert.CertConfig.GetNamespace()
 }
 
 func fetchCluster(ctx context.Context, clusterService cluster.Interface, provider, namespace, name string) (*cluster.Cluster, error) {


### PR DESCRIPTION
Currently there is an hardcoded logic in `kubectl gs login` that looks for the secret generated by cert-operator in the `default` namespace for azure clusters.
With the bump to latest cert-operator on the newest azure release, this won't work any more (the secret is generated in the org namespace).

Problem: we're going to have a mixed situation for azure, until all clusters are migrated to the newest release (yet to be released).

With this PR I suggest relaxing the namespace check and looking for the desired secret by label.

Blocks https://github.com/giantswarm/roadmap/issues/554