### PR TITLE
In the `login` command, only delete the created CertConfig resource instead of all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
+- `login` command: Prevent deletion of all CertConfig resources in a namespace, instead delete only one.
 - Adjust `login` to consider other prefixes while parsing the MC API endpoint.
 
 ## [1.58.1] - 2021-12-17

--- a/pkg/data/domain/clientcert/service.go
+++ b/pkg/data/domain/clientcert/service.go
@@ -47,10 +47,7 @@ func (s *Service) Create(ctx context.Context, clientCert *ClientCert) error {
 }
 
 func (s *Service) Delete(ctx context.Context, clientCert *ClientCert) error {
-	kp := clientCert.Object()
-	namespace := runtimeclient.InNamespace(clientCert.CertConfig.Namespace)
-
-	err := s.client.K8sClient.CtrlClient().DeleteAllOf(ctx, kp, namespace)
+	err := s.client.K8sClient.CtrlClient().Delete(ctx, clientCert.CertConfig)
 	if apierrors.IsNotFound(err) {
 		// Resource was already deleted.
 	} else if err != nil {


### PR DESCRIPTION
<!--

Please consider:

- Add a user-friendly description of your change to `CHANGELOG.md`.

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.

- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.

- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.

- Are you making user-facing changes? Please ping team Rainbow to update any Management API guides in happa.

-->
