### PR TITLE
Allow configuration of cluster-openstack and default-apps-openstack catalogs

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -135,10 +135,10 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.OpenStack.NodeCIDR, flagOpenStackNodeCIDR, "", "CIDR used for the nodes.")
 
 	// OpenStack App only.
-	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppCatalog, flagClusterAppCatalog, "giantswarm-catalog", "Cluster App version to be installed. (OpenStack App CR only).")
-	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppVersion, flagClusterAppVersion, "0.2.2", "Cluster App version to be installed. (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppCatalog, flagClusterAppCatalog, "giantswarm", "Cluster App version to be installed. (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppVersion, flagClusterAppVersion, "0.1.0", "Cluster App version to be installed. (OpenStack App CR only).")
 	cmd.Flags().StringVar(&f.ClusterApp.ClusterUserConfigMap, flagClusterUserConfigMap, "", "Path to the user values configmap YAML file for Cluster App (OpenStack App CR only).")
-	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsAppCatalog, flagDefaultAppsAppCatalog, "giantswarm-catalog", "Default Apps App version to be installed. (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsAppCatalog, flagDefaultAppsAppCatalog, "giantswarm", "Default Apps App version to be installed. (OpenStack App CR only).")
 	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsAppVersion, flagDefaultAppsAppVersion, "0.1.0", "Default Apps App version to be installed. (OpenStack App CR only).")
 	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsUserConfigMap, flagDefaultAppsUserConfigMap, "", "Path to the user values configmap YAML file for Default Apps App (OpenStack App CR only).")
 	cmd.Flags().BoolVar(&f.ClusterApp.ClusterTopology, flagClusterTopology, false, "Templated cluster as an App CR. (OpenStack App CR only).")

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -22,9 +22,11 @@ const (
 	flagAWSControlPlaneSubnet = "control-plane-subnet"
 
 	// Cluster App only.
+	flagClusterAppCatalog        = "cluster-app-catalog"
 	flagClusterAppVersion        = "cluster-app-version"
 	flagClusterUserConfigMap     = "cluster-user-configmap"
 	flagClusterTopology          = "cluster-topology"
+	flagDefaultAppsAppCatalog    = "default-apps-app-catalog"
 	flagDefaultAppsAppVersion    = "default-apps-app-version"
 	flagDefaultAppsUserConfigMap = "default-apps-user-configmap"
 
@@ -76,11 +78,15 @@ type openStackFlag struct {
 }
 
 type clusterAppFlag struct {
-	ClusterUserConfigMap     string
-	ClusterAppVersion        string
-	ClusterTopology          bool
-	DefaultAppsUserConfigMap string
+	ClusterTopology bool
+
+	ClusterAppCatalog    string
+	ClusterAppVersion    string
+	ClusterUserConfigMap string
+
 	DefaultAppsAppVersion    string
+	DefaultAppsAppCatalog    string
+	DefaultAppsUserConfigMap string
 }
 
 type flag struct {
@@ -129,10 +135,12 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.OpenStack.NodeCIDR, flagOpenStackNodeCIDR, "", "CIDR used for the nodes.")
 
 	// OpenStack App only.
+	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppCatalog, flagClusterAppCatalog, "giantswarm-catalog", "Cluster App version to be installed. (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppVersion, flagClusterAppVersion, "0.2.2", "Cluster App version to be installed. (OpenStack App CR only).")
 	cmd.Flags().StringVar(&f.ClusterApp.ClusterUserConfigMap, flagClusterUserConfigMap, "", "Path to the user values configmap YAML file for Cluster App (OpenStack App CR only).")
-	cmd.Flags().StringVar(&f.ClusterApp.ClusterAppVersion, flagClusterAppVersion, "0.1.0", "Cluster App version to be installed. (OpenStack App CR only).")
-	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsUserConfigMap, flagDefaultAppsUserConfigMap, "", "Path to the user values configmap YAML file for Default Apps App (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsAppCatalog, flagDefaultAppsAppCatalog, "giantswarm-catalog", "Default Apps App version to be installed. (OpenStack App CR only).")
 	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsAppVersion, flagDefaultAppsAppVersion, "0.1.0", "Default Apps App version to be installed. (OpenStack App CR only).")
+	cmd.Flags().StringVar(&f.ClusterApp.DefaultAppsUserConfigMap, flagDefaultAppsUserConfigMap, "", "Path to the user values configmap YAML file for Default Apps App (OpenStack App CR only).")
 	cmd.Flags().BoolVar(&f.ClusterApp.ClusterTopology, flagClusterTopology, false, "Templated cluster as an App CR. (OpenStack App CR only).")
 
 	// TODO: Make these flags visible once we have a better method for displaying provider-specific flags.
