### PR TITLE
Let `template cluster` add a service priority label by default

### DIFF
--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -150,6 +150,10 @@ func newcapiClusterCR(config ClusterConfig, infrastructureRef *corev1.ObjectRefe
 				label.ReleaseVersion:         config.ReleaseVersion,
 				label.AzureOperatorVersion:   config.ReleaseComponents["azure-operator"],
 				label.ClusterOperatorVersion: config.ReleaseComponents["cluster-operator"],
+
+				// According to RFC https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority
+				// we use "highest" as the default service priority.
+				label.ServicePriority: label.ServicePriorityHighest,
 			},
 			Annotations: map[string]string{
 				annotation.ClusterDescription: config.Description,
@@ -158,6 +162,10 @@ func newcapiClusterCR(config ClusterConfig, infrastructureRef *corev1.ObjectRefe
 		Spec: capi.ClusterSpec{
 			InfrastructureRef: infrastructureRef,
 		},
+	}
+
+	if val, ok := config.Labels[label.ServicePriority]; ok {
+		cluster.ObjectMeta.Labels[label.ServicePriority] = val
 	}
 
 	return cluster

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/giantswarm/appcatalog v0.7.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.11.0
+	github.com/giantswarm/k8smetadata v0.11.1-0.20220602152437-d2d60476daf4
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/giantswarm/release-operator/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,8 @@ github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ij
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.0 h1:XWcN0b6yBm2eH2Ael5SFFR87iRIigI+SRIfuiQBsxZ4=
 github.com/giantswarm/k8smetadata v0.11.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.11.1-0.20220602152437-d2d60476daf4 h1:O89R6iN6SJkJZujHf52b+uW+ibfskglnlfM9BUZnbp4=
+github.com/giantswarm/k8smetadata v0.11.1-0.20220602152437-d2d60476daf4/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22288 https://github.com/giantswarm/giantswarm/issues/13342

This PR adds

- By default, the cluster CR output will contain the label `giantswarm.io/service-priority: highest`
- Let the user override the label value by using the `--label` or `--service-priority` flag