### PR TITLE
When loging in take the k8s API endpoint from Cluster CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- When loging in, take the k8s API endpoint from the `Cluster` CR rather than calculating it.
+
 ## [2.11.2] - 2022-05-26
 
 ### Fixed

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -216,7 +216,7 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 		certCRT:       secret.Data[credentialKeyCertCRT],
 		certKey:       secret.Data[credentialKeyCertKey],
 		certCA:        secret.Data[credentialKeyCertCA],
-		clusterServer: getServerAddress(certConfig),
+		clusterServer: fmt.Sprintf("%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port),
 		filePath:      r.flag.SelfContained,
 		loginOptions:  r.loginOptions,
 	}
@@ -310,13 +310,4 @@ func getClusterBasePath(k8sConfigAccess clientcmd.ConfigAccess, provider string)
 	}
 
 	return strings.TrimPrefix(clusterServer, "https://g8s."), nil
-}
-
-func getServerAddress(certconfig clientCertConfig) string {
-	switch certconfig.provider {
-	case key.ProviderOpenStack:
-		return fmt.Sprintf("https://api.%s.%s:6443", certconfig.clusterName, certconfig.clusterBasePath)
-	default:
-		return fmt.Sprintf("https://api.%s.k8s.%s", certconfig.clusterName, certconfig.clusterBasePath)
-	}
 }


### PR DESCRIPTION
We are now building the k8s api endpoint by manipulating strings with the expected values, but all that info is already stored in the `Cluster` CR. This way if there are differences between providers, it doesn't really matter to `kubectl-gs` because it only uses whatever the provider has set on the CRs.

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
