### PR TITLE
[WIP] Add `organization` flag for templating App CR in org namespace

### DIFF
--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -20,6 +20,7 @@ const (
 	flagNamespace                  = "namespace"
 	flagNamespaceConfigAnnotations = "namespace-annotations"
 	flagNamespaceConfigLabels      = "namespace-labels"
+	flagOrganization               = "organization"
 	flagUserConfigMap              = "user-configmap"
 	flagUserSecret                 = "user-secret"
 	flagVersion                    = "version"
@@ -33,6 +34,7 @@ type flag struct {
 	InCluster                      bool
 	Name                           string
 	Namespace                      string
+	Organization                   string
 	Version                        string
 	flagNamespaceConfigAnnotations []string
 	flagNamespaceConfigLabels      []string
@@ -46,6 +48,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the app in the Catalog.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Name of the cluster the app will be deployed to.")
+	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
 	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, false, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagCluster))
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
@@ -68,6 +71,12 @@ func (f *flag) Validate() error {
 	if !f.InCluster && f.Cluster == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagCluster)
 	}
+	// Once we fully migrate to org namespace, checking for
+	// the `organization` flag should be mandatory.
+	//
+	/*if !f.InCluster && f.Organization == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagOrganization)
+	}*/
 	if f.Version == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagVersion)
 	}

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/giantswarm/microerror"
@@ -50,6 +52,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		appName = r.flag.Name
 	}
 
+	// Since organization may be provided in a mixed-cases form,
+	// make sure it is lowercased before using.
+	organization := strings.ToLower(r.flag.Organization)
+
 	appConfig := templateapp.Config{
 		AppName:           appName,
 		Catalog:           r.flag.Catalog,
@@ -58,6 +64,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		InCluster:         r.flag.InCluster,
 		Name:              r.flag.Name,
 		Namespace:         r.flag.Namespace,
+		Organization:      organization,
 		Version:           r.flag.Version,
 	}
 
@@ -68,9 +75,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		assetName = key.GenerateAssetName(appName, "userconfig", r.flag.Cluster)
 	}
 
+	// If organization is passed to the command use it as the indicator for
+	// templating App CR in org namespace.
 	var namespace string
 	if r.flag.InCluster {
 		namespace = r.flag.Namespace
+	} else if appConfig.Organization != "" {
+		namespace = fmt.Sprintf("org-%s", appConfig.Organization)
 	} else {
 		namespace = r.flag.Cluster
 	}

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -82,6 +82,20 @@ func Test_NewAppCR(t *testing.T) {
 			},
 			expectedGoldenFile: "app_override_app_name_yaml_output.golden",
 		},
+		{
+			name: "case 5: flawless flow for organization",
+			config: Config{
+				AppName:           "nginx-ingress-controller-app",
+				Catalog:           "giantswarm",
+				Cluster:           "eggs2",
+				DefaultingEnabled: true,
+				Name:              "nginx-ingress-controller-app",
+				Namespace:         "kube-system",
+				Organization:      "giantswarm",
+				Version:           "1.17.0",
+			},
+			expectedGoldenFile: "app_flawless_flow_organization_yaml_output.golden",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/template/app/testdata/app_flawless_flow_organization_yaml_output.golden
+++ b/pkg/template/app/testdata/app_flawless_flow_organization_yaml_output.golden
@@ -1,0 +1,14 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    giantswarm.io/cluster: eggs2
+  name: nginx-ingress-controller-app
+  namespace: org-giantswarm
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: false
+  name: nginx-ingress-controller-app
+  namespace: kube-system
+  version: 1.17.0


### PR DESCRIPTION
### Description

This PR is part of the ongoing migration towards handling App CRs in the org namespace instead of cluster namespaces. 

Related issue: https://github.com/giantswarm/giantswarm/issues/20443
Related PRs: https://github.com/giantswarm/cluster-apps-operator/pull/148

This PR adds `organization` flag to the `template app` command. This flag is now optional, and thus is not validated, to support old behavior of templating App CR into cluster namespace.

Upon passing this new flag to the command, App CR will be templated for the org-namespace.

### Examples

#### Without `organization` flag

1. `kubectl gs template app --name hello-world --version 0.1.0 --namespace default --cluster ab23c --catalog giantswarm`

```yaml
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: ab23c
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: false
  name: hello-world
  namespace: default
  version: 0.1.0
```

2. `kubectl gs template app --name hello-world --version 0.1.0 --namespace default --cluster ab23c --catalog giantswarm --user-configmap /tmp/userconfig.yaml`

```yaml
---
apiVersion: v1
data:
  values: |
    doesThisConfigMakeSense:
      notReally: true
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: hello-world-userconfig-ab23c
  namespace: ab23c
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  name: hello-world
  namespace: ab23c
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: false
  name: hello-world
  namespace: default
  userConfig:
    configMap:
      name: hello-world-userconfig-ab23c
      namespace: ab23c
  version: 0.1.0
```

#### With `organization` flag

1. `kubectl gs template app --name hello-world --version 0.1.0 --namespace default --cluster ab23c --catalog giantswarm --organization giantswarm`

```yaml
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    giantswarm.io/cluster: ab23c
  name: hello-world
  namespace: org-giantswarm
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: false
  name: hello-world
  namespace: default
  version: 0.1.0
```

2. `kubectl template app --name hello-world --version 0.1.0 --namespace default --cluster ab23c --catalog giantswarm --organization giantswarm --user-configmap /tmp/userconfig.yaml`

```yaml
---
apiVersion: v1
data:
  values: |
    doesThisConfigMakeSense:
      notReally: true
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: hello-world-userconfig-ab23c
  namespace: org-giantswarm
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    giantswarm.io/cluster: ab23c
  name: hello-world
  namespace: org-giantswarm
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: false
  name: hello-world
  namespace: default
  userConfig:
    configMap:
      name: hello-world-userconfig-ab23c
      namespace: org-giantswarm
  version: 0.1.0
```