### PR TITLE
Fix nilpointer of configmap labels

### DIFF
--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -132,6 +132,7 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			return microerror.Mask(err)
 		}
 
+		userConfigMap.ObjectMeta.Labels = map[string]string{}
 		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)
@@ -205,6 +206,7 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			return microerror.Mask(err)
 		}
 
+		userConfigMap.ObjectMeta.Labels = map[string]string{}
 		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)


### PR DESCRIPTION
Sorry, I missed this off of my previous PR #719

---

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
