### PR TITLE
Make region and AZs optional for CAPA cluster template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
 - Add templating for clusters using Cluster API provider Google Cloud (CAPG).
+
+### Changed
+
+- Make the region and availability zones flags optional for CAPA clusters.
 
 ## [2.5.0] - 2022-03-23
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -324,22 +324,6 @@ func (f *flag) Validate() error {
 			if len(f.ControlPlaneAZ) != 0 && len(f.ControlPlaneAZ) != 1 && len(f.ControlPlaneAZ) != 3 {
 				return microerror.Maskf(invalidFlagError, "--%s must be set to either one or three availability zone names", flagControlPlaneAZ)
 			}
-			isCapiVersion, err := key.IsCAPIVersion(strings.TrimPrefix(f.Release, "v"))
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			if isCapiVersion {
-				if f.Region == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagRegion)
-				}
-				if f.ControlPlaneAZ == nil {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagControlPlaneAZ)
-				}
-				if f.AWS.MachinePool.AZs == nil {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagAWSMachinePoolAZs)
-				}
-			}
-
 			if f.AWS.ControlPlaneSubnet != "" {
 				matchedSubnet, err := regexp.MatchString("^20|21|22|23|24|25$", f.AWS.ControlPlaneSubnet)
 				if err == nil && !matchedSubnet {

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -105,9 +105,8 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 				Replicas:     config.BastionReplicas,
 			},
 			ControlPlane: &capa.ControlPlane{
-				InstanceType:      config.ControlPlaneInstanceType,
-				Replicas:          3,
-				AvailabilityZones: config.ControlPlaneAZ,
+				InstanceType: config.ControlPlaneInstanceType,
+				Replicas:     3,
 			},
 			MachinePools: &[]capa.MachinePool{
 				{


### PR DESCRIPTION
With the release of https://github.com/giantswarm/cluster-aws/releases/tag/v0.2.1 the Region and Availability Zones are now optional when creating CAPA clusters and will default to match that of the management cluster being applied to. This change continues that and makes the properties optional when running `kubectl gs template cluster` 

Towards https://github.com/giantswarm/giantswarm/issues/21298

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
