### PR TITLE
Add availabilityZones to controlPlane config for OpenStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `--enable-long-names` feature flag to `template cluster/networkpool/nodepool` to allow resource names longer than 5 characters. Only for internal testing.
 
+### Changed
+
+- Add missing availability zones to cluster configuration for OpenStack.
+
 ## [2.2.0] - 2022-03-04
 
 ### Added

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -61,8 +61,9 @@ func templateClusterOpenstack(ctx context.Context, k8sClient k8sclient.Interface
 				},
 			},
 			ControlPlane: &openstack.ControlPlane{
-				MachineConfig: openstack.MachineConfig(config.OpenStack.ControlPlane),
-				Replicas:      controlPlaneReplicas,
+				MachineConfig:     openstack.MachineConfig(config.OpenStack.ControlPlane),
+				Replicas:          controlPlaneReplicas,
+				AvailabilityZones: config.ControlPlaneAZ,
 			},
 			NodePools: []openstack.NodePool{
 				{

--- a/cmd/template/cluster/provider/templates/openstack/types.go
+++ b/cmd/template/cluster/provider/templates/openstack/types.go
@@ -36,8 +36,9 @@ type Bastion struct {
 }
 
 type ControlPlane struct {
-	MachineConfig `json:",inline"`
-	Replicas      int `json:"replicas,omitempty"`
+	MachineConfig     `json:",inline"`
+	Replicas          int      `json:"replicas,omitempty"`
+	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 }
 
 type NodeClass struct {


### PR DESCRIPTION
This PR adds the missing `availabilityZones` array in control plane section. See https://github.com/giantswarm/cluster-openstack/blob/main/helm/cluster-openstack/values.yaml#L30

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