@@ -149,9 +157,11 @@ func (f *flag) Init(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden(flagOpenStackNodeCIDR)
 
 	_ = cmd.Flags().MarkHidden(flagClusterTopology)
+	_ = cmd.Flags().MarkHidden(flagClusterAppCatalog)
 	_ = cmd.Flags().MarkHidden(flagClusterAppVersion)
-	_ = cmd.Flags().MarkHidden(flagDefaultAppsAppVersion)
 	_ = cmd.Flags().MarkHidden(flagClusterUserConfigMap)
+	_ = cmd.Flags().MarkHidden(flagDefaultAppsAppCatalog)
+	_ = cmd.Flags().MarkHidden(flagDefaultAppsAppVersion)
 	_ = cmd.Flags().MarkHidden(flagDefaultAppsUserConfigMap)
 
 	// Common.

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -81,7 +81,7 @@ func WriteOpenStackTemplateAppCR(ctx context.Context, config ClusterCRsConfig) e
 
 	clusterAppConfig := templateapp.Config{
 		AppName:   config.Name,
-		Catalog:   "control-plane-catalog",
+		Catalog:   config.ClusterAppCatalog,
 		InCluster: true,
 		Name:      "cluster-openstack",
 		Namespace: fmt.Sprintf("org-%s", config.Organization),
@@ -90,7 +90,7 @@ func WriteOpenStackTemplateAppCR(ctx context.Context, config ClusterCRsConfig) e
 
 	defaultAppsAppConfig := templateapp.Config{
 		AppName:   fmt.Sprintf("%s-default-apps", config.Name),
-		Catalog:   "default",
+		Catalog:   config.DefaultAppsAppCatalog,
 		InCluster: true,
 		Name:      "default-apps-openstack",
 		Namespace: fmt.Sprintf("org-%s", config.Organization),

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -53,8 +53,10 @@ type ClusterCRsConfig struct {
 	PodsCIDR       string
 
 	// App settings
+	ClusterAppCatalog           string
 	ClusterAppUserConfigMap     string
 	ClusterAppVersion           string
+	DefaultAppsAppCatalog       string
 	DefaultAppsAppUserConfigMap string
 	DefaultAppsAppVersion       string
 }

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -79,8 +79,10 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			RootVolumeSourceType: r.flag.OpenStack.RootVolumeSourceType,
 			RootVolumeSourceUUID: r.flag.OpenStack.RootVolumeSourceUUID,
 
+			ClusterAppCatalog:           r.flag.ClusterApp.ClusterAppCatalog,
 			ClusterAppVersion:           r.flag.ClusterApp.ClusterAppVersion,
 			ClusterAppUserConfigMap:     r.flag.ClusterApp.ClusterUserConfigMap,
+			DefaultAppsAppCatalog:       r.flag.ClusterApp.DefaultAppsAppCatalog,
 			DefaultAppsAppVersion:       r.flag.ClusterApp.DefaultAppsAppVersion,
 			DefaultAppsAppUserConfigMap: r.flag.ClusterApp.DefaultAppsUserConfigMap,
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/586

Adds two new flags `--cluster-app-catalog` and `--defaulta-apps-app-catalog` to simplify testing of apps in test catalogs.

Not adding a changelog entry as this adds functionality to a previous unreleased PR https://github.com/giantswarm/kubectl-gs/pull/635

Sample output with `kubectl-gs template cluster --provider openstack --cluster-topology --organization giantswarm-2 --cluster-app-version 1.2.3-abc --name thom1 --cluster-app-catalog giantswarm-test --default-apps-app-version 0.0.0-def --default-apps-app-catalog giantswarm-test`:
```
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
  name: thom1
  namespace: org-giantswarm-2
spec:
  catalog: giantswarm-test
  config:
    configMap:
      name: ""
      namespace: ""
    secret:
      name: ""
      namespace: ""
  kubeConfig:
    context:
      name: ""
    inCluster: true
    secret:
      name: ""
      namespace: ""
  name: cluster-openstack
  namespace: org-giantswarm-2
  version: 1.2.3-abc
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
  name: thom1-default-apps
  namespace: org-giantswarm-2
spec:
  catalog: giantswarm-test
  config:
    configMap:
      name: ""
      namespace: ""
    secret:
      name: ""
      namespace: ""
  kubeConfig:
    context:
      name: ""
    inCluster: true
    secret:
      name: ""
      namespace: ""
  name: default-apps-openstack
  namespace: org-giantswarm-2
  version: 0.0.0-def
```
<!--

Please consider:

- Add a user-friendly description of your change to `CHANGELOG.md`.

- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.

- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.

- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.

- Are you making user-facing changes? Please ping team Rainbow to update any Management API guides in happa.

-->
