### PR TITLE
Bump version to 2.3.2-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "kubectl-gs"
 	source      = "https://github.com/giantswarm/kubectl-gs"
-	version     = "2.3.1"
+	version     = "2.3.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
[Release automation failed](https://github.com/giantswarm/kubectl-gs/runs/5509030675?check_suite_focus=true) to do this, so I'm doing it manually here.