### PR TITLE
Schedule cluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add support scheduling cluster updates.
+- Add support cluster updates and scheduling cluster updates.
 
 ## [1.56.0] - 2021-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add `update cluster` to set cluster updates on a scheduled time .
+- Add support scheduling cluster updates.
 
 ## [1.56.0] - 2021-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `update cluster` to set cluster updates on a scheduled time .
+
 ## [1.56.0] - 2021-12-07
 
 ### Added

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -23,16 +23,19 @@ const (
 Updates given cluster with the provided values.
 
 Options:
-  --name <name>               		Name of the cluster to update.
-  --namespace <namespace>     		Namespace of the cluster.
+  --name <cluster-name>             	Name of the cluster to update.
+  --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
-  --scheduled-time <scheduled-time>     Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.
+  --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.
   --provider <provider> 		Name of the provider.`
 
 	examples = `  # Display this help
 kubectl gs update cluster --help
 
-# Update cluster version
+# Update cluster
+kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --provider aws
+
+# Schedule cluster update
 kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "30 Jan 22 12:00 UTC" --provider aws`
 )
 

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -27,7 +27,7 @@ Options:
   --namespace <namespace>     		Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
   --scheduled-time <scheduled-time>     Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.
-  --provider <provider> 			Name of the provider.`
+  --provider <provider> 		Name of the provider.`
 
 	examples = `  # Display this help
 kubectl gs update cluster --help

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -1,0 +1,88 @@
+package cluster
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/giantswarm/kubectl-gs/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/pkg/middleware/renewtoken"
+)
+
+const (
+	name = "cluster --name <cluster-name> --namespace <cluster-namespace> --release-version <release-version> --scheduled-time <scheduled-time> --provider <provider>"
+
+	shortDescription = "Schedule a cluster update."
+	longDescription  = `Schedule a cluster update.
+
+Updates given cluster with the provided values.
+
+Options:
+  --name <name>               		Name of the cluster to update.
+  --namespace <namespace>     		Namespace of the cluster.
+  --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
+  --scheduled-time <scheduled-time>     Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.
+  --provider <provider> 			Name of the provider.`
+
+	examples = `  # Display this help
+kubectl gs update cluster --help
+
+# Update cluster version
+kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "30 Jan 22 12:00 UTC" --provider aws`
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	K8sConfigAccess clientcmd.ConfigAccess
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.K8sConfigAccess == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sConfigAccess must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Short:   shortDescription,
+		Long:    longDescription,
+		Example: examples,
+		Args:    cobra.ExactValidArgs(0),
+		RunE:    r.Run,
+		PreRunE: middleware.Compose(
+			renewtoken.Middleware(config.K8sConfigAccess),
+		),
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -26,7 +26,7 @@ Options:
   --name <cluster-name>             	Name of the cluster to update.
   --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
-  --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.
+  --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated, time format 'YYYY-MM-DD HH:MM'.
   --provider <provider> 		Name of the provider.`
 
 	examples = `  # Display this help
@@ -36,7 +36,7 @@ kubectl gs update cluster --help
 kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --provider aws
 
 # Schedule cluster update
-kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "30 Jan 22 12:00 UTC" --provider aws`
+kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "2022-01-01 10:00" --provider aws`
 )
 
 type Config struct {

--- a/cmd/update/cluster/error.go
+++ b/cmd/update/cluster/error.go
@@ -1,0 +1,50 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagError = &microerror.Error{
+	Kind: "invalidFlagError",
+}
+
+// IsInvalidFlag asserts invalidFlagError.
+func IsInvalidFlag(err error) bool {
+	return microerror.Cause(err) == invalidFlagError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var noResourcesError = &microerror.Error{
+	Kind: "noResourcesError",
+}
+
+// IsNoResources asserts noResourcesError.
+func IsNoResources(err error) bool {
+	return microerror.Cause(err) == noResourcesError
+}
+
+var notAllowedError = &microerror.Error{
+	Kind: "notAllowedError",
+}
+
+// IsNotAllowed asserts notAllowedError.
+func IsNotAllowed(err error) bool {
+	return microerror.Cause(err) == notAllowedError
+}

--- a/cmd/update/cluster/flag.go
+++ b/cmd/update/cluster/flag.go
@@ -29,7 +29,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ReleaseVersion, flagReleaseVersion, "", "Update the cluster to a release version. The release version must be higher than the current release version.")
 	_ = cmd.Flags().MarkHidden(flagReleaseVersion)
 
-	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
+	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
 	_ = cmd.Flags().MarkHidden(flagScheduledTime)
 
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Name of the provider.")
@@ -51,10 +51,6 @@ func (f *flag) Validate() error {
 
 	if f.ReleaseVersion == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagReleaseVersion)
-	}
-
-	if f.ScheduledTime == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagScheduledTime)
 	}
 
 	return nil

