### PR TITLE
Add missing fix to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Add tests for `kubectl gs login`.
 - Add `--visibility` flag to `template catalog` to add label to control display in web UI.
 
+### Fixed
+
+- Look up cluster-related AppCatalogEntries in the `giantswarm` namespace instead of the `default` namespace.
+
 ## [2.3.1] - 2022-03-11
 
 ### Fixed


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21161 and discovered while testing https://github.com/giantswarm/test-infra/pull/164

A bug in `kubectl-gs` v2.3.1 was fixed with https://github.com/giantswarm/kubectl-gs/pull/676 and released as v2.4.0, but it wasn't mentioned in the changelog. I found the change using `git diff` and thought it was worth mentioning in the changelog even though it's already released.