### PR TITLE
Add visibility flag to template catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--visibility` flag to `template catalog` to set label to control display in web UI.
+
 ### Changed
 
 - `login`: simplify description for the `--certificate-ttl` flag.

--- a/cmd/template/catalog/flag.go
+++ b/cmd/template/catalog/flag.go
@@ -15,6 +15,7 @@ const (
 	flagNamespace   = "namespace"
 	flagSecret      = "secret"
 	flagURL         = "url"
+	flagVisibility  = "visibility"
 )
 
 type flag struct {
@@ -25,6 +26,7 @@ type flag struct {
 	Namespace   string
 	Secret      string
 	URL         string
+	Visibility  string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -35,6 +37,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the catalog will be created.")
 	cmd.Flags().StringVar(&f.Secret, flagSecret, "", "Path to a secret file.")
 	cmd.Flags().StringVar(&f.URL, flagURL, "", "Catalog storage URL.")
+	cmd.Flags().StringVar(&f.Visibility, flagVisibility, "public", "Visibility label for whether catalog appears in the web UI.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/catalog/runner.go
+++ b/cmd/template/catalog/runner.go
@@ -55,6 +55,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		Name:        r.flag.Name,
 		Namespace:   r.flag.Namespace,
 		URL:         r.flag.URL,
+		Visibility:  r.flag.Visibility,
 	}
 
 	if r.flag.ConfigMap != "" {

--- a/pkg/template/catalog/catalog.go
+++ b/pkg/template/catalog/catalog.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,6 +16,7 @@ type Config struct {
 	Namespace            string
 	LogoURL              string
 	URL                  string
+	Visibility           string
 }
 
 func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
@@ -38,6 +40,11 @@ func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
 		}
 	}
 
+	labelValues := map[string]string{}
+	if config.Visibility != "" {
+		labelValues[label.CatalogVisibility] = config.Visibility
+	}
+
 	catalogCR := &applicationv1alpha1.Catalog{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Catalog",
@@ -46,6 +53,7 @@ func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
 			Namespace: config.Namespace,
+			Labels:    labelValues,
 		},
 		Spec: applicationv1alpha1.CatalogSpec{
 			Config:      catalogConfig,


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/giantswarm/issues/19941

## Reason

As a user of app platform I'd like to be able to view custom catalogs in the web UI.

## Context

Only catalog CRs with the label `application.giantswarm.io/catalog-visibility: public` are shown. Any other value hides the catalog unless the user is an admin.

This adds a `--visibility` flag that defaults to public. That makes the most sense to me but happy to change the default if others disagree.

Docs: https://github.com/giantswarm/docs/pull/1361


