### PR TITLE
Add in-cluster flag to template app command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--in-cluster` flag to `template app` command to support installation of MC apps.
+
 ### Fixed
 
 - Adjust `login` to consider other prefixes while parsing the MC API endpoint.

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -13,6 +15,7 @@ const (
 	flagCatalog                    = "catalog"
 	flagCluster                    = "cluster"
 	flagDefaultingEnabled          = "defaulting-enabled"
+	flagInCluster                  = "in-cluster"
 	flagName                       = "name"
 	flagNamespace                  = "namespace"
 	flagNamespaceConfigAnnotations = "namespace-annotations"
@@ -27,6 +30,7 @@ type flag struct {
 	Catalog                        string
 	Cluster                        string
 	DefaultingEnabled              bool
+	InCluster                      bool
 	Name                           string
 	Namespace                      string
 	Version                        string
@@ -43,6 +47,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Name of the cluster the app will be deployed to.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
+	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, true, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagCluster))
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
 	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user secrets YAML file.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")
@@ -60,7 +65,7 @@ func (f *flag) Validate() error {
 	if f.Namespace == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagNamespace)
 	}
-	if f.Cluster == "" {
+	if !f.InCluster && f.Cluster == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagCluster)
 	}
 	if f.Version == "" {

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -47,7 +47,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Name of the cluster the app will be deployed to.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
-	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, true, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagCluster))
+	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, false, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagCluster))
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
 	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user secrets YAML file.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -47,11 +47,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var err error
 
 	appConfig := templateapp.Config{
+		AppName:           r.flag.AppName,
 		Catalog:           r.flag.Catalog,
-		Name:              r.flag.Name,
-		Namespace:         r.flag.Namespace,
 		Cluster:           r.flag.Cluster,
 		DefaultingEnabled: r.flag.DefaultingEnabled,
+		InCluster:         r.flag.InCluster,
+		Name:              r.flag.Name,
+		Namespace:         r.flag.Namespace,
 		Version:           r.flag.Version,
 	}
 
@@ -61,9 +63,16 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			return microerror.Mask(err)
 		}
 
+		var assetName string
+		if r.flag.InCluster {
+			assetName = key.GenerateAssetName(r.flag.Name, "userconfig")
+		} else {
+			assetName = key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster)
+		}
+
 		secretConfig := templateapp.SecretConfig{
 			Data:      userConfigSecretData,
-			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
+			Name:      assetName,
 			Namespace: r.flag.Cluster,
 		}
 		userSecret, err := templateapp.NewSecret(secretConfig)
@@ -86,9 +95,17 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				return microerror.Mask(err)
 			}
 		}
+
+		var assetName string
+		if r.flag.InCluster {
+			assetName = key.GenerateAssetName(r.flag.Name, "userconfig")
+		} else {
+			assetName = key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster)
+		}
+
 		configMapConfig := templateapp.ConfigMapConfig{
 			Data:      configMapData,
-			Name:      key.GenerateAssetName(r.flag.Name, "userconfig", r.flag.Cluster),
+			Name:      assetName,
 			Namespace: r.flag.Cluster,
 		}
 		userConfigMap, err := templateapp.NewConfigMap(configMapConfig)

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -1,9 +1,14 @@
 package key
 
 const AppCRTemplate = `
-{{- .UserConfigConfigMap -}}
+{{- if .UserConfigConfigMap -}}
+---
+{{ .UserConfigConfigMap -}}
+{{- end -}}
+{{- if .UserConfigSecret -}}
 ---
 {{ .UserConfigSecret -}}