--- a/cmd/update/cluster/flag.go
+++ b/cmd/update/cluster/flag.go
@@ -24,16 +24,12 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the cluster to update.")
-	_ = cmd.Flags().MarkHidden(flagName)
 
 	cmd.Flags().StringVar(&f.ReleaseVersion, flagReleaseVersion, "", "Update the cluster to a release version. The release version must be higher than the current release version.")
-	_ = cmd.Flags().MarkHidden(flagReleaseVersion)
 
 	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
-	_ = cmd.Flags().MarkHidden(flagScheduledTime)
 
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Name of the provider.")
-	_ = cmd.Flags().MarkHidden(flagProvider)
 
 	f.config = genericclioptions.NewConfigFlags(true)
 	f.print = genericclioptions.NewPrintFlags("")

--- a/cmd/update/cluster/flag.go
+++ b/cmd/update/cluster/flag.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	flagName           = "name"
+	flagReleaseVersion = "release-version"
+	flagScheduledTime  = "scheduled-time"
+	flagProvider       = "provider"
+)
+
+type flag struct {
+	config         genericclioptions.RESTClientGetter
+	print          *genericclioptions.PrintFlags
+	Name           string
+	ReleaseVersion string
+	ScheduledTime  string
+	Provider       string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the cluster to update.")
+	_ = cmd.Flags().MarkHidden(flagName)
+
+	cmd.Flags().StringVar(&f.ReleaseVersion, flagReleaseVersion, "", "Update the cluster to a release version. The release version must be higher than the current release version.")
+	_ = cmd.Flags().MarkHidden(flagReleaseVersion)
+
+	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
+	_ = cmd.Flags().MarkHidden(flagScheduledTime)
+
+	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Name of the provider.")
+	_ = cmd.Flags().MarkHidden(flagProvider)
+
+	f.config = genericclioptions.NewConfigFlags(true)
+	f.print = genericclioptions.NewPrintFlags("")
+
+	// Merging current command flags and config flags,
+	// to be able to override kubectl-specific ones.
+	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())
+	f.print.AddFlags(cmd)
+}
+
+func (f *flag) Validate() error {
+	if f.Name == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagName)
+	}
+
+	if f.ReleaseVersion == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagReleaseVersion)
+	}
+
+	if f.ScheduledTime == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagScheduledTime)
+	}
+
+	return nil
+}

--- a/cmd/update/cluster/runner.go
+++ b/cmd/update/cluster/runner.go
@@ -1,0 +1,126 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/kubectl-gs/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+
+	service cluster.Interface
+
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		_ = cmd.Help()
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var err error
+
+	name := r.flag.Name
+	targetRelease := r.flag.ReleaseVersion
+	scheduledTime := r.flag.ScheduledTime
+	provider := r.flag.Provider
+
+	config := commonconfig.New(r.flag.config)
+	{
+		err = r.getService(config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	namespace, _, err := r.flag.config.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	getOptions := cluster.GetOptions{
+		Name:      name,
+		Namespace: namespace,
+		Provider:  provider,
+	}
+
+	resource, err := r.service.Get(ctx, getOptions)
+	if cluster.IsNotFound(err) {
+		return microerror.Maskf(notFoundError, "Cluster with name '%s' cannot be found in the '%s' namespace.\n", getOptions.Name, getOptions.Namespace)
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	patches := cluster.PatchOptions{
+		PatchSpecs: []cluster.PatchSpec{
+			{
+				Op:    "add",
+				Path:  fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(annotation.UpdateScheduleTargetRelease)),
+				Value: targetRelease,
+			},
+			{
+				Op:    "add",
+				Path:  fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(annotation.UpdateScheduleTargetTime)),
+				Value: scheduledTime,
+			},
+		},
+	}
+
+	err = r.service.Patch(ctx, resource.Object(), patches)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Fprintf(r.stdout, "Cluster '%s' is scheduled on '%v' to update to release version '%s'\n", name, scheduledTime, targetRelease)
+	return nil
+}
+
+func replaceToEscape(from string) string {
+	return strings.Replace(from, "/", "~1", -1)
+}
+
+func (r *runner) getService(config *commonconfig.CommonConfig) error {
+	if r.service != nil {
+		return nil
+	}
+
+	client, err := config.GetClient(r.logger)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	serviceConfig := cluster.Config{
+		Client: client,
+	}
+	r.service, err = cluster.New(serviceConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/cmd/update/cluster/runner.go
+++ b/cmd/update/cluster/runner.go
@@ -108,7 +108,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				},
 			},
 		}
