### PR TITLE
Update kubectl-gs template catalog with new CR definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   debug-tag:
     docker:
-      - image: cimg/base:2022.04
+      - image: cimg/base:2022.05
     steps:
       - checkout
       - run: |
@@ -14,7 +14,7 @@ jobs:
 
   update-krew-index:
     docker:
-      - image: cimg/go:1.18.1
+      - image: cimg/go:1.18.2
 
     environment:
       KREW_RELEASE_BOT_VERSION: v0.0.38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Updated `kubectl gs template catalog` to support multiple repository mirrors.
+
 ## [2.12.0] - 2022-06-02
 
 ### Changed

--- a/cmd/get/catalogs/printer.go
+++ b/cmd/get/catalogs/printer.go
@@ -2,6 +2,7 @@ package catalogs
 
 import (
 	"fmt"
+	"strings"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -107,11 +108,23 @@ func getCatalogRow(a catalogdata.Catalog) metav1.TableRow {
 		return metav1.TableRow{}
 	}
 
+	var urlString string
+	{
+		urls := []string{}
+		for _, repo := range a.CR.Spec.Repositories {
+			urls = append(urls, repo.URL)
+		}
+		urlString = strings.Join(urls, ", ")
+		if len(urlString) > 80 {
+			urlString = fmt.Sprintf("%s...", urlString[:77])
+		}
+	}
+
 	return metav1.TableRow{
 		Cells: []interface{}{
 			a.CR.Name,
 			a.CR.Namespace,
-			a.CR.Spec.Storage.URL,
+			urlString,
 			output.TranslateTimestampSince(a.CR.CreationTimestamp),
 		},
 		Object: runtime.RawExtension{

--- a/cmd/get/catalogs/printer.go
+++ b/cmd/get/catalogs/printer.go
@@ -118,6 +118,10 @@ func getCatalogRow(a catalogdata.Catalog) metav1.TableRow {
 		if len(urlString) > 80 {
 			urlString = fmt.Sprintf("%s...", urlString[:77])
 		}
+		if len(urlString) == 0 {
+			// No .spec.repositories
+			urlString = a.CR.Spec.Storage.URL
+		}
 	}
 
 	return metav1.TableRow{

--- a/cmd/template/catalog/command.go
+++ b/cmd/template/catalog/command.go
@@ -12,6 +12,15 @@ import (
 const (
 	name        = "catalog"
 	description = "Template Catalog CR."
+	example     = `
+    Basic catalog with a single repository:
+
+    kubectl-gs template catalog --name my-catalog --namespace default --logo https://example.com/img.jpg --description 'Custom catalog' --type helm --url https://example.com/helm-catalog/
+
+    Catalog with a multiple repository mirrors:
+
+    kubectl-gs template catalog --name my-catalog --namespace default --logo https://example.com/img.jpg --description 'Custom catalog' --type helm --url https://example.com/helm-catalog/ --type helm --url https://example.com/helm-mirror/ --type oci --url oci://example.com/oci-registry/
+`
 )
 
 type Config struct {
@@ -41,10 +50,11 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	c := &cobra.Command{
-		Use:   name,
-		Short: description,
-		Long:  description,
-		RunE:  r.Run,
+		Use:     name,
+		Short:   description,
+		Long:    description,
+		Example: example,
+		RunE:    r.Run,
 	}
 
 	f.Init(c)

--- a/cmd/template/catalog/flag.go
+++ b/cmd/template/catalog/flag.go
@@ -15,6 +15,7 @@ const (
 	flagNamespace   = "namespace"
 	flagSecret      = "secret"
 	flagURL         = "url"
+	flagURLType     = "type"
 	flagVisibility  = "visibility"
 )
 
@@ -25,7 +26,8 @@ type flag struct {
 	Name        string
 	Namespace   string
 	Secret      string
-	URL         string
+	URLs        []string
+	URLTypes    []string
 	Visibility  string
 }
 
@@ -36,8 +38,11 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Name, flagName, "", "Catalog name.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the catalog will be created.")
 	cmd.Flags().StringVar(&f.Secret, flagSecret, "", "Path to a secret file.")
-	cmd.Flags().StringVar(&f.URL, flagURL, "", "Catalog storage URL.")
+	cmd.Flags().StringArrayVar(&f.URLs, flagURL, []string{}, "Catalog storage URL.")
+	cmd.Flags().StringArrayVar(&f.URLTypes, flagURLType, []string{}, "Type of catalog storage.")
 	cmd.Flags().StringVar(&f.Visibility, flagVisibility, "public", "Visibility label for whether catalog appears in the web UI.")
+
+	// TODO(kuba): add long desc. with usage example, especially --url --type --url etc.
 }
 
 func (f *flag) Validate() error {
@@ -57,11 +62,22 @@ func (f *flag) Validate() error {
 	if f.Namespace == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagNamespace)
 	}
-	if f.URL == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagURL)
+	if len(f.URLs) == 0 {
+		return microerror.Maskf(invalidFlagError, "at least one --%s must be defined", flagURL)
 	}
-	if _, err := url.ParseRequestURI(f.URL); err != nil {
-		return microerror.Maskf(invalidFlagError, "--%s must be a valid URL", flagURL)
+	for _, u := range f.URLs {
+		if _, err := url.ParseRequestURI(u); err != nil {
+			return microerror.Maskf(invalidFlagError, "--%s must be a valid URL: %#q", flagURL, u)
+		}
+	}
+	if len(f.URLTypes) == 0 {
+		return microerror.Maskf(invalidFlagError, "at least one --%s must be defined", flagURLType)
+	}
+	if len(f.URLs) != len(f.URLTypes) {
+		return microerror.Maskf(invalidFlagError,
+			"number of --%s (%d) and --%s (%d) has to match",
+			flagURL, len(f.URLs), flagURLType, len(f.URLTypes),
+		)
 	}
 
 	return nil

--- a/cmd/template/catalog/flag.go
+++ b/cmd/template/catalog/flag.go
@@ -41,8 +41,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(&f.URLs, flagURL, []string{}, "Catalog storage URL.")
 	cmd.Flags().StringArrayVar(&f.URLTypes, flagURLType, []string{"helm"}, "Type of catalog storage.")
 	cmd.Flags().StringVar(&f.Visibility, flagVisibility, "public", "Visibility label for whether catalog appears in the web UI.")
-
-	// TODO(kuba): add long desc. with usage example, especially --url --type --url etc.
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/catalog/flag.go
+++ b/cmd/template/catalog/flag.go
@@ -39,7 +39,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace where the catalog will be created.")
 	cmd.Flags().StringVar(&f.Secret, flagSecret, "", "Path to a secret file.")
 	cmd.Flags().StringArrayVar(&f.URLs, flagURL, []string{}, "Catalog storage URL.")
-	cmd.Flags().StringArrayVar(&f.URLTypes, flagURLType, []string{}, "Type of catalog storage.")
+	cmd.Flags().StringArrayVar(&f.URLTypes, flagURLType, []string{"helm"}, "Type of catalog storage.")
 	cmd.Flags().StringVar(&f.Visibility, flagVisibility, "public", "Visibility label for whether catalog appears in the web UI.")
 
 	// TODO(kuba): add long desc. with usage example, especially --url --type --url etc.

--- a/cmd/template/catalog/runner.go
+++ b/cmd/template/catalog/runner.go
@@ -48,14 +48,22 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		return microerror.Mask(err)
 	}
 
+	// Conversion of URLs and URLTypes to a map helps us remove duplicate
+	// values. URLs and URLTypes have the same number of items, as guaranteed
+	// by flag validation.
+	repositories := map[string]string{}
+	for i, url := range r.flag.URLs {
+		repositories[url] = r.flag.URLTypes[i]
+	}
+
 	config := templatecatalog.Config{
-		Description: r.flag.Description,
-		LogoURL:     r.flag.LogoURL,
-		ID:          catalogID,
-		Name:        r.flag.Name,
-		Namespace:   r.flag.Namespace,
-		URL:         r.flag.URL,
-		Visibility:  r.flag.Visibility,
+		Description:  r.flag.Description,
+		LogoURL:      r.flag.LogoURL,
+		ID:           catalogID,
+		Name:         r.flag.Name,
+		Namespace:    r.flag.Namespace,
+		Repositories: repositories,
+		Visibility:   r.flag.Visibility,
 	}
 
 	if r.flag.ConfigMap != "" {

--- a/cmd/update/app/runner_test.go
+++ b/cmd/update/app/runner_test.go
@@ -217,6 +217,12 @@ func newCatalog(catalogName string) *applicationv1alpha1.Catalog {
 				Type: "helm",
 				URL:  fmt.Sprintf("http://%s/", address),
 			},
+			Repositories: []applicationv1alpha1.CatalogSpecRepository{
+				{
+					Type: "helm",
+					URL:  fmt.Sprintf("http://%s/", address),
+				},
+			},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
-	github.com/coreos/go-oidc/v3 v3.1.0
+	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.13.0
 	github.com/giantswarm/apiextensions-application v0.3.1
@@ -18,14 +18,14 @@ require (
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/giantswarm/release-operator/v3 v3.2.0
-	github.com/google/go-cmp v0.5.7
+	github.com/google/go-cmp v0.5.8
 	github.com/pkg/errors v0.9.1
 	github.com/rhysd/go-github-selfupdate v1.2.3
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/cobra v1.4.0
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.23.0
 	k8s.io/apiextensions-apiserver v0.23.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.13.0
-	github.com/giantswarm/apiextensions-application v0.3.1
+	github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e
 	github.com/giantswarm/apiextensions/v6 v6.0.0
 	github.com/giantswarm/app/v6 v6.10.0
 	github.com/giantswarm/appcatalog v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.13.0
-	github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e
+	github.com/giantswarm/apiextensions-application v0.4.0
 	github.com/giantswarm/apiextensions/v6 v6.0.0
 	github.com/giantswarm/app/v6 v6.10.0
 	github.com/giantswarm/appcatalog v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -389,7 +389,6 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/apiextensions-application v0.3.1 h1:lFocFEFOAQnn2U0O72fP4NQYqHcFc37NyVFMtCB0Tas=
 github.com/giantswarm/apiextensions-application v0.3.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e h1:sbcvomsRyF2XELxRyH+7LL6ktujFE2wEA6JsJn7RgeI=
 github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions-application v0.3.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
-github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e h1:sbcvomsRyF2XELxRyH+7LL6ktujFE2wEA6JsJn7RgeI=
-github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
+github.com/giantswarm/apiextensions-application v0.4.0 h1:7dNG5bdbO6zSNDAbHlJrc3fJ/iXUTlzhLWGhz7tTsPs=
+github.com/giantswarm/apiextensions-application v0.4.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions/v6 v6.0.0 h1:SamEmmMgLW67ediwm4FawaE1gOtkMQKJOtDBqRzhUoc=
 github.com/giantswarm/apiextensions/v6 v6.0.0/go.mod h1:ugRm5aLig6GCOymmwRG2nQ0nScMJKJt8Lq6GuDZ6oOo=
 github.com/giantswarm/app/v6 v6.10.0 h1:YVKStwofYYjVr6Hzx6Esubxqj869duEwhxVTgs1VFR0=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/coreos/go-iptables v0.3.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmeka
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible h1:sdJrfw8akMnCuUlaZU3tE/uYXFgfqom8DBE9so9EBsM=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
-github.com/coreos/go-oidc/v3 v3.1.0 h1:6avEvcdvTa1qYsOZ6I5PRkSYHzpTNWgKYmaJfaYbrRw=
-github.com/coreos/go-oidc/v3 v3.1.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
+github.com/coreos/go-oidc/v3 v3.2.0 h1:2eR2MGR7thBXSQ2YbODlF0fcmgtliLCfr9iX6RW11fc=
+github.com/coreos/go-oidc/v3 v3.2.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
 github.com/coreos/go-semver v0.1.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -611,8 +611,9 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
 github.com/google/go-github/v30 v30.1.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=
@@ -1482,8 +1483,8 @@ golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
-golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401 h1:zwrSfklXn0gxyLRX/aR+q6cgHbV/ItVyzbPlbA+dkAw=
+golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1717,7 +1718,6 @@ golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpd
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v2 v2.1.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/giantswarm/apiextensions-application v0.1.0/go.mod h1:O6mg+EdXC9CyTLg
 github.com/giantswarm/apiextensions-application v0.3.0/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions-application v0.3.1 h1:lFocFEFOAQnn2U0O72fP4NQYqHcFc37NyVFMtCB0Tas=
 github.com/giantswarm/apiextensions-application v0.3.1/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
+github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e h1:sbcvomsRyF2XELxRyH+7LL6ktujFE2wEA6JsJn7RgeI=
+github.com/giantswarm/apiextensions-application v0.3.2-0.20220601125452-b940494d929e/go.mod h1:O6mg+EdXC9CyTLgi0d3rf6QTXrQX/79iw4kjMJRinig=
 github.com/giantswarm/apiextensions/v6 v6.0.0 h1:SamEmmMgLW67ediwm4FawaE1gOtkMQKJOtDBqRzhUoc=
 github.com/giantswarm/apiextensions/v6 v6.0.0/go.mod h1:ugRm5aLig6GCOymmwRG2nQ0nScMJKJt8Lq6GuDZ6oOo=
 github.com/giantswarm/app/v6 v6.10.0 h1:YVKStwofYYjVr6Hzx6Esubxqj869duEwhxVTgs1VFR0=

--- a/pkg/app/validate.go
+++ b/pkg/app/validate.go
@@ -314,6 +314,11 @@ func (s *Service) fetchCatalogIndex(ctx context.Context, catalogName, catalogNam
 			break
 		}
 	}
+	// Legacy: use deprecated .spec.storage in case .spec.repositories is empty.
+	if catalogURL == "" && !foundHelmRepository && catalog.Spec.Storage.Type == "helm" {
+		catalogURL = catalog.Spec.Storage.URL
+		foundHelmRepository = true
+	}
 	// Error for catalogs where we for sure can't fetch the index because we don't
 	// know about the storage type yet.
 	if !foundHelmRepository {

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -178,7 +178,16 @@ func (s *Service) validateVersion(ctx context.Context, appName, appVersion, appC
 		return microerror.Mask(err)
 	}
 
-	tarbalURL, err := appcatalog.NewTarballURL(catalog.Spec.Repositories[0].URL, appName, appVersion)
+	var storageURL string
+	if len(catalog.Spec.Repositories) > 0 {
+		// The new way - Catalogs support more than one chart repository.
+		storageURL = catalog.Spec.Repositories[0].URL
+	} else {
+		// DEPRECATED: The legacy way - failsafe in case somebody forgets to
+		// set repositories.
+		storageURL = catalog.Spec.Storage.URL
+	}
+	tarbalURL, err := appcatalog.NewTarballURL(storageURL, appName, appVersion)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -178,7 +178,7 @@ func (s *Service) validateVersion(ctx context.Context, appName, appVersion, appC
 		return microerror.Mask(err)
 	}
 
-	tarbalURL, err := appcatalog.NewTarballURL(catalog.Spec.Storage.URL, appName, appVersion)
+	tarbalURL, err := appcatalog.NewTarballURL(catalog.Spec.Repositories[0].URL, appName, appVersion)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/template/catalog/catalog.go
+++ b/pkg/template/catalog/catalog.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -15,12 +16,16 @@ type Config struct {
 	Name                 string
 	Namespace            string
 	LogoURL              string
-	URL                  string
+	Repositories         map[string]string
 	Visibility           string
 }
 
 func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
 	var catalogConfig *applicationv1alpha1.CatalogSpecConfig
+
+	if len(config.Repositories) == 0 {
+		return nil, microerror.Maskf(executionFailedError, "config.Repositories cannot be empty")
+	}
 
 	if config.CatalogConfigMapName != "" || config.CatalogSecretName != "" {
 		catalogConfig = &applicationv1alpha1.CatalogSpecConfig{}
@@ -45,6 +50,14 @@ func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
 		labelValues[label.CatalogVisibility] = config.Visibility
 	}
 
+	repositories := []applicationv1alpha1.CatalogSpecRepository{}
+	for url, urlType := range config.Repositories {
+		repositories = append(repositories, applicationv1alpha1.CatalogSpecRepository{
+			URL:  url,
+			Type: urlType,
+		})
+	}
+
 	catalogCR := &applicationv1alpha1.Catalog{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Catalog",
@@ -60,10 +73,11 @@ func NewCatalogCR(config Config) (*applicationv1alpha1.Catalog, error) {
 			Description: config.Description,
 			LogoURL:     config.LogoURL,
 			Storage: applicationv1alpha1.CatalogSpecStorage{
-				URL:  config.URL,
-				Type: "helm",
+				URL:  repositories[0].URL,
+				Type: repositories[0].Type,
 			},
-			Title: config.Name,
+			Repositories: repositories,
+			Title:        config.Name,
 		},
 	}
 

--- a/pkg/template/catalog/error.go
+++ b/pkg/template/catalog/error.go
@@ -1,0 +1,9 @@
+package catalog
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21782

Team Honeybadger is extending Catalog CRs in order to provide Helm Catalog redundancy and allow internal catalogs to rely on OCI Registries. Where previously Catalog CRs allowed for specifying just one backend in `.spec.storage`, we now support an array of backends in `.spec.repositories`. `.spec.storage` is kept for backwards compatiblilty until older versions of app-operator are phased out. This required extending the `kubectl gs template catalog` command.

Docs https://github.com/giantswarm/docs/pull/1466

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [x] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here. 
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