+{{- end -}}
 ---
 {{ .AppCR -}}
 `

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -39,22 +39,25 @@ type ConfigMapConfig struct {
 func NewAppCR(config Config) ([]byte, error) {
 	userConfig := applicationv1alpha1.AppSpecUserConfig{}
 
+	var namespace string
+	if config.InCluster {
+		namespace = config.Namespace
+	} else {
+		namespace = config.Cluster
+	}
+
 	if config.UserConfigConfigMapName != "" {
 		userConfig.ConfigMap = applicationv1alpha1.AppSpecUserConfigConfigMap{
 			Name:      config.UserConfigConfigMapName,
-			Namespace: config.Cluster,
+			Namespace: namespace,
 		}
 	}
 
 	if config.UserConfigSecretName != "" {
 		userConfig.Secret = applicationv1alpha1.AppSpecUserConfigSecret{
 			Name:      config.UserConfigSecretName,
-			Namespace: config.Cluster,
+			Namespace: namespace,
 		}
-	}
-
-	if config.AppName == "" {
-		config.AppName = config.Name
 	}
 
 	appCR := &applicationv1alpha1.App{
@@ -64,7 +67,7 @@ func NewAppCR(config Config) ([]byte, error) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.AppName,
-			Namespace: config.Cluster,
+			Namespace: namespace,
 		},
 		Spec: applicationv1alpha1.AppSpec{
 			Catalog:   config.Catalog,
@@ -82,10 +85,17 @@ func NewAppCR(config Config) ([]byte, error) {
 		},
 	}
 
+	if config.InCluster {
+		appCR.SetLabels(map[string]string{
+			"app-operator.giantswarm.io/version": "0.0.0",
+		})
+	}
+
 	if !config.DefaultingEnabled && !config.InCluster {
 		appCR.SetLabels(map[string]string{
 			"app-operator.giantswarm.io/version": "1.0.0",
 		})
+
 		appCR.Spec.Config = applicationv1alpha1.AppSpecConfig{
 			ConfigMap: applicationv1alpha1.AppSpecConfigConfigMap{
 				Name:      config.Cluster + "-cluster-values",

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -14,6 +14,7 @@ type Config struct {
 	Catalog                    string
 	Cluster                    string
 	DefaultingEnabled          bool
+	InCluster                  bool
 	Name                       string
 	Namespace                  string
 	NamespaceConfigAnnotations map[string]string
@@ -70,7 +71,7 @@ func NewAppCR(config Config) ([]byte, error) {
 			Name:      config.Name,
 			Namespace: config.Namespace,
 			KubeConfig: applicationv1alpha1.AppSpecKubeConfig{
-				InCluster: false,
+				InCluster: config.InCluster,
 			},
 			UserConfig: userConfig,
 			Version:    config.Version,
@@ -81,7 +82,7 @@ func NewAppCR(config Config) ([]byte, error) {
 		},
 	}
 
-	if !config.DefaultingEnabled {
+	if !config.DefaultingEnabled && !config.InCluster {
 		appCR.SetLabels(map[string]string{
 			"app-operator.giantswarm.io/version": "1.0.0",
 		})
@@ -178,7 +179,7 @@ func printAppCR(appCR *v1alpha1.App, defaultingEnabled bool) ([]byte, error) {
 	if defaultingEnabled {
 		delete(spec, "config")
 		spec["kubeConfig"] = map[string]bool{
-			"inCluster": false,
+			"inCluster": appCR.Spec.KubeConfig.InCluster,
 		}
 	}
 

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -18,6 +18,7 @@ func Test_NewAppCR(t *testing.T) {
 		{
 			name: "case 0: flawless flow",
 			config: Config{
+				AppName:           "nginx-ingress-controller-app",
 				Catalog:           "giantswarm",
 				Cluster:           "eggs2",
 				DefaultingEnabled: true,
@@ -30,6 +31,7 @@ func Test_NewAppCR(t *testing.T) {
 		{
 			name: "case 1: defaulting disabled",
 			config: Config{
+				AppName:           "nginx-ingress-controller-app",
 				Catalog:           "giantswarm",
 				Cluster:           "eggs2",
 				DefaultingEnabled: false,
@@ -42,6 +44,7 @@ func Test_NewAppCR(t *testing.T) {
 		{
 			name: "case 2: user values",
 			config: Config{
+				AppName:                 "nginx-ingress-controller-app",
 				Catalog:                 "giantswarm",
 				Cluster:                 "eggs2",
 				DefaultingEnabled:       true,
@@ -55,6 +58,7 @@ func Test_NewAppCR(t *testing.T) {
 		{
 			name: "case 3: user secrets with defauting disabled",
 			config: Config{
+				AppName:              "nginx-ingress-controller-app",
 				Catalog:              "giantswarm",
 				Cluster:              "eggs2",
 				DefaultingEnabled:    false,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20230

Currently `kubectl-gs template app` can only create App CRs for WC Apps. To support creating clusters using App CRs in a CAPI management cluster, I am adding a new flag `--in-cluster` which will install the app with `.kubeconfig.inCluster` set to `true` and adjust namespaces and names to suit our naming conventions.

<!--

Please consider:

- Add a user-friendly description of your change to `CHANGELOG.md`.

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.

- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.

- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.

- Are you making user-facing changes? Please ping team Rainbow to update any Management API guides in happa.

-->