-		messageFormat := "An upgrade of cluster %s to release %s has been scheduled for\n    %v, (%v)"
+		messageFormat := "An upgrade of cluster %s to release %s has been scheduled for\n\n    %v, (%v)"
 		msg = fmt.Sprintf(messageFormat, name, targetRelease, t.Format(time.RFC1123), t.Local().Format(time.RFC1123))
 	} else {
 		patches = cluster.PatchOptions{

--- a/cmd/update/cluster/runner.go
+++ b/cmd/update/cluster/runner.go
@@ -108,10 +108,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				},
 			},
 		}
-		messageFormat := `An upgrade of cluster %s to release %s has been scheduled for
-
-		%v, (%v)
-		`
+		messageFormat := "An upgrade of cluster %s to release %s has been scheduled for\n    %v, (%v)"
 		msg = fmt.Sprintf(messageFormat, name, targetRelease, t.Format(time.RFC1123), t.Local().Format(time.RFC1123))
 	} else {
 		patches = cluster.PatchOptions{

--- a/cmd/update/cluster/runner_test.go
+++ b/cmd/update/cluster/runner_test.go
@@ -27,7 +27,7 @@ func Test_run(t *testing.T) {
 		{
 			name:    "update cluster with a scheduled time",
 			storage: []runtime.Object{newCluster("abcd1", "default", "16.0.1"), newAWSCluster("abcd1", "default", "16.0.1")},
-			flags:   flag{Name: "abcd1", ReleaseVersion: "16.1.0", ScheduledTime: "30 Jan 22 12:00 UTC", Provider: "aws"},
+			flags:   flag{Name: "abcd1", ReleaseVersion: "16.1.0", ScheduledTime: "2022-01-01 01:00", Provider: "aws"},
 		},
 		{
 			name:    "update cluster immediately",

--- a/cmd/update/cluster/runner_test.go
+++ b/cmd/update/cluster/runner_test.go
@@ -1,0 +1,102 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	infrastructurev1alpha3 "github.com/giantswarm/apiextensions/v3/pkg/apis/infrastructure/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/kubectl-gs/internal/label"
+	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/kubeconfig"
+)
+
+func Test_run(t *testing.T) {
+	var testCases = []struct {
+		name    string
+		storage []runtime.Object
+		flags   flag
+	}{
+		{
+			name:    "update cluster",
+			storage: []runtime.Object{newCluster("abcd1", "default", "16.0.1"), newAWSCluster("abcd1", "default", "16.0.1")},
+			flags:   flag{Name: "abcd1", ReleaseVersion: "16.1.0", ScheduledTime: "30 Jan 22 12:00 UTC", Provider: "aws"},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			var err error
+
+			ctx := context.TODO()
+
+			fakeKubeConfig := kubeconfig.CreateFakeKubeConfig()
+
+			flag := &tc.flags
+			flag.print = genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault)
+			flag.config = genericclioptions.NewTestConfigFlags().WithClientConfig(fakeKubeConfig)
+
+			out := new(bytes.Buffer)
+			runner := &runner{
+				flag:    flag,
+				stdout:  out,
+				service: cluster.NewFakeService(tc.storage),
+			}
+
+			err = runner.run(ctx, nil, []string{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func newCluster(name, namespace, targetRelease string) *capiv1alpha3.Cluster {
+	c := &capiv1alpha3.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				capiv1alpha3.ClusterLabelName: name,
+				label.ReleaseVersion:          "16.0.1",
+			},
+			Annotations: map[string]string{
+				"cluster.giantswarm.io/description": "fake-cluster",
+			},
+		},
+	}
+
+	return c
+}
+
+func newAWSCluster(name, namespace, targetRelease string) *infrastructurev1alpha3.AWSCluster {
+	c := &infrastructurev1alpha3.AWSCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infrastructure.giantswarm.io/v1alpha3",
+			Kind:       "AWSCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				label.Cluster: name,
+			},
+			Annotations: map[string]string{
+				"cluster.giantswarm.io/description": "fake-cluster",
+			},
+		},
+	}
+
+	return c
+}

--- a/cmd/update/cluster/runner_test.go
+++ b/cmd/update/cluster/runner_test.go
@@ -25,9 +25,14 @@ func Test_run(t *testing.T) {
 		flags   flag
 	}{
 		{
-			name:    "update cluster",
+			name:    "update cluster with a scheduled time",
 			storage: []runtime.Object{newCluster("abcd1", "default", "16.0.1"), newAWSCluster("abcd1", "default", "16.0.1")},
 			flags:   flag{Name: "abcd1", ReleaseVersion: "16.1.0", ScheduledTime: "30 Jan 22 12:00 UTC", Provider: "aws"},
+		},
+		{
+			name:    "update cluster immediately",
+			storage: []runtime.Object{newCluster("abcd1", "default", "16.0.1"), newAWSCluster("abcd1", "default", "16.0.1")},
+			flags:   flag{Name: "abcd1", ReleaseVersion: "16.1.0", Provider: "aws"},
 		},
 	}
 

--- a/cmd/update/command.go
+++ b/cmd/update/command.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/giantswarm/kubectl-gs/cmd/update/app"
+	"github.com/giantswarm/kubectl-gs/cmd/update/cluster"
 )
 
 const (
@@ -59,6 +60,23 @@ func New(config Config) (*cobra.Command, error) {
 		}
 	}
 
