### PR TITLE
Add `--keep-context` flag to `login` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add support for templating App CRs in organization namespace.
 - Add `--catalog-namespace` flag to `template app`.
+- Add `--keep-context` flag to `login`.
 
 ## [1.60.0] - 2022-01-27
 
@@ -377,7 +378,7 @@ If you are upgrading from an earlier releases, apply these changes to migrate an
 ### Changed
 
 - Extend `template app` to only output required fields, the flag `--defaulting-enabled`
-can be set to false to disable this.
+  can be set to false to disable this.
 
 ## [1.29.2] - 2021-06-17
 
@@ -730,7 +731,7 @@ This release supports rendering for CRs:
 - `AppCatalog`
 - `App`
 
-[Unreleased]: https://github.com/giantswarm/giantswarm/compare/v1.60.0...HEAD
+[unreleased]: https://github.com/giantswarm/giantswarm/compare/v1.60.0...HEAD
 [1.60.0]: https://github.com/giantswarm/giantswarm/compare/v1.59.0...v1.60.0
 [1.59.0]: https://github.com/giantswarm/giantswarm/compare/v1.58.2...v1.59.0
 [1.58.2]: https://github.com/giantswarm/kubectl-gs/compare/v1.58.1...v1.58.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,7 +383,7 @@ If you are upgrading from an earlier releases, apply these changes to migrate an
 ### Changed
 
 - Extend `template app` to only output required fields, the flag `--defaulting-enabled`
-  can be set to false to disable this.
+can be set to false to disable this.
 
 ## [1.29.2] - 2021-06-17
 

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -26,7 +26,7 @@ type authInfo struct {
 
 // storeCredentials stores the installation's CA certificate, and
 // updates the kubeconfig with the configuration for the k8s api access.
-func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult authInfo, fs afero.Fs, internalAPI bool) error {
+func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult authInfo, fs afero.Fs, internalAPI bool, keepContext bool) error {
 	config, err := k8sConfigAccess.GetStartingConfig()
 	if err != nil {
 		return microerror.Mask(err)
@@ -105,8 +105,10 @@ func storeCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.In
 		// Add context configuration to config.
 		config.Contexts[contextName] = initialContext
 
-		// Select newly created context as current.
-		config.CurrentContext = contextName
+		if !keepContext {
+			// Select newly created context as current.
+			config.CurrentContext = contextName
+		}
 	}
 
 	err = clientcmd.ModifyConfig(k8sConfigAccess, *config, false)

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -13,6 +13,7 @@ const (
 	flagClusterAdmin   = "cluster-admin"
 	flagInternalAPI    = "internal-api"
 	callbackServerPort = "callback-port"
+	flagKeepContext    = "keep-context"
 
 	flagWCName              = "workload-cluster"
 	flagWCOrganization      = "organization"
@@ -26,6 +27,7 @@ type flag struct {
 	CallbackServerPort int
 	ClusterAdmin       bool
 	InternalAPI        bool
+	KeepContext        bool
 
 	WCName              string
 	WCOrganization      string
@@ -41,6 +43,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.CallbackServerPort, callbackServerPort, 0, "TCP port to use by the OIDC callback server. If not specified, a free port will be selected randomly.")
 	cmd.Flags().BoolVar(&f.ClusterAdmin, flagClusterAdmin, false, "Login with cluster-admin access.")
 	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
+	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current context.")
 
 	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("Organization that owns the workload cluster. Requires --%s.", flagWCName))

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -43,7 +43,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.CallbackServerPort, callbackServerPort, 0, "TCP port to use by the OIDC callback server. If not specified, a free port will be selected randomly.")
 	cmd.Flags().BoolVar(&f.ClusterAdmin, flagClusterAdmin, false, "Login with cluster-admin access.")
 	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
-	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current context.")
+	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
 
 	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("Organization that owns the workload cluster. Requires --%s.", flagWCName))

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -284,7 +284,7 @@ func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool,
 	}
 
 	// Store kubeconfig and CA certificate.
-	err = storeCredentials(r.k8sConfigAccess, i, authResult, r.fs, r.flag.InternalAPI)
+	err = storeCredentials(r.k8sConfigAccess, i, authResult, r.fs, r.flag.InternalAPI, r.flag.KeepContext)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -297,10 +297,21 @@ func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool,
 
 	contextName := kubeconfig.GenerateKubeContextName(i.Codename)
 	if firstLogin {
-		fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s' and selected.", contextName)
-		fmt.Fprintf(r.stdout, " ")
+		if r.flag.KeepContext {
+			fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s'.", contextName)
+			fmt.Fprintf(r.stdout, " ")
+		} else {
+			fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s' and selected.", contextName)
+			fmt.Fprintf(r.stdout, " ")
+		}
 	}
-	fmt.Fprintf(r.stdout, "To switch back to this context later, use either of these commands:\n\n")
+
+	if r.flag.KeepContext {
+		fmt.Fprintf(r.stdout, "To switch to this context later, use either of these commands:\n\n")
+	} else {
+		fmt.Fprintf(r.stdout, "To switch back to this context later, use either of these commands:\n\n")
+
+	}
 	fmt.Fprintf(r.stdout, "  kubectl gs login %s\n", i.Codename)
 	fmt.Fprintf(r.stdout, "  kubectl config use-context %s\n", contextName)
 

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -298,10 +298,10 @@ func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool,
 	contextName := kubeconfig.GenerateKubeContextName(i.Codename)
 	if firstLogin {
 		if r.flag.KeepContext {
-			fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s'.", contextName)
+			fmt.Fprintf(r.stdout, "A new kubectl context '%s' has been created.", contextName)
 			fmt.Fprintf(r.stdout, " ")
 		} else {
-			fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s' and selected.", contextName)
+			fmt.Fprintf(r.stdout, "A new kubectl context '%s' has been created and selected.", contextName)
 			fmt.Fprintf(r.stdout, " ")
 		}
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20455 and https://github.com/giantswarm/opsctl/pull/1325.

Description:
This PR adds the `--keep-context` flag to the `login` command. Enabling this boolean flag allows users to keep the current context selected after executing the authentication flow with `kubectl gs login <MAPI/web UI URL>`.

For example:
- A user has the `gs-goldfish` context selected, and would like to create a kubectl context for the `gauss` installation.
- They execute the command `kubectl gs login https://g8s.gauss.eu-west-1.aws.gigantic.io --keep-context`.
- They receive a variation of the original message, informing them that the context has been created (but not selected):
<img width="600" alt="Screen Shot 2022-02-03 at 17 22 52" src="https://user-images.githubusercontent.com/62935115/152383964-0e793d0a-b126-465a-a304-54b4fbf09098.png">

This flag has no effect when `kubectl gs login` is used with a context name or left empty, as using the command in these ways are expected to perform a context switch.

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
