### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+# Configuration for GitHub automatic release notes.
+# See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Note: changes here should also be reflected in pull_request_template.md
+
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - dev-change
+      - refactor
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: New features
+      labels:
+        - feature
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
This adds configuration for Github's automatic release notes feature.

The main idea here is to have breaking changes mentioned in their own section, if there are any.
