### PR TITLE
Clarify number of AZs when templating an Azure cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Improved description of the `--control-plane-az` parameter when templating a cluster.
+
 ## [2.7.0] - 2022-04-01
 
 - In `kubectl gs login`, add support for workload clusters on OpenStack.

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -237,7 +237,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden(flagDefaultAppsVersion)
 
 	// Common.
-	cmd.Flags().StringSliceVar(&f.ControlPlaneAZ, flagControlPlaneAZ, nil, "Availability zone(s) to use by control plane nodes.")
+	cmd.Flags().StringSliceVar(&f.ControlPlaneAZ, flagControlPlaneAZ, nil, "Availability zone(s) to use by control plane nodes. Azure only supports one.")
 	cmd.Flags().StringVar(&f.ControlPlaneInstanceType, flagControlPlaneInstanceType, "", "Instance type used for Control plane nodes")
 	cmd.Flags().StringVar(&f.Description, flagDescription, "", "User-friendly description of the cluster's purpose (formerly called name).")
 	cmd.Flags().StringVar(&f.KubernetesVersion, flagKubernetesVersion, "v1.20.9", "Cluster Kubernetes version.")


### PR DESCRIPTION
A customer made me notice that it is not clear that on Azure we can only choose one Availability Zone while templating a cluster. This makes it clearer.
