### PR TITLE
Fix crash when listing nodepool without release label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed crash if listing nodepools when one is missing the release version label
+
 ## [2.1.0] - 2022-02-08
 
 ### Fixed
 
 - `login` command: Try logging in again if token renewal fails.
-- Add `security` API group to scheme in order to get `organizations` during `login`.  
+- Add `security` API group to scheme in order to get `organizations` during `login`.
 
 ### Changed
 

--- a/cmd/get/nodepools/provider/azure.go
+++ b/cmd/get/nodepools/provider/azure.go
@@ -79,6 +79,9 @@ func getAzureNodePoolRow(nodePool nodepool.Nodepool, capabilities *feature.Servi
 
 func getAzureLatestCondition(nodePool nodepool.Nodepool, capabilities *feature.Service) string {
 	releaseVersion := key.ReleaseVersion(nodePool.MachinePool)
+	if releaseVersion == "" {
+		return naValue
+	}
 	isSupported := capabilities.Supports(feature.NodePoolConditions, releaseVersion)
 	if !isSupported {
 		return naValue
@@ -93,6 +96,9 @@ func getAzureLatestCondition(nodePool nodepool.Nodepool, capabilities *feature.S
 
 func getAzureAutoscaling(nodePool nodepool.Nodepool, capabilities *feature.Service) string {
 	releaseVersion := key.ReleaseVersion(nodePool.MachinePool)
+	if releaseVersion == "" {
+		return naValue
+	}
 	isSupported := capabilities.Supports(feature.Autoscaling, releaseVersion)
 	if !isSupported {
 		return naValue


### PR DESCRIPTION
Fixes a crash when listing nodepools where one is missing the required release label.

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Request SIG UX for review. They care about almost all user-facing changes.


Feel free to remove this checklist when done.
