### PR TITLE
Update check: set empty API token

### DIFF
--- a/pkg/selfupdate/updater.go
+++ b/pkg/selfupdate/updater.go
@@ -12,9 +12,6 @@ import (
 )
 
 type Config struct {
-	// GithubToken will be used when fetching versions
-	// from private GitHub repositories.
-	GithubToken string
 	// CurrentVersion is the currently installed version
 	// of the application.
 	CurrentVersion string
@@ -26,7 +23,6 @@ type Config struct {
 }
 
 type Updater struct {
-	githubToken    string
 	currentVersion semver.Version
 	repository     string
 	cacheDir       string
@@ -46,8 +42,7 @@ func New(c Config) (*Updater, error) {
 	var err error
 
 	u := &Updater{
-		githubToken: c.GithubToken,
-		cacheDir:    c.CacheDir,
+		cacheDir: c.CacheDir,
 	}
 
 	{
@@ -65,8 +60,10 @@ func New(c Config) (*Updater, error) {
 	}
 
 	{
+		// APIToken is empty here to suppress the use of the GITHUB_TOKEN
+		// environment variable or any .gitconfig token.
 		u.selfUpdater, err = selfupdate.NewUpdater(selfupdate.Config{
-			APIToken: u.githubToken,
+			APIToken: "",
 		})
 		if err != nil {
 			return nil, microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1053

Since kubectl-gs is a public GitHub repository, there is no need to pass a token for the update check. This PR enforces an empty string instead.

An empty token also means that if the `GITHUB_TOKEN` environment variable is set, it will be used for API authentication with GitHub. This _might_ affect access to the repo's releases.

https://github.com/rhysd/go-github-selfupdate/blob/master/selfupdate/updater.go#L54-L56