### PR TITLE
Adapt capo templating to use existing networks and subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Improve flag handling and naming for `template cluster` command (no user facing changes).
+- Add new flags for `template cluster --provider-openstack` to be able to use existing networks and subnets.
 
 ## [2.1.1] - 2022-02-25
 

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -48,6 +48,8 @@ func templateClusterOpenstack(ctx context.Context, k8sClient k8sclient.Interface
 			CloudConfig:        config.OpenStack.CloudConfig,
 			CloudName:          config.OpenStack.Cloud,
 			NodeCIDR:           config.OpenStack.NodeCIDR,
+			NetworkName:        config.OpenStack.NetworkName,
+			SubnetName:         config.OpenStack.SubnetName,
 			ExternalNetworkID:  config.OpenStack.ExternalNetworkID,
 			Bastion: &openstack.Bastion{
 				MachineConfig: openstack.MachineConfig(config.OpenStack.Bastion),

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -42,6 +42,8 @@ type OpenStackConfig struct {
 	EnableOIDC        bool
 	ExternalNetworkID string
 	NodeCIDR          string
+	NetworkName       string
+	SubnetName        string
 
 	Bastion      MachineConfig
 	ControlPlane MachineConfig

--- a/cmd/template/cluster/provider/templates/openstack/types.go
+++ b/cmd/template/cluster/provider/templates/openstack/types.go
@@ -9,6 +9,8 @@ type ClusterConfig struct {
 	ClusterName        string        `json:"clusterName,omitempty"`
 	KubernetesVersion  string        `json:"kubernetesVersion,omitempty"`
 	NodeCIDR           string        `json:"nodeCIDR,omitempty"`
+	NetworkName        string        `json:"networkName,omitempty"`
+	SubnetName         string        `json:"subnetName,omitempty"`
 	ExternalNetworkID  string        `json:"externalNetworkID,omitempty"`
 	OIDC               *OIDC         `json:"oidc,omitempty"`
 	Bastion            *Bastion      `json:"bastion,omitempty"`


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/773

CAPO uses nodeCIDR as a switch. When it is set, CAPO creates a network
and subnet. When it is not set, it uses an existing network and a subnet,
which must be declared.

Complementary of https://github.com/giantswarm/cluster-openstack/pull/63

Documented with https://github.com/giantswarm/docs/pull/1334

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [x] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
