### PR TITLE
Display notes for App CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add a NOTES column to the output of listing and getting App resources. The column contains information why the last Helm release attempt failed if so, empty otherwiseg
+
 ## [2.10.0] - 2022-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add a NOTES column to the output of listing and getting App resources. The column contains information why the last Helm release attempt failed if so, empty otherwiseg
+- Add a NOTES column to the output of the `get apps` command. The column contains information why the last Helm release attempt failed if so, empty otherwise.
 
 ## [2.10.0] - 2022-05-13
 

--- a/cmd/get/apps/printer.go
+++ b/cmd/get/apps/printer.go
@@ -71,6 +71,7 @@ func getTable(appResource app.Resource) *metav1.Table {
 		{Name: "Version", Type: "string"},
 		{Name: "Last Deployed", Type: "string", Format: "date-time"},
 		{Name: "Status", Type: "string"},
+		{Name: "Notes", Type: "string"},
 	}
 
 	switch c := appResource.(type) {
@@ -96,6 +97,7 @@ func getAppRow(a app.App) metav1.TableRow {
 			a.CR.Status.Version,
 			output.TranslateTimestampSince(a.CR.Status.Release.LastDeployed),
 			a.CR.Status.Release.Status,
+			a.CR.Status.Release.Reason,
 		},
 		Object: runtime.RawExtension{
 			Object: a.CR,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22017

## Description 

The displayed content is `.status.release.reason`.

The status of an App CR is synced over from the associated Chart CR. The reason field contains information on the outcome of the last Helm release, only for error scenarios. The other fields reflect the actual current state of the Helm release.

## Related changes
- https://github.com/giantswarm/chart-operator/pull/873

## Example outputs

Happy path, the actual release matches the desired release, the last Helm release attempt was successful.

```
NAME              VERSION                                          LAST DEPLOYED   STATUS     NOTES
hello-world-app   0.3.0-7b13cb84dc6a7a5aa955d01710e306879d99ef02   13m             deployed
```

We update the App CR version to let's say `0.3.0-b7314a5111b7223ad46653e7c848afe47e3e15fa` with contains errors that causes the Helm release for it to fail with an error message. This will persist the reason of the failure on the Chart CR that will be synced over to the App CR by `app-operator`.  In this case `kubectl-gs` will now display details on the last failure:
- the version that the Helm release failed for
- the error categorisation as determined by `chart-operator`
- the error message returned by the Helm release

```
NAME              VERSION                                          LAST DEPLOYED   STATUS     NOTES
hello-world-app   0.3.0-7b13cb84dc6a7a5aa955d01710e306879d99ef02   12m             deployed   Deployment failed for `0.3.0-b7314a5111b7223ad46653e7c848afe47e3e15fa` with `unknown-error`: `unable to recognize "": no matches for kind "Deployment" in version "dummies/v1"`
```

IMPORTANT: Please note the `VERSION`, `LAST DEPLOYED` and `STATUS` columns always contain the actual status of the Helm release. Since the  Helm release for version `0.3.0-7b13cb84dc6a7a5aa955d01710e306879d99ef02` was successful and it failed for `0.3.0-b7314a5111b7223ad46653e7c848afe47e3e15fa` means that the Helm release was not updated so version `0.3.0-7b13cb84dc6a7a5aa955d01710e306879d99ef02` is still the currently deployed version by Helm. The `NOTES` column contains the info that `0.3.0-b7314a5111b7223ad46653e7c848afe47e3e15fa` failed and with what reason.


---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [x] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
