### PR TITLE
Improve the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,14 @@
-<!--
+_Description goes here_
 
-Please consider:
+---
 
-- Add a user-friendly description of your change to `CHANGELOG.md`.
+As the creator of a pull request, please consider:
 
-- Provide a link to the issue, and please describe the goal you are trying to accomplish in this description.
+- [ ] Describe the goal you are trying to accomplish here, above the line.
+- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
+- [ ] Provide a link to the issue you are solving or working towards, if available.
+- [ ] Request SIG UX for review. They care about almost all user-facing changes.
+- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
+- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)
 
-- SIG UX cares about almost all changes here and is always happy to offer feedback. Simply request a review.
-
-- Our public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) may need an update to reflect the change you are making.
-
-- Are you making user-facing changes? Please ping team Rainbow to update any Management API guides in happa.
-
--->
+Feel free to remove this checklist when done.


### PR DESCRIPTION
This PR attempts to improve the PR template to

- Make sure breaking changes are labelled as such (which can then be used in release automation)
- Make the checklist easier to use.
- Make it visible (instead of hidden through HTML comments)

I'm also removing `Please ping team Rainbow ...` because we are pinged automatically as CODEOWNER.