### PR TITLE
Allow usage of any existing current context in login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--enforce-context` flag to `login` command which allows switching to kubectl contexts with arbitrary names.
+
 ## [2.9.1] - 2022-05-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add `--enforce-context` flag to `login` command which allows switching to kubectl contexts with arbitrary names.
+- Allow to reuse any current context in `login` command by omitting the argument. This allows creating clientCerts for WCs in an arbitrary MC context. (not following `gs-codename` format)
 
 ## [2.9.1] - 2022-05-06
 

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -29,7 +29,6 @@ type flag struct {
 	ClusterAdmin       bool
 	InternalAPI        bool
 	KeepContext        bool
-	EnforceContext     bool
 
 	WCName              string
 	WCOrganization      string
@@ -47,7 +46,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
 	cmd.Flags().StringVar(&f.SelfContained, flagSelfContained, "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")
 	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
-	cmd.Flags().BoolVar(&f.EnforceContext, flagEnforceContext, false, "Enforce login using kubectl context name. If set/true, the first argument will be interpreted as a context name, even without gs- prefix.")
 
 	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("Organization that owns the workload cluster. Requires --%s.", flagWCName))

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -14,7 +14,6 @@ const (
 	flagInternalAPI    = "internal-api"
 	callbackServerPort = "callback-port"
 	flagKeepContext    = "keep-context"
-	flagEnforceContext = "enforce-context"
 
 	flagWCName              = "workload-cluster"
 	flagWCOrganization      = "organization"

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -14,6 +14,7 @@ const (
 	flagInternalAPI    = "internal-api"
 	callbackServerPort = "callback-port"
 	flagKeepContext    = "keep-context"
+	flagEnforceContext = "enforce-context"
 
 	flagWCName              = "workload-cluster"
 	flagWCOrganization      = "organization"
@@ -28,6 +29,7 @@ type flag struct {
 	ClusterAdmin       bool
 	InternalAPI        bool
 	KeepContext        bool
+	EnforceContext     bool
 
 	WCName              string
 	WCOrganization      string
@@ -45,6 +47,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
 	cmd.Flags().StringVar(&f.SelfContained, flagSelfContained, "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")
 	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
+	cmd.Flags().BoolVar(&f.EnforceContext, flagEnforceContext, false, "Enforce login using kubectl context name. If set/true, the first argument will be interpreted as a context name, even without gs- prefix.")
 
 	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("Organization that owns the workload cluster. Requires --%s.", flagWCName))

--- a/cmd/login/mc.go
+++ b/cmd/login/mc.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (r *runner) handleMCLogin(ctx context.Context, installationIdentifier string) error {
-	if _, contextType := kubeconfig.IsKubeContext(installationIdentifier); contextType == kubeconfig.ContextTypeMC || r.flag.EnforceContext {
+	if _, contextType := kubeconfig.IsKubeContext(installationIdentifier); contextType == kubeconfig.ContextTypeMC {
 		return r.loginWithKubeContextName(ctx, installationIdentifier)
 
 	} else if kubeconfig.IsCodeName(installationIdentifier) {

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -435,7 +435,8 @@ func createValidTestConfig(wcSuffix string, authProvider bool) *clientcmdapi.Con
 func createNonDefaultTestConfig() *clientcmdapi.Config {
 	const (
 		server      = "https://anything.com:8080"
-		token       = "the-token"
+		clientkey   = "the-key"
+		clientcert  = "the-cert"
 		clustername = "arbitraryname"
 	)
 
@@ -449,9 +450,8 @@ func createNonDefaultTestConfig() *clientcmdapi.Config {
 	}
 	config.CurrentContext = clustername
 	config.AuthInfos["user-"+clustername] = &clientcmdapi.AuthInfo{
-		Token: token,
-	}
-
+		ClientCertificateData: []byte(clientcert),
+		ClientKeyData:         []byte(clientkey)}
 	return config
 }
 

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -165,7 +165,7 @@ func TestLogin(t *testing.T) {
 			startConfig: createValidTestConfig("", true),
 			expectError: unknownUrlError,
 		},
-		// Logging into non default context
+		// Logging into non default context with argument
 		{
 			name:        "case 12",
 			startConfig: createNonDefaultTestConfig(),
@@ -175,14 +175,12 @@ func TestLogin(t *testing.T) {
 			},
 			expectError: contextDoesNotExistError,
 		},
-		// Logging into non default context
+		// Logging into non default context without argument
 		{
 			name:        "case 13",
 			startConfig: createNonDefaultTestConfig(),
-			mcArg:       []string{"arbitraryname"},
 			flags: &flag{
-				WCCertTTL:      "8h",
-				EnforceContext: true,
+				WCCertTTL: "8h",
 			},
 		},
 	}

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -165,6 +165,26 @@ func TestLogin(t *testing.T) {
 			startConfig: createValidTestConfig("", true),
 			expectError: unknownUrlError,
 		},
+		// Logging into non default context
+		{
+			name:        "case 12",
+			startConfig: createNonDefaultTestConfig(),
+			mcArg:       []string{"arbitraryname"},
+			flags: &flag{
+				WCCertTTL: "8h",
+			},
+			expectError: contextDoesNotExistError,
+		},
+		// Logging into non default context
+		{
+			name:        "case 13",
+			startConfig: createNonDefaultTestConfig(),
+			mcArg:       []string{"arbitraryname"},
+			flags: &flag{
+				WCCertTTL:      "8h",
+				EnforceContext: true,
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -407,6 +427,29 @@ func createValidTestConfig(wcSuffix string, authProvider bool) *clientcmdapi.Con
 		config.AuthInfos["gs-user-"+clustername] = &clientcmdapi.AuthInfo{
 			Token: token,
 		}
+	}
+
+	return config
+}
+
+func createNonDefaultTestConfig() *clientcmdapi.Config {
+	const (
+		server      = "https://anything.com:8080"
+		token       = "the-token"
+		clustername = "arbitraryname"
+	)
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters[clustername] = &clientcmdapi.Cluster{
+		Server: server,
+	}
+	config.Contexts[clustername] = &clientcmdapi.Context{
+		Cluster:  clustername,
+		AuthInfo: "user-" + clustername,
+	}
+	config.CurrentContext = clustername
+	config.AuthInfos["user-"+clustername] = &clientcmdapi.AuthInfo{
+		Token: token,
 	}
 
 	return config

--- a/pkg/kubeconfig/auth.go
+++ b/pkg/kubeconfig/auth.go
@@ -34,8 +34,11 @@ func GetAuthType(config *clientcmdapi.Config, contextName string) AuthType {
 	case authInfo.AuthProvider != nil:
 		return AuthTypeAuthProvider
 	case len(authInfo.ClientCertificate) > 0:
+		return AuthTypeClientCertificate
 	case len(authInfo.ClientCertificateData) > 0:
+		return AuthTypeClientCertificate
 	case len(authInfo.ClientKey) > 0:
+		return AuthTypeClientCertificate
 	case len(authInfo.ClientKeyData) > 0:
 		return AuthTypeClientCertificate
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1082

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
