### PR TITLE
Fetch release components to set CR labels when templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Set correct labels of GiantSwarm components on cluster templates.
+
 ### Changed
 
 - `login`: simplify description for the `--certificate-ttl` flag.

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -35,7 +35,7 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 			}
 		}
 	} else {
-		err = WriteGSAWSTemplate(out, config)
+		err = WriteGSAWSTemplate(ctx, client, out, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -44,7 +44,7 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 	return nil
 }
 
-func WriteGSAWSTemplate(out io.Writer, config ClusterConfig) error {
+func WriteGSAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {
 	var err error
 
 	crsConfig := aws.ClusterCRsConfig{
@@ -57,6 +57,11 @@ func WriteGSAWSTemplate(out io.Writer, config ClusterConfig) error {
 		Owner:          config.Organization,
 		ReleaseVersion: config.ReleaseVersion,
 		Labels:         config.Labels,
+	}
+
+	crsConfig.ReleaseComponents, err = key.GetReleaseComponents(ctx, client.CtrlClient(), config.ReleaseVersion)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	crs, err := aws.NewClusterCRs(crsConfig)

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -68,6 +68,7 @@ type ClusterConfig struct {
 	Name              string
 	Organization      string
 	ReleaseVersion    string
+	ReleaseComponents map[string]string
 	Labels            map[string]string
 	Namespace         string
 	PodsCIDR          string
@@ -105,6 +106,8 @@ func newCAPIV1Alpha3ClusterCR(config ClusterConfig, infrastructureRef *corev1.Ob
 				capiv1alpha3.ClusterLabelName: config.Name,
 				label.Organization:            config.Organization,
 				label.ReleaseVersion:          config.ReleaseVersion,
+				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
+				label.ClusterOperatorVersion:  config.ReleaseComponents["cluster-operator"],
 			},
 			Annotations: map[string]string{
 				annotation.ClusterDescription: config.Description,

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -36,7 +36,7 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 			}
 		}
 	} else {
-		err = WriteGSAWSTemplate(out, config)
+		err = WriteGSAWSTemplate(ctx, client, out, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -45,8 +45,12 @@ func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Wr
 	return nil
 }
 
-func WriteGSAWSTemplate(out io.Writer, config NodePoolCRsConfig) error {
+func WriteGSAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {
 	var err error
+	config.ReleaseComponents, err = key.GetReleaseComponents(ctx, client.CtrlClient(), config.ReleaseVersion)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
 	crsConfig := aws.NodePoolCRsConfig{
 		AvailabilityZones:                   config.AvailabilityZones,

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -66,6 +66,8 @@ func newCAPIV1Alpha3MachinePoolCR(config NodePoolCRsConfig, infrastructureRef *c
 				capiv1alpha3.ClusterLabelName: config.ClusterName,
 				label.MachinePool:             config.NodePoolName,
 				label.Organization:            config.Organization,
+				label.ReleaseVersion:          config.ReleaseVersion,
+				label.AzureOperatorVersion:    config.ReleaseComponents["azure-operator"],
 			},
 			Annotations: map[string]string{
 				annotation.MachinePoolName: config.Description,
@@ -102,6 +104,7 @@ func newSparkCR(config NodePoolCRsConfig) *corev1alpha1.Spark {
 			Labels: map[string]string{
 				label.Cluster:                 config.ClusterName,
 				capiv1alpha3.ClusterLabelName: config.ClusterName,
+				label.ReleaseVersion:          config.ReleaseVersion,
 			},
 		},
 		Spec: corev1alpha1.SparkSpec{},

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 	v1 "k8s.io/api/core/v1"
@@ -172,6 +173,21 @@ func SSHSSOPublicKey(ctx context.Context, client runtimeclient.Client) (string, 
 	sshSSOPublicKey := base64.StdEncoding.EncodeToString(secretList.Items[0].Data["value"])
 
 	return sshSSOPublicKey, nil
+}
+
+func GetReleaseComponents(ctx context.Context, client runtimeclient.Client, releaseName string) (map[string]string, error) {
+	releaseComponents := make(map[string]string)
+	release := &releasev1alpha1.Release{}
+	err := client.Get(ctx, runtimeclient.ObjectKey{Namespace: "", Name: fmt.Sprintf("v%s", releaseName)}, release)
+	if err != nil {
+		return releaseComponents, microerror.Mask(err)
+	}
+
+	for _, component := range release.Spec.Components {
+		releaseComponents[component.Name] = component.Version
+	}
+
+	return releaseComponents, nil
 }
 
 func UbuntuSudoersConfigEncoded() string {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21251

Since the very first release of `kubectl-gs` we have code that _tries_ to add the labels for the GiantSwarm components (to know which resources to reconcile) to the cluster templates. This has been always broken, but we haven't noticed until now because we have our own admission controllers that also default these labels. So the templates generated by kubectl-gs were wrong, but the admission webhooks set the right values on these labels.

We should generate the right templates from `kubectl-gs`.