### PR TITLE
Use v1beta1 types on Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add support to `template cluster --provider openstack` for templating clusters as App CRs.
 
+### Changed
+
+- Use `v1beta1` api version when templating ClusterAPI manifests on Azure.
+
 ## [1.58.2] - 2022-01-13
 
 ### Added

--- a/cmd/template/cluster/provider/templates/azure/azure_cluster.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/azure_cluster.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureCluster
 metadata:
   labels:

--- a/cmd/template/cluster/provider/templates/azure/azure_machine_template.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/azure_machine_template.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
   labels:
@@ -11,6 +11,11 @@ metadata:
   namespace: {{ .Namespace }}
 spec:
   template:
+    metadata:
+      labels:
+        "release.giantswarm.io/version": "{{ .Version }}"
+        "giantswarm.io/organization": "{{ .Organization }}"
+        "cluster.x-k8s.io/watch-filter": "capi"
     spec:
       dataDisks:
       - diskSizeGB: 256

--- a/cmd/template/cluster/provider/templates/azure/bastion_azure_machine_template.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/bastion_azure_machine_template.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
   labels:

--- a/cmd/template/cluster/provider/templates/azure/bastion_machine_deployment.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/bastion_machine_deployment.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   creationTimestamp: null
@@ -33,7 +33,7 @@ spec:
         dataSecretName: {{ .Name }}-bastion
       clusterName: {{ .Name }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachineTemplate
         name: {{ .Name }}-bastion
       version: v0.0.0

--- a/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   annotations:
@@ -12,17 +12,15 @@ metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:
-{{- if .PodsCIDR }}
   clusterNetwork:
     pods:
       cidrBlocks:
-      - {{ .PodsCIDR }}
-{{- end }}
+      - {{ or .PodsCIDR "192.168.0.0/16" }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
     name: {{ .Name }}-control-plane
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureCluster
     name: {{ .Name }}

--- a/cmd/template/cluster/provider/templates/azure/kubeadm_control_plane.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/kubeadm_control_plane.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
   labels:
@@ -99,7 +99,7 @@ spec:
       shell: /bin/bash
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: AzureMachineTemplate
       name: {{ .Name }}-control-plane
   replicas: 1

--- a/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/azure_machine_pool.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachinePool
 metadata:
   name: {{ .Name }}

--- a/cmd/template/nodepool/provider/templates/azure/kubeadm_config.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/kubeadm_config.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfig
 metadata:
   name: {{ .Name }}

--- a/cmd/template/nodepool/provider/templates/azure/machine_pool.yaml.tmpl
+++ b/cmd/template/nodepool/provider/templates/azure/machine_pool.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: {{ .Name }}
@@ -19,12 +19,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfig
           name: {{ .Name }}
       clusterName: {{ .ClusterName }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureMachinePool
         name: {{ .Name }}
       version: {{ .KubernetesVersion }}


### PR DESCRIPTION
This PR updates the CAPI manifest used to template Azure clusters from v1alpha4 to v1beta1, which is the latest CAPI version.

[We pass the `allocate-node-cidrs` to controller-manager](https://github.com/giantswarm/kyverno-policies/pull/98) , and that requires to set the pod cidrs on the `Cluster` CR. This PR also adds a default for that.