### PR TITLE
Pass region flag to template config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass region flag to template config
+
 ## [2.11.1] - 2022-05-25
 
 ### Fixed

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -60,6 +60,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			PodsCIDR:          r.flag.PodsCIDR,
 			ReleaseVersion:    r.flag.Release,
 			Namespace:         metav1.NamespaceDefault,
+			Region:            r.flag.Region,
 
 			App:       r.flag.App,
 			AWS:       r.flag.AWS,


### PR DESCRIPTION
Ensure that the `region` CLI flag is passed through for use by the templates

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
