### PR TITLE
Bastion capz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- base64 encode ssh key for CAPZ clusters.
+- Fix bastion systemd unit on CAPZ clusters.
+- Make CAPZ clusters compatible with cluster-apps-operator new version.
+
 ## [2.8.1] - 2022-05-03
 
 ### Fixed

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -51,7 +51,7 @@ func WriteCAPZTemplate(ctx context.Context, client k8sclient.Interface, out io.W
 		}
 
 		var tpl bytes.Buffer
-		t := template.Must(template.New(config.FileName).Parse(fmt.Sprintf(key.BastionIgnitionTemplate, config.Name, key.BastionSSHDConfigEncoded(), sshSSOPublicKey)))
+		t := template.Must(template.New(config.FileName).Parse(fmt.Sprintf(key.BastionIgnitionTemplate, config.Name, key.BastionSSHDConfigEncoded(), base64.StdEncoding.EncodeToString([]byte(sshSSOPublicKey)))))
 		err = t.Execute(&tpl, data)
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/azure/cluster.yaml.tmpl
@@ -9,6 +9,7 @@ metadata:
     "cluster.x-k8s.io/cluster-name": "{{ .Name }}"
     "giantswarm.io/organization": "{{ .Organization }}"
     "cluster.x-k8s.io/watch-filter": "capi"
+    cluster-apps-operator.giantswarm.io/watching: ""
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:

--- a/internal/key/templates.go
+++ b/internal/key/templates.go
@@ -210,4 +210,6 @@ Description=Set Bastion zone as ready by creating /run/cluster-api/bootstrap-suc
 [Service]
 Type=oneshot
 ExecStart=/bin/sh -c 'mkdir -p /run/cluster-api/ ; echo "success" >/run/cluster-api/bootstrap-success.complete'
+
+[Install]\nWantedBy=multi-user.target
 `


### PR DESCRIPTION
- base64 encode ssh key for CAPZ clusters.
- Fix bastion systemd unit on CAPZ clusters.
- Make CAPZ clusters compatible with cluster-apps-operator new version.


