### PR TITLE
Selfupdate: Synchronize changes from devctl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Improved description of the `--control-plane-az` parameter when templating a cluster.
 
+### Fixed
+
+- Create cache directory if it does not exist, yet.
+
 ## [2.7.0] - 2022-04-01
 
 - In `kubectl gs login`, add support for workload clusters on OpenStack.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Improved description of the `--control-plane-az` parameter when templating a cluster.
 
-### Fixed
-
-- Create cache directory if it does not exist, yet.
-
 ## [2.7.0] - 2022-04-01
 
 - In `kubectl gs login`, add support for workload clusters on OpenStack.

--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -138,9 +138,8 @@ func (u *Updater) getLatestVersion() (semver.Version, error) {
 
 	if allowCache {
 		u.cache.LatestVersion = latestVersion.Version.String()
-		// We ignore the error, because if saving fails, we'll just
-		// fetch the version again next time.
-		err := u.cache.Persist(u.cacheDir)
+
+		err = u.cache.Persist(u.cacheDir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: Failed to persist the cache with error: %s", err)
 		}

--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -1,7 +1,9 @@
 package selfupdate
 
 import (
+	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/blang/semver"
@@ -138,7 +140,10 @@ func (u *Updater) getLatestVersion() (semver.Version, error) {
 		u.cache.LatestVersion = latestVersion.Version.String()
 		// We ignore the error, because if saving fails, we'll just
 		// fetch the version again next time.
-		_ = u.cache.Persist(u.cacheDir)
+		err := u.cache.Persist(u.cacheDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: Failed to persist the cache with error: %s", err)
+		}
 	}
 
 	return latestVersion.Version, nil


### PR DESCRIPTION
There are changes made in devctl which could be useful for kubectl-gs.

Background: I had some trouble with generating the cache directory in opsctl and determined differences in common update routines in devctl, kubectl-gs and opsctl repository. I there would like to synchronize those changes.
