### PR TITLE
Simplify log in with context name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Simplify log in with context name
+
 ### Added
 
 - Add `--keep-context` flag to `login`.

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -168,45 +168,12 @@ func (r *runner) tryToReuseExistingContext(ctx context.Context, isCreatingClient
 // loginWithKubeContextName switches the active kubernetes context to
 // the one specified.
 func (r *runner) loginWithKubeContextName(ctx context.Context, contextName string) error {
-	var contextAlreadySelected bool
-
 	codeName := kubeconfig.GetCodeNameFromKubeContext(contextName)
-	err := switchContext(ctx, r.k8sConfigAccess, contextName)
-	if IsContextAlreadySelected(err) {
-		contextAlreadySelected = true
-	} else if IsNewLoginRequired(err) {
-		config, err := r.k8sConfigAccess.GetStartingConfig()
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		authType := kubeconfig.GetAuthType(config, contextName)
-		if authType == kubeconfig.AuthTypeAuthProvider {
-			// If we get here, we are sure that the kubeconfig context exists.
-			authProvider, _ := kubeconfig.GetAuthProvider(config, contextName)
-			issuer := authProvider.Config[Issuer]
-
-			err = r.loginWithURL(ctx, issuer, false, "")
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-
-		return nil
-	} else if err != nil {
+	err := r.loginWithCodeName(ctx, codeName)
+	if err != nil {
 		return microerror.Mask(err)
 	}
-
 	fmt.Fprint(r.stdout, color.YellowString("Note: No need to pass the '%s' prefix. 'kubectl gs login %s' works fine.\n", kubeconfig.ContextPrefix, codeName))
-
-	if contextAlreadySelected {
-		fmt.Fprintf(r.stdout, "Context '%s' is already selected.\n", contextName)
-	} else {
-		fmt.Fprintf(r.stdout, "Switched to context '%s'.\n", contextName)
-	}
-
-	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the management cluster of installation '%s'.\n", codeName))
-
 	return nil
 }
 


### PR DESCRIPTION
It appears that  `loginWithKubeContextName` does the same thing as `loginWithCodeName` except getting the code name from the context and displaying an info. Therefore I simplified it.

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
