### PR TITLE
Populate the nodepool release label value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Populate the nodepool release label for AWS provider
+
 ## [1.58.0] - 2021-12-14
 
 ### Added

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -60,6 +60,8 @@ func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
 		OnDemandPercentageAboveBaseCapacity: config.OnDemandPercentageAboveBaseCapacity,
 		Owner:                               config.Organization,
 		UseAlikeInstanceTypes:               config.UseAlikeInstanceTypes,
+		ReleaseVersion:                      config.ReleaseVersion,
+		ReleaseComponents:                   config.ReleaseComponents,
 	}
 
 	crs, err := aws.NewNodePoolCRs(crsConfig)


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--

Please consider:

- Add a user-friendly description of your change to `CHANGELOG.md`.

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.

- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.

- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.

- Are you making user-facing changes? Please ping team Rainbow to update any Management API guides in happa.

-->
