### PR TITLE
Allow to remove cluster update schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Allow to remove the cluster upgrade schedule.
+- Allow to remove the scheduled update time from the cluster.
 
 ## [2.10.0] - 2022-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow to remove the cluster upgrade schedule.
+
 ## [2.10.0] - 2022-05-13
 
 ### Added

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -26,6 +26,7 @@ Options:
   --name <cluster-name>             	Name of the cluster to update.
   --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
+  --remove-schedule						Optionally: Remove the scheduled time for the cluster.
   --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated, time format 'YYYY-MM-DD HH:MM'.
   --provider <provider> 		Name of the provider.`
 
@@ -36,7 +37,10 @@ kubectl gs update cluster --help
 kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --provider aws
 
 # Schedule cluster update
-kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "2022-01-01 10:00" --provider aws`
+kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "2022-01-01 10:00" --provider aws
+
+# Remove schedule for cluster update
+kubectl gs update cluster --name abcd1 --namespace my-org --provider aws --remove-schedule`
 )
 
 type Config struct {

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -26,7 +26,7 @@ Options:
   --name <cluster-name>             	Name of the cluster to update.
   --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
-  --remove-schedule				Optionally: Remove the scheduled time for the cluster.
+  --remove-schedule				Optionally: Remove the scheduled time from the cluster.
   --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated, time format 'YYYY-MM-DD HH:MM'.
   --provider <provider> 		Name of the provider.`
 
@@ -39,7 +39,7 @@ kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1
 # Schedule cluster update
 kubectl gs update cluster --name abcd1 --namespace my-org --release-version 16.1.0 --scheduled-time "2022-01-01 10:00" --provider aws
 
-# Remove schedule for cluster update
+# Remove the scheduled time from the cluster
 kubectl gs update cluster --name abcd1 --namespace my-org --provider aws --remove-schedule`
 )
 

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -26,7 +26,7 @@ Options:
   --name <cluster-name>             	Name of the cluster to update.
   --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
-  --remove-schedule				Optionally: Remove the scheduled time from the cluster.
+  --remove-schedule			Optionally: Remove the scheduled time from the cluster.
   --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated, time format 'YYYY-MM-DD HH:MM'.
   --provider <provider> 		Name of the provider.`
 

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -26,7 +26,7 @@ Options:
   --name <cluster-name>             	Name of the cluster to update.
   --namespace <cluster-namespace>   	Namespace of the cluster.
   --release-version <release-version>   Update the cluster to a release version. The release version must be higher than the current release version.
-  --remove-schedule						Optionally: Remove the scheduled time for the cluster.
+  --remove-schedule				Optionally: Remove the scheduled time for the cluster.
   --scheduled-time <scheduled-time>     Optionally: Scheduled time when cluster should be updated, time format 'YYYY-MM-DD HH:MM'.
   --provider <provider> 		Name of the provider.`
 

--- a/cmd/update/cluster/flag.go
+++ b/cmd/update/cluster/flag.go
@@ -9,6 +9,7 @@ import (
 const (
 	flagName           = "name"
 	flagReleaseVersion = "release-version"
+	flagRemoveSchedule = "remove-schedule"
 	flagScheduledTime  = "scheduled-time"
 	flagProvider       = "provider"
 )
@@ -18,6 +19,7 @@ type flag struct {
 	print          *genericclioptions.PrintFlags
 	Name           string
 	ReleaseVersion string
+	RemoveSchedule bool
 	ScheduledTime  string
 	Provider       string
 }
@@ -26,6 +28,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the cluster to update.")
 
 	cmd.Flags().StringVar(&f.ReleaseVersion, flagReleaseVersion, "", "Update the cluster to a release version. The release version must be higher than the current release version.")
+
+	cmd.Flags().BoolVar(&f.RemoveSchedule, flagRemoveSchedule, false, "Remove the schedule time for the cluster.")
 
 	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
 

--- a/cmd/update/cluster/flag.go
+++ b/cmd/update/cluster/flag.go
@@ -29,7 +29,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&f.ReleaseVersion, flagReleaseVersion, "", "Update the cluster to a release version. The release version must be higher than the current release version.")
 
-	cmd.Flags().BoolVar(&f.RemoveSchedule, flagRemoveSchedule, false, "Remove the schedule time for the cluster.")
+	cmd.Flags().BoolVar(&f.RemoveSchedule, flagRemoveSchedule, false, "Remove the schedule time from the cluster.")
 
 	cmd.Flags().StringVar(&f.ScheduledTime, flagScheduledTime, "", "Optionally: Scheduled time when cluster should be updated. The value has to be in RFC822 Format and UTC time zone.")
 

--- a/cmd/update/cluster/runner.go
+++ b/cmd/update/cluster/runner.go
@@ -97,7 +97,21 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	var patches cluster.PatchOptions
 	var msg string
-	if scheduledTime != "" {
+	if r.flag.RemoveSchedule {
+		patches = cluster.PatchOptions{
+			PatchSpecs: []cluster.PatchSpec{
+				{
+					Op:   "remove",
+					Path: fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(annotation.UpdateScheduleTargetRelease)),
+				},
+				{
+					Op:   "remove",
+					Path: fmt.Sprintf("/metadata/annotations/%s", replaceToEscape(annotation.UpdateScheduleTargetTime)),
+				},
+			},
+		}
+		msg = fmt.Sprintf("The schedule for upgrading the cluster %s has been removed\n", name)
+	} else if scheduledTime != "" {
 		patches = cluster.PatchOptions{
 			PatchSpecs: []cluster.PatchSpec{
 				{


### PR DESCRIPTION
Allow users to remove scheduled update time from cluster.
---

Issue: https://github.com/giantswarm/roadmap/issues/1074
Docs PR: https://github.com/giantswarm/docs/pull/1440

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [x] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [x] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
