### PR TITLE
Adjust `login` to consider other prefixes while parsing the MC API URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust `login` to consider other prefixes while parsing the MC API endpoint.
+
 ## [1.58.1] - 2021-12-17
 
 ### Fixed

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -488,5 +488,8 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess) (string, error) 
 	reg := regexp.MustCompile(`:[0-9]+$`)
 	clusterServer = reg.ReplaceAllString(clusterServer, "")
 
+	// Some management clusters might have 'api.g8s' as prefix (example: Viking).
+	clusterServer = strings.TrimPrefix(clusterServer, "https://api.g8s.")
+
 	return strings.TrimPrefix(clusterServer, "https://g8s."), nil
 }


### PR DESCRIPTION
Viking has a different schema for the MC API hostname compared to other MCs:

```
$ opsctl show installation -i anaconda|yq -r .Services.k8s.Host
g8s.anaconda.vir.aws.k8s.3stripes.net:443

$ opsctl show installation -i viking|yq -r .Services.k8s.Host
api.g8s.eu-central-1.aws.cps.REDACTED.com:443
```

This makes kubeconfig creation to fail.
This PR fixes this edge case.