### PR TITLE
Label CAPA apps with cluster name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add cluster name label to CAPA Apps and ConfigMaps created with `kubectl-gs template`
+
 ## [2.4.0] - 2022-03-21
 
 ### Added

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -11,6 +11,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
+	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
+
 	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider/templates/aws"
 	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider/templates/capa"
 	"github.com/giantswarm/kubectl-gs/internal/key"
@@ -130,6 +132,8 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			return microerror.Mask(err)
 		}
 
+		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {
 			return microerror.Mask(err)
@@ -155,6 +159,9 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			ExtraLabels: map[string]string{
+				k8smetadata.Cluster: config.Name,
+			},
 		}
 
 		var err error
@@ -198,6 +205,8 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			return microerror.Mask(err)
 		}
 
+		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {
 			return microerror.Mask(err)
@@ -224,6 +233,9 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			ExtraLabels: map[string]string{
+				k8smetadata.Cluster: config.Name,
+			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/giantswarm/appcatalog v0.6.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v5 v5.12.0
-	github.com/giantswarm/k8smetadata v0.9.3
+	github.com/giantswarm/k8smetadata v0.10.1
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/giantswarm/cluster-api-provider-azure v0.4.12-gsalpha3/go.mod h1:v/WB
 github.com/giantswarm/k8sclient/v5 v5.12.0 h1:oG5k7LLqMT+OaR/jMqOAQMTCpv5OdwjcJhFYGdIPThQ=
 github.com/giantswarm/k8sclient/v5 v5.12.0/go.mod h1:KXRSG1t+XBDsXx089Jp9agMjQ4xEIWywJUchAZ2OQ6c=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
-github.com/giantswarm/k8smetadata v0.9.3 h1:YJJ5NJzjIQImNZc96ia2zh1PEkMt9+G+HalA8ZL8qxQ=
-github.com/giantswarm/k8smetadata v0.9.3/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.10.1 h1:JHTgTavRtcnmzq0j8TC9EXtGG4+trCkBwuwJPAH+EWE=
+github.com/giantswarm/k8smetadata v0.10.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.3.0/go.mod h1:g8oCEMFAoEs70riRRmj9+6eiz7SqNxYl+2OfxFh1po0=
 github.com/giantswarm/microerror v0.4.0 h1:QeU+UZL0rRlVXKqYOHMxS0L7g8UD+dn84NT7myWVh4U=

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -30,6 +30,8 @@ type Config struct {
 	UserConfigSecretName       string
 	Organization               string
 	Version                    string
+	ExtraLabels                map[string]string
+	ExtraAnnotations           map[string]string
 }
 
 type UserConfig struct {
@@ -65,6 +67,10 @@ func NewAppCR(config Config) ([]byte, error) {
 		crNamespace = config.Cluster
 	}
 
+	for key, val := range config.ExtraLabels {
+		appLabels[key] = val
+	}
+
 	if config.UserConfigConfigMapName != "" {
 		userConfig.ConfigMap = applicationv1alpha1.AppSpecUserConfigConfigMap{
 			Name:      config.UserConfigConfigMapName,
@@ -85,9 +91,10 @@ func NewAppCR(config Config) ([]byte, error) {
 			APIVersion: "application.giantswarm.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.AppName,
-			Namespace: crNamespace,
-			Labels:    appLabels,
+			Name:        config.AppName,
+			Namespace:   crNamespace,
+			Labels:      appLabels,
+			Annotations: config.ExtraAnnotations,
 		},
 		Spec: applicationv1alpha1.AppSpec{
 			Catalog:   config.Catalog,


### PR DESCRIPTION
Add the associated cluster name as a label on the Apps and ConfigMaps created by `kubectl-gs template`. 

This would make cleanup/deleting of a cluster easier as you can target the initial resources via a label selector more easily.


Works towards https://github.com/giantswarm/roadmap/issues/933

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
