### PR TITLE
add config for options

### DIFF
--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -26,7 +26,7 @@ type authInfo struct {
 
 // storeMCCredentials stores the installation's CA certificate, and
 // updates the kubeconfig with the configuration for the k8s api access.
-func storeMCCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult authInfo, fs afero.Fs, internalAPI bool, keepContext bool) error {
+func storeMCCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.Installation, authResult authInfo, fs afero.Fs, internalAPI bool, switchContext bool) error {
 	config, err := k8sConfigAccess.GetStartingConfig()
 	if err != nil {
 		return microerror.Mask(err)
@@ -105,7 +105,7 @@ func storeMCCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.
 		// Add context configuration to config.
 		config.Contexts[contextName] = initialContext
 
-		if !keepContext {
+		if switchContext {
 			// Select newly created context as current.
 			config.CurrentContext = contextName
 		}
@@ -200,7 +200,7 @@ func printMCCredentials(k8sConfigAccess clientcmd.ConfigAccess, i *installation.
 
 // switchContext modifies the existing kubeconfig, and switches the currently
 // active context to the one specified.
-func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, newContextName string, keepContext bool) error {
+func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, newContextName string, switchContext bool) error {
 	config, err := k8sConfigAccess.GetStartingConfig()
 	if err != nil {
 		return microerror.Mask(err)
@@ -254,7 +254,7 @@ func switchContext(ctx context.Context, k8sConfigAccess clientcmd.ConfigAccess, 
 	} else if authType == kubeconfig.AuthTypeUnknown {
 		return microerror.Maskf(incorrectConfigurationError, "There is no authentication configuration for the '%s' context", newContextName)
 	}
-	if !keepContext {
+	if switchContext {
 		config.CurrentContext = newContextName
 	}
 

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -122,7 +122,6 @@ func (r *runner) setLoginOptions(ctx context.Context) {
 	originContext, err := r.tryToGetCurrentContext(ctx)
 	if err != nil {
 		fmt.Fprintln(r.stdout, color.YellowString("Failed trying to determine current context. %s", err))
-
 	}
 	r.loginOptions = LoginOptions{
 		originContext:     originContext,
@@ -486,13 +485,14 @@ func (r *runner) createClusterClientCert(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	//
-
 	fmt.Fprint(r.stdout, color.GreenString("\nCreated client certificate for workload cluster '%s'.\n", r.flag.WCName))
 
 	if r.loginOptions.selfContainedWC {
 		fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s' and stored in '%s'. You can select this context like this:\n\n", contextName, r.flag.SelfContained)
 		fmt.Fprintf(r.stdout, "  kubectl cluster-info --kubeconfig %s \n", r.flag.SelfContained)
+	} else if !r.loginOptions.switchToWCcontext {
+		fmt.Fprintf(r.stdout, "A new kubectl context has been created named '%s'. To switch back to this context later, use this command:\n\n", contextName)
+		fmt.Fprintf(r.stdout, "  kubectl config use-context %s\n", contextName)
 	} else if contextExists {
 		fmt.Fprintf(r.stdout, "Switched to context '%s'.\n\n", contextName)
 		fmt.Fprintf(r.stdout, "To switch back to this context later, use this command:\n\n")

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -121,7 +121,8 @@ func (r *runner) tryToGetCurrentContext(ctx context.Context) (string, error) {
 func (r *runner) setLoginOptions(ctx context.Context) {
 	originContext, err := r.tryToGetCurrentContext(ctx)
 	if err != nil {
-		fmt.Fprintln(r.stdout, "Failed trying to determine current context. %s", err)
+		fmt.Fprintln(r.stdout, color.YellowString("Failed trying to determine current context. %s", err))
+
 	}
 	r.loginOptions = LoginOptions{
 		originContext:     originContext,

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -468,7 +468,7 @@ func (r *runner) createClusterClientCert(ctx context.Context) error {
 	var contextExists bool
 	var contextName string
 	if r.loginOptions.selfContainedWC {
-		contextName, contextExists, err = printWCCredentials(r.k8sConfigAccess, r.fs, r.flag.SelfContained, clientCertResource, secret, clusterBasePath)
+		contextName, contextExists, err = printWCCredentials(r.k8sConfigAccess, r.fs, r.flag.SelfContained, clientCertResource, secret, clusterBasePath, r.loginOptions)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
This is a sub PR to https://github.com/giantswarm/kubectl-gs/pull/661 to make things a bit more visible
We add a little config that contains options to determine how to switch back and forth between contexts.
This should also fix the bug you found @kuosandys 

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
