### PR TITLE
Make kubectl-gs login work on gcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make `kubectl gs login` to work on GCP clusters.
+
 ## [2.11.2] - 2022-05-26
 
 ### Fixed

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -300,7 +300,7 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess, provider string)
 	clusterServer = strings.TrimPrefix(clusterServer, "https://api.g8s.")
 
 	// openstack clusters have an api.$INSTALLATION prefix
-	if provider == key.ProviderOpenStack {
+	if key.IsPureCAPIProvider(provider) {
 		if _, contextType := kubeconfig.IsKubeContext(config.CurrentContext); contextType == kubeconfig.ContextTypeMC {
 			clusterName := kubeconfig.GetCodeNameFromKubeContext(config.CurrentContext)
 			clusterServer = strings.TrimPrefix(clusterServer, "https://api."+clusterName+".")
@@ -313,8 +313,8 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess, provider string)
 }
 
 func getServerAddress(certconfig clientCertConfig) string {
-	switch certconfig.provider {
-	case key.ProviderOpenStack:
+	switch {
+	case key.IsPureCAPIProvider(certconfig.provider):
 		return fmt.Sprintf("https://api.%s.%s:6443", certconfig.clusterName, certconfig.clusterBasePath)
 	default:
 		return fmt.Sprintf("https://api.%s.k8s.%s", certconfig.clusterName, certconfig.clusterBasePath)


### PR DESCRIPTION
Add support for `kubectl gs login` in `gcp`.