### PR TITLE
Build windows-amd64 binaries

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -254,9 +254,10 @@ jobs:
       matrix:
         platform:
           - darwin-amd64
-          - linux-amd64
           - darwin-arm64
+          - linux-amd64
           - linux-arm64
+          - windows-amd64
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GO_VERSION: 1.17.8


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/333

This will eventually get replaced by devctl (see https://github.com/giantswarm/devctl/pull/405)