### PR TITLE
Modify `STATUS` column of `get releases` command table output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Modify `STATUS` column of `get releases` command table output to display release state.
+
 ## [1.56.0] - 2021-12-07
 
 ### Added

--- a/cmd/get/releases/printer.go
+++ b/cmd/get/releases/printer.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,10 +106,7 @@ func getTableRow(release release.Release) metav1.TableRow {
 		return metav1.TableRow{}
 	}
 
-	status := "inactive"
-	if release.CR.Status.Ready {
-		status = "active"
-	}
+	status := getReleaseStatus(release.CR.Spec.State)
 
 	kubernetesVersion := naValue
 	containerLinuxVersion := naValue
@@ -150,4 +148,12 @@ func getTableRow(release release.Release) metav1.TableRow {
 			Object: release.CR,
 		},
 	}
+}
+
+func getReleaseStatus(status releasev1alpha1.ReleaseState) string {
+	if status == "" {
+		return naValue
+	}
+
+	return strings.ToUpper(status.String())
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/538.

This PR modifies the `STATUS` column in the table outputted by the `get releases` command. It will display each release's state as `ACTIVE`, `DEPRECATED`, `WIP`, or `PREVIEW`.

Current output of the command and the spec for this change can also be found in the linked issue.

<img width="713" alt="Screen Shot 2021-12-08 at 14 47 15" src="https://user-images.githubusercontent.com/62935115/145219134-74a0a73e-648f-472f-b49a-2d8959756be6.png">

Documentation will be updated with [this PR in the `docs` repo](https://github.com/giantswarm/docs/pull/1241).