### PR TITLE
Expand abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add cluster name label to Cluster API provider Azure (CAPA) Apps and ConfigMaps created with `kubectl-gs template`
+- Add cluster name label to Cluster API provider AWS (CAPA) Apps and ConfigMaps created with `kubectl-gs template`
 
 ## [2.4.0] - 2022-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-- Add templating for CAPG clusters.
+- Add templating for clusters using Cluster API provider Google Cloud (CAPG).
 
 ## [2.5.0] - 2022-03-23
 
 ### Added
 
-- Add cluster name label to CAPA Apps and ConfigMaps created with `kubectl-gs template`
+- Add cluster name label to Cluster API provider Azure (CAPA) Apps and ConfigMaps created with `kubectl-gs template`
 
 ## [2.4.0] - 2022-03-21
 


### PR DESCRIPTION
As we decided to avoid the Cluster API abbreviations in our public communication, I'm replacing the most recent uses here.