### PR TITLE
Add catalog-namespace flag to template app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add support for templating App CRs in organization namespace.
+- Add `--catalog-namespace` flag to `template app`.
 
 ## [1.60.0] - 2022-01-27
 

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -13,6 +13,7 @@ import (
 const (
 	flagAppName                    = "app-name"
 	flagCatalog                    = "catalog"
+	flagCatalogNamespace           = "catalog-namespace"
 	flagCluster                    = "cluster"
 	flagDefaultingEnabled          = "defaulting-enabled"
 	flagInCluster                  = "in-cluster"
@@ -29,6 +30,7 @@ const (
 type flag struct {
 	AppName                        string
 	Catalog                        string
+	CatalogNamespace               string
 	Cluster                        string
 	DefaultingEnabled              bool
 	InCluster                      bool
@@ -45,6 +47,7 @@ type flag struct {
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AppName, flagAppName, "", "Optionally set a different name for the App CR.")
 	cmd.Flags().StringVar(&f.Catalog, flagCatalog, "", "Catalog name where app is stored.")
+	cmd.Flags().StringVar(&f.CatalogNamespace, flagCatalogNamespace, "", "Catalog namespace where Catalog CR is stored if outside the default namespace.")
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the app in the Catalog.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the app will be deployed.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Name of the cluster the app will be deployed to.")

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -59,6 +59,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	appConfig := templateapp.Config{
 		AppName:           appName,
 		Catalog:           r.flag.Catalog,
+		CatalogNamespace:  r.flag.CatalogNamespace,
 		Cluster:           r.flag.Cluster,
 		DefaultingEnabled: r.flag.DefaultingEnabled,
 		InCluster:         r.flag.InCluster,

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -18,6 +18,7 @@ import (
 type Config struct {
 	AppName                    string
 	Catalog                    string
+	CatalogNamespace           string
 	Cluster                    string
 	DefaultingEnabled          bool
 	InCluster                  bool
@@ -100,6 +101,10 @@ func NewAppCR(config Config) ([]byte, error) {
 				Labels:      config.NamespaceConfigLabels,
 			},
 		},
+	}
+
+	if config.CatalogNamespace != "" {
+		appCR.Spec.CatalogNamespace = config.CatalogNamespace
 	}
 
 	if !config.DefaultingEnabled && !config.InCluster {


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/giantswarm/issues/19941

> If the Catalog CR is not in the default namespace you need to set the catalog namespace to the organization namespace where it is stored. This can be done using kubectl gs template app.

I somehow missed in testing that this flag didn't exist yet. Getting it sorted.


