### PR TITLE
aws CAPA - fix EKS infrascture ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CRD API version for EKS infrastcture ref in cluster CR template. 
+
 ## [1.53.0] - 2021-11-29
 
 ### Changed

--- a/cmd/template/cluster/provider/templates/aws/cluster_eks.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/aws/cluster_eks.yaml.tmpl
@@ -21,6 +21,6 @@ spec:
     kind: AWSManagedControlPlane
     name: {{ .Name }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     kind: AWSManagedControlPlane
     name: {{ .Name }}-control-plane


### PR DESCRIPTION
with EKS there is only AWSManagedControl plane CR in controlplane API version, there is no infrastructure CR

this was hard to find typo :)

