### PR TITLE
Fix windows build

### DIFF
--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -89,7 +89,7 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: DIR=$(PACKAGE_DIR)/
 $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(VERSION)-windows-amd64.exe
 	@echo "====> $@"
 
-	@ if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
+	@if [ "${CODE_SIGNING_CERT_BUNDLE_PASSWORD}" != "" ]; then \
 	  echo 'Signing the Windows binary'; \
 	  mkdir -p certs; \
 	  echo ${CODE_SIGNING_CERT_BUNDLE_BASE64} | base64 -d > certs/code-signing.p12; \

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -98,7 +98,7 @@ $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-windows-amd64.zip: $(APPLICATION)-v$(V
 		  -v ${PWD}/certs:/mnt/certs \
 		  -v ${PWD}:/mnt/binaries \
 		  --user ${USERID}:${GROUPID} \
-		  quay.io/giantswarm/signcode-util:1.0.0 \
+		  quay.io/giantswarm/signcode-util:1.1.1 \
 		  sign \
 		  -pkcs12 /mnt/certs/code-signing.p12 \
 		  -n "Giant Swarm CLI tool $(APPLICATION)" \


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/333

The attempt to fix a shell syntax problem in the build process.

Also updates signcode-util to the latest release.