+	var clusterCmd *cobra.Command
+	{
+		c := cluster.Config{
+			Logger: config.Logger,
+
+			K8sConfigAccess: config.K8sConfigAccess,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		clusterCmd, err = cluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	f := &flag{}
 
 	r := &runner{
@@ -78,6 +96,7 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(appCmd)
+	c.AddCommand(clusterCmd)
 
 	return c, nil
 }

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -2,8 +2,12 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
@@ -77,4 +81,20 @@ func (s *Service) getAll(ctx context.Context, provider, namespace string) (Resou
 	}
 
 	return clusterCollection, nil
+}
+
+func (s *Service) Patch(ctx context.Context, object runtime.Object, options PatchOptions) error {
+	var err error
+
+	bytes, err := json.Marshal(options.PatchSpecs)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.client.K8sClient.CtrlClient().Patch(ctx, object, client.RawPatch(types.JSONPatchType, bytes))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/pkg/data/domain/cluster/service_fake.go
+++ b/pkg/data/domain/cluster/service_fake.go
@@ -2,10 +2,14 @@ package cluster
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/kubectl-gs/pkg/data/client"
 )
@@ -50,4 +54,20 @@ func (ms *FakeService) Get(ctx context.Context, options GetOptions) (Resource, e
 	}
 
 	return result, nil
+}
+
+func (ms *FakeService) Patch(ctx context.Context, object runtime.Object, options PatchOptions) error {
+	var err error
+
+	bytes, err := json.Marshal(options.PatchSpecs)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = ms.service.client.K8sClient.CtrlClient().Patch(ctx, object, runtimeclient.RawPatch(types.JSONPatchType, bytes))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
 }

--- a/pkg/data/domain/cluster/spec.go
+++ b/pkg/data/domain/cluster/spec.go
@@ -16,11 +16,22 @@ type GetOptions struct {
 	Namespace string
 }
 
+type PatchOptions struct {
+	PatchSpecs []PatchSpec
+}
+
+type PatchSpec struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
 // Interface represents the contract for the clusters service.
 // Using this instead of a regular 'struct' makes mocking the
 // service in tests much simpler.
 type Interface interface {
 	Get(context.Context, GetOptions) (Resource, error)
+	Patch(context.Context, runtime.Object, PatchOptions) error
 }
 
 type Resource interface {


### PR DESCRIPTION
We want to allow users scheduling cluster updates via `kubectl-gs`.

I did try to find a place where we can support this. Currently we have `kubectl gs update app` and I added `kubectl gs update cluster` to that. If there's a better proposal I'm totally open about that.

Example:

Scheduling cluster updates
```
kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "2022-01-30 12:00" --provider aws
```

Update cluster immediately
```
kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --provider aws
```

Issue: https://github.com/giantswarm/giantswarm/issues/19989