### PR TITLE
Import repository secrets into action

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -263,6 +263,8 @@ jobs:
       GO_VERSION: 1.17.8
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
+      CODE_SIGNING_CERT_BUNDLE_BASE64: ${{ secrets.CODE_SIGNING_CERT_BUNDLE_BASE64 }}
+      CODE_SIGNING_CERT_BUNDLE_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_BUNDLE_PASSWORD }}
     needs:
       - create_release
       - gather_facts


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/333

This should enable code signing in the action.

**Temporary.** This will later be replaced by devctl.