### PR TITLE
Display `SERVICE PRIORITY` column in `get clusters` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+- Add `SERVICE PRIORITY` column to `get clusters` command table output.
+
 ### Fixed
 
 - Take `--context` flag into account when building config for `login`.

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -15,8 +15,9 @@ import (
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	"github.com/giantswarm/k8smetadata/pkg/label"
+
 	"github.com/giantswarm/kubectl-gs/internal/key"
-	"github.com/giantswarm/kubectl-gs/internal/label"
 	"github.com/giantswarm/kubectl-gs/pkg/data/domain/cluster"
 	"github.com/giantswarm/kubectl-gs/pkg/output"
 	"github.com/giantswarm/kubectl-gs/test/goldenfile"
@@ -39,12 +40,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 0: print list of AWS clusters, with table output",
 			clusterRes: newClusterCollection(
-				*newAWSCluster("1sad2", time.Now().Format(time.RFC3339), "12.0.0", "test", "test cluster 1", nil),
-				*newAWSCluster("2a03f", time.Now().Format(time.RFC3339), "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAWSCluster("asd29", time.Now().Format(time.RFC3339), "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAWSCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", nil),
-				*newAWSCluster("9f012", time.Now().Format(time.RFC3339), "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAWSCluster("2f0as", time.Now().Format(time.RFC3339), "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("1sad2", time.Now().Format(time.RFC3339), "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAWSCluster("2a03f", time.Now().Format(time.RFC3339), "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", time.Now().Format(time.RFC3339), "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAWSCluster("9f012", time.Now().Format(time.RFC3339), "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", time.Now().Format(time.RFC3339), "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeDefault,
@@ -53,12 +54,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 1: print list of AWS clusters, with JSON output",
 			clusterRes: newClusterCollection(
-				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeJSON,
@@ -67,12 +68,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 2: print list of AWS clusters, with YAML output",
 			clusterRes: newClusterCollection(
-				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeYAML,
@@ -81,12 +82,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 3: print list of AWS clusters, with name output",
 			clusterRes: newClusterCollection(
-				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAWSCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAWSCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAWSCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAWSCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeName,
@@ -94,28 +95,28 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name:               "case 4: print single AWS cluster, with table output",
-			clusterRes:         newAWSCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeDefault,
 			expectedGoldenFile: "print_single_aws_cluster_table_output.golden",
 		},
 		{
 			name:               "case 5: print single AWS cluster, with JSON output",
-			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeJSON,
 			expectedGoldenFile: "print_single_aws_cluster_json_output.golden",
 		},
 		{
 			name:               "case 6: print single AWS cluster, with YAML output",
-			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeYAML,
 			expectedGoldenFile: "print_single_aws_cluster_yaml_output.golden",
 		},
 		{
 			name:               "case 7: print single AWS cluster, with name output",
-			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAWSCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAWS,
 			outputType:         output.TypeName,
 			expectedGoldenFile: "print_single_aws_cluster_name_output.golden",
@@ -123,12 +124,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 8: print list of Azure clusters, with table output",
 			clusterRes: newClusterCollection(
-				*newAzureCluster("1sad2", time.Now().Format(time.RFC3339), "12.0.0", "test", "test cluster 1", nil),
-				*newAzureCluster("2a03f", time.Now().Format(time.RFC3339), "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAzureCluster("asd29", time.Now().Format(time.RFC3339), "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAzureCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", nil),
-				*newAzureCluster("9f012", time.Now().Format(time.RFC3339), "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAzureCluster("2f0as", time.Now().Format(time.RFC3339), "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("1sad2", time.Now().Format(time.RFC3339), "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAzureCluster("2a03f", time.Now().Format(time.RFC3339), "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", time.Now().Format(time.RFC3339), "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAzureCluster("9f012", time.Now().Format(time.RFC3339), "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", time.Now().Format(time.RFC3339), "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeDefault,
@@ -137,12 +138,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 9: print list of Azure clusters, with JSON output",
 			clusterRes: newClusterCollection(
-				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeJSON,
@@ -151,12 +152,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 10: print list of Azure clusters, with YAML output",
 			clusterRes: newClusterCollection(
-				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeYAML,
@@ -165,12 +166,12 @@ func Test_printOutput(t *testing.T) {
 		{
 			name: "case 11: print list of Azure clusters, with name output",
 			clusterRes: newClusterCollection(
-				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", nil),
-				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
-				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
-				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", nil),
-				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
-				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("1sad2", "2021-01-02T15:04:32Z", "12.0.0", "test", "test cluster 1", label.ServicePriorityHighest, nil),
+				*newAzureCluster("2a03f", "2021-01-02T15:04:32Z", "11.0.0", "test", "test cluster 2", label.ServicePriorityMedium, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+				*newAzureCluster("asd29", "2021-01-02T15:04:32Z", "10.5.0", "test", "test cluster 3", label.ServicePriorityLowest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated, infrastructurev1alpha3.ClusterStatusConditionCreating}),
+				*newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", "", nil),
+				*newAzureCluster("9f012", "2021-01-02T15:04:32Z", "9.0.0", "test", "test cluster 5", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting}),
+				*newAzureCluster("2f0as", "2021-01-02T15:04:32Z", "10.5.0", "random", "test cluster 6", "", []string{infrastructurev1alpha3.ClusterStatusConditionDeleting, infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeName,
@@ -178,28 +179,28 @@ func Test_printOutput(t *testing.T) {
 		},
 		{
 			name:               "case 12: print single Azure cluster, with table output",
-			clusterRes:         newAzureCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeDefault,
 			expectedGoldenFile: "print_single_azure_cluster_table_output.golden",
 		},
 		{
 			name:               "case 13: print single Azure cluster, with JSON output",
-			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeJSON,
 			expectedGoldenFile: "print_single_azure_cluster_json_output.golden",
 		},
 		{
 			name:               "case 14: print single Azure cluster, with YAML output",
-			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeYAML,
 			expectedGoldenFile: "print_single_azure_cluster_yaml_output.golden",
 		},
 		{
 			name:               "case 15: print single Azure cluster, with name output",
-			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
+			clusterRes:         newAzureCluster("f930q", "2021-01-02T15:04:32Z", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityHighest, []string{infrastructurev1alpha3.ClusterStatusConditionCreated}),
 			provider:           key.ProviderAzure,
 			outputType:         output.TypeName,
 			expectedGoldenFile: "print_single_azure_cluster_name_output.golden",
@@ -248,7 +249,7 @@ func Test_printOutput(t *testing.T) {
 	}
 }
 
-func newcapiCluster(id, created, release, org, description string, conditions []string) *capi.Cluster {
+func newcapiCluster(id, created, release, org, description, servicePriority string, conditions []string) *capi.Cluster {
 	location, _ := time.LoadLocation("UTC")
 	parsedCreationDate, _ := time.ParseInLocation(time.RFC3339, created, location)
 	c := &capi.Cluster{
@@ -264,6 +265,7 @@ func newcapiCluster(id, created, release, org, description string, conditions []
 				label.ReleaseVersion:  release,
 				label.Organization:    org,
 				capi.ClusterLabelName: id,
+				label.ServicePriority: servicePriority,
 			},
 			Annotations: map[string]string{
 				annotation.ClusterDescription: description,
@@ -319,9 +321,9 @@ func newAWSClusterResource(id, created, release, org, description string, condit
 	return c
 }
 
-func newAWSCluster(id, created, release, org, description string, conditions []string) *cluster.Cluster {
+func newAWSCluster(id, created, release, org, description, servicePriority string, conditions []string) *cluster.Cluster {
 	awsCluster := newAWSClusterResource(id, created, release, org, description, conditions)
-	capiCluster := newcapiCluster(id, "default", release, org, description, conditions)
+	capiCluster := newcapiCluster(id, "default", release, org, description, servicePriority, conditions)
 
 	c := &cluster.Cluster{
 		AWSCluster: awsCluster,
@@ -348,9 +350,9 @@ func newAzureClusterResource(id, namespace string) *capz.AzureCluster {
 	return c
 }
 
-func newAzureCluster(id, created, release, org, description string, conditions []string) *cluster.Cluster {
+func newAzureCluster(id, created, release, org, description, servicePriority string, conditions []string) *cluster.Cluster {
 	azureCluster := newAzureClusterResource(id, "default")
-	capiCluster := newcapiCluster(id, created, release, org, description, conditions)
+	capiCluster := newcapiCluster(id, created, release, org, description, servicePriority, conditions)
 
 	c := &cluster.Cluster{
 		AzureCluster: azureCluster,

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -19,6 +19,7 @@ func GetAWSTable(clusterResource cluster.Resource) *metav1.Table {
 		{Name: "Age", Type: "string", Format: "date-time"},
 		{Name: "Condition", Type: "string"},
 		{Name: "Release", Type: "string"},
+		{Name: "Service Priority", Type: "string"},
 		{Name: "Organization", Type: "string"},
 		{Name: "Description", Type: "string"},
 	}
@@ -46,6 +47,7 @@ func getAWSClusterRow(c cluster.Cluster) metav1.TableRow {
 			output.TranslateTimestampSince(c.AWSCluster.CreationTimestamp),
 			getLatestAWSCondition(c.AWSCluster.Status.Cluster.Conditions),
 			c.AWSCluster.Labels[label.ReleaseVersion],
+			getClusterServicePriority(c.Cluster),
 			c.AWSCluster.Labels[label.Organization],
 			c.AWSCluster.Spec.Cluster.Description,
 		},

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -18,6 +18,7 @@ func GetAzureTable(clusterResource cluster.Resource) *metav1.Table {
 		{Name: "Age", Type: "string", Format: "date-time"},
 		{Name: "Condition", Type: "string"},
 		{Name: "Release", Type: "string"},
+		{Name: "Service Priority", Type: "string"},
 		{Name: "Organization", Type: "string"},
 		{Name: "Description", Type: "string"},
 	}
@@ -45,6 +46,7 @@ func getAzureClusterRow(c cluster.Cluster) metav1.TableRow {
 			output.TranslateTimestampSince(c.Cluster.CreationTimestamp),
 			getLatestCondition(c.Cluster.GetConditions()),
 			c.Cluster.Labels[label.ReleaseVersion],
+			getClusterServicePriority(c.Cluster),
 			c.Cluster.Labels[label.Organization],
 			getClusterDescription(c.Cluster),
 		},

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -49,7 +49,7 @@ func getClusterServicePriority(res *capi.Cluster) string {
 	servicePriority := naValue
 
 	if servicePriorityLabel := res.Labels[label.ServicePriority]; servicePriorityLabel != "" {
-		servicePriority = strings.ToUpper(servicePriorityLabel)
+		servicePriority = servicePriorityLabel
 	}
 
 	return servicePriority

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -44,3 +44,13 @@ func getClusterOrganization(res *capi.Cluster) string {
 
 	return organization
 }
+
+func getClusterServicePriority(res *capi.Cluster) string {
+	servicePriority := naValue
+
+	if servicePriorityLabel := res.Labels[label.ServicePriority]; servicePriorityLabel != "" {
+		servicePriority = strings.ToUpper(servicePriorityLabel)
+	}
+
+	return servicePriority
+}

--- a/cmd/get/clusters/provider/openstack.go
+++ b/cmd/get/clusters/provider/openstack.go
@@ -18,6 +18,7 @@ func GetOpenStackTable(clusterResource cluster.Resource) *metav1.Table {
 		{Name: "Condition", Type: "string"},
 		{Name: "Cluster Version", Type: "string"},
 		{Name: "Preinstalled Apps Version", Type: "string"},
+		{Name: "Service Priority", Type: "string"},
 		{Name: "Organization", Type: "string"},
 		{Name: "Description", Type: "string"},
 	}
@@ -56,6 +57,7 @@ func getOpenStackClusterRow(c cluster.Cluster) metav1.TableRow {
 			getLatestCondition(c.Cluster.GetConditions()),
 			clusterAppVersion,
 			defaultAppsAppVersion,
+			getClusterServicePriority(c.Cluster),
 			getClusterOrganization(c.Cluster),
 			getClusterDescription(c.Cluster),
 		},

--- a/cmd/get/clusters/runner_test.go
+++ b/cmd/get/clusters/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -37,9 +38,9 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 0: get clusters",
 			storage: []runtime.Object{
-				newcapiCluster("1sad2", "default", "10.5.0", "some-org", "test cluster 3", nil),
+				newcapiCluster("1sad2", "default", "10.5.0", "some-org", "test cluster 3", label.ServicePriorityHighest, nil),
 				newAWSClusterResource("1sad2", time.Now().Format(time.RFC3339), "10.5.0", "some-org", "test cluster 3", nil),
-				newcapiCluster("f930q", "default", "11.0.0", "some-other", "test cluster 4", nil),
+				newcapiCluster("f930q", "default", "11.0.0", "some-other", "test cluster 4", label.ServicePriorityMedium, nil),
 				newAWSClusterResource("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", nil),
 			},
 			args:               nil,
@@ -54,9 +55,9 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 2: get cluster by id",
 			storage: []runtime.Object{
-				newcapiCluster("1sad2", time.Now().Format(time.RFC3339), "10.5.0", "some-org", "test cluster 3", nil),
+				newcapiCluster("1sad2", time.Now().Format(time.RFC3339), "10.5.0", "some-org", "test cluster 3", label.ServicePriorityHighest, nil),
 				newAWSClusterResource("1sad2", time.Now().Format(time.RFC3339), "10.5.0", "some-org", "test cluster 3", nil),
-				newcapiCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", nil),
+				newcapiCluster("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", label.ServicePriorityMedium, nil),
 				newAWSClusterResource("f930q", time.Now().Format(time.RFC3339), "11.0.0", "some-other", "test cluster 4", nil),
 			},
 			args:               []string{"f930q"},
@@ -71,9 +72,9 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 4: get cluster by id, with no infrastructure cluster",
 			storage: []runtime.Object{
-				newcapiCluster("1sad2", "default", "10.5.0", "some-org", "test cluster 3", nil),
+				newcapiCluster("1sad2", "default", "10.5.0", "some-org", "test cluster 3", label.ServicePriorityHighest, nil),
 				newAWSClusterResource("1sad2", "2021-01-01T15:04:32Z", "10.5.0", "some-org", "test cluster 3", nil),
-				newcapiCluster("f930q", "default", "11.0.0", "some-other", "test cluster 3", nil),
+				newcapiCluster("f930q", "default", "11.0.0", "some-other", "test cluster 3", label.ServicePriorityMedium, nil),
 			},
 			args:         []string{"f930q"},
 			errorMatcher: IsNotFound,

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_json_output.golden
@@ -13,6 +13,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "1sad2",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "highest",
                     "release.giantswarm.io/version": "12.0.0"
                 },
                 "annotations": {
@@ -40,6 +41,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "2a03f",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "medium",
                     "release.giantswarm.io/version": "11.0.0"
                 },
                 "annotations": {
@@ -74,6 +76,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "asd29",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "lowest",
                     "release.giantswarm.io/version": "10.5.0"
                 },
                 "annotations": {
@@ -113,6 +116,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "f930q",
                     "giantswarm.io/organization": "some-other",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "11.0.0"
                 },
                 "annotations": {
@@ -140,6 +144,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "9f012",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "9.0.0"
                 },
                 "annotations": {
@@ -174,6 +179,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "2f0as",
                     "giantswarm.io/organization": "random",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "10.5.0"
                 },
                 "annotations": {

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
@@ -1,7 +1,7 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         12.0.0    HIGHEST            test           test cluster 1
-2a03f   0s    CREATED     11.0.0    MEDIUM             test           test cluster 2
-asd29   0s    CREATED     10.5.0    LOWEST             test           test cluster 3
+1sad2   0s    n/a         12.0.0    highest            test           test cluster 1
+2a03f   0s    CREATED     11.0.0    medium             test           test cluster 2
+asd29   0s    CREATED     10.5.0    lowest             test           test cluster 3
 f930q   0s    n/a         11.0.0    n/a                some-other     test cluster 4
 9f012   0s    DELETING    9.0.0     n/a                test           test cluster 5
 2f0as   0s    DELETING    10.5.0    n/a                random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_table_output.golden
@@ -1,7 +1,7 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         12.0.0    test           test cluster 1
-2a03f   0s    CREATED     11.0.0    test           test cluster 2
-asd29   0s    CREATED     10.5.0    test           test cluster 3
-f930q   0s    n/a         11.0.0    some-other     test cluster 4
-9f012   0s    DELETING    9.0.0     test           test cluster 5
-2f0as   0s    DELETING    10.5.0    random         test cluster 6
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+1sad2   0s    n/a         12.0.0    HIGHEST            test           test cluster 1
+2a03f   0s    CREATED     11.0.0    MEDIUM             test           test cluster 2
+asd29   0s    CREATED     10.5.0    LOWEST             test           test cluster 3
+f930q   0s    n/a         11.0.0    n/a                some-other     test cluster 4
+9f012   0s    DELETING    9.0.0     n/a                test           test cluster 5
+2f0as   0s    DELETING    10.5.0    n/a                random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_aws_clusters_yaml_output.golden
@@ -9,6 +9,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 1sad2
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: highest
       release.giantswarm.io/version: 12.0.0
     name: 1sad2
     namespace: default
@@ -28,6 +29,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 2a03f
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: medium
       release.giantswarm.io/version: 11.0.0
     name: 2a03f
     namespace: default
@@ -51,6 +53,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: asd29
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: lowest
       release.giantswarm.io/version: 10.5.0
     name: asd29
     namespace: default
@@ -77,6 +80,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: f930q
       giantswarm.io/organization: some-other
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 11.0.0
     name: f930q
     namespace: default
@@ -96,6 +100,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 9f012
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 9.0.0
     name: 9f012
     namespace: default
@@ -119,6 +124,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 2f0as
       giantswarm.io/organization: random
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 10.5.0
     name: 2f0as
     namespace: default

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_json_output.golden
@@ -13,6 +13,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "1sad2",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "highest",
                     "release.giantswarm.io/version": "12.0.0"
                 },
                 "annotations": {
@@ -40,6 +41,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "2a03f",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "medium",
                     "release.giantswarm.io/version": "11.0.0"
                 },
                 "annotations": {
@@ -74,6 +76,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "asd29",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "lowest",
                     "release.giantswarm.io/version": "10.5.0"
                 },
                 "annotations": {
@@ -113,6 +116,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "f930q",
                     "giantswarm.io/organization": "some-other",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "11.0.0"
                 },
                 "annotations": {
@@ -140,6 +144,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "9f012",
                     "giantswarm.io/organization": "test",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "9.0.0"
                 },
                 "annotations": {
@@ -174,6 +179,7 @@
                 "labels": {
                     "cluster.x-k8s.io/cluster-name": "2f0as",
                     "giantswarm.io/organization": "random",
+                    "giantswarm.io/service-priority": "",
                     "release.giantswarm.io/version": "10.5.0"
                 },
                 "annotations": {

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
@@ -1,7 +1,7 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         12.0.0    HIGHEST            test           test cluster 1
-2a03f   0s    CREATED     11.0.0    MEDIUM             test           test cluster 2
-asd29   0s    CREATED     10.5.0    LOWEST             test           test cluster 3
+1sad2   0s    n/a         12.0.0    highest            test           test cluster 1
+2a03f   0s    CREATED     11.0.0    medium             test           test cluster 2
+asd29   0s    CREATED     10.5.0    lowest             test           test cluster 3
 f930q   0s    n/a         11.0.0    n/a                some-other     test cluster 4
 9f012   0s    DELETING    9.0.0     n/a                test           test cluster 5
 2f0as   0s    DELETING    10.5.0    n/a                random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_table_output.golden
@@ -1,7 +1,7 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         12.0.0    test           test cluster 1
-2a03f   0s    CREATED     11.0.0    test           test cluster 2
-asd29   0s    CREATED     10.5.0    test           test cluster 3
-f930q   0s    n/a         11.0.0    some-other     test cluster 4
-9f012   0s    DELETING    9.0.0     test           test cluster 5
-2f0as   0s    DELETING    10.5.0    random         test cluster 6
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+1sad2   0s    n/a         12.0.0    HIGHEST            test           test cluster 1
+2a03f   0s    CREATED     11.0.0    MEDIUM             test           test cluster 2
+asd29   0s    CREATED     10.5.0    LOWEST             test           test cluster 3
+f930q   0s    n/a         11.0.0    n/a                some-other     test cluster 4
+9f012   0s    DELETING    9.0.0     n/a                test           test cluster 5
+2f0as   0s    DELETING    10.5.0    n/a                random         test cluster 6

--- a/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_list_of_azure_clusters_yaml_output.golden
@@ -9,6 +9,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 1sad2
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: highest
       release.giantswarm.io/version: 12.0.0
     name: 1sad2
     namespace: default
@@ -28,6 +29,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 2a03f
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: medium
       release.giantswarm.io/version: 11.0.0
     name: 2a03f
     namespace: default
@@ -51,6 +53,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: asd29
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: lowest
       release.giantswarm.io/version: 10.5.0
     name: asd29
     namespace: default
@@ -77,6 +80,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: f930q
       giantswarm.io/organization: some-other
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 11.0.0
     name: f930q
     namespace: default
@@ -96,6 +100,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 9f012
       giantswarm.io/organization: test
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 9.0.0
     name: 9f012
     namespace: default
@@ -119,6 +124,7 @@ items:
     labels:
       cluster.x-k8s.io/cluster-name: 2f0as
       giantswarm.io/organization: random
+      giantswarm.io/service-priority: ""
       release.giantswarm.io/version: 10.5.0
     name: 2f0as
     namespace: default

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_json_output.golden
@@ -8,6 +8,7 @@
         "labels": {
             "cluster.x-k8s.io/cluster-name": "f930q",
             "giantswarm.io/organization": "some-other",
+            "giantswarm.io/service-priority": "highest",
             "release.giantswarm.io/version": "11.0.0"
         },
         "annotations": {

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
@@ -1,2 +1,2 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-f930q   0s    CREATED     11.0.0    HIGHEST            some-other     test cluster 4
+f930q   0s    CREATED     11.0.0    highest            some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_table_output.golden
@@ -1,2 +1,2 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-f930q   0s    CREATED     11.0.0    some-other     test cluster 4
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+f930q   0s    CREATED     11.0.0    HIGHEST            some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_aws_cluster_yaml_output.golden
@@ -7,6 +7,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: f930q
     giantswarm.io/organization: some-other
+    giantswarm.io/service-priority: highest
     release.giantswarm.io/version: 11.0.0
   name: f930q
   namespace: default

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_json_output.golden
@@ -8,6 +8,7 @@
         "labels": {
             "cluster.x-k8s.io/cluster-name": "f930q",
             "giantswarm.io/organization": "some-other",
+            "giantswarm.io/service-priority": "highest",
             "release.giantswarm.io/version": "11.0.0"
         },
         "annotations": {

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
@@ -1,2 +1,2 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-f930q   0s    CREATED     11.0.0    HIGHEST            some-other     test cluster 4
+f930q   0s    CREATED     11.0.0    highest            some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_table_output.golden
@@ -1,2 +1,2 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-f930q   0s    CREATED     11.0.0    some-other     test cluster 4
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+f930q   0s    CREATED     11.0.0    HIGHEST            some-other     test cluster 4

--- a/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
+++ b/cmd/get/clusters/testdata/print_single_azure_cluster_yaml_output.golden
@@ -7,6 +7,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: f930q
     giantswarm.io/organization: some-other
+    giantswarm.io/service-priority: highest
     release.giantswarm.io/version: 11.0.0
   name: f930q
   namespace: default

--- a/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
+++ b/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
@@ -1,2 +1,2 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-f930q   0s    n/a         11.0.0    MEDIUM             some-other     test cluster 4
+f930q   0s    n/a         11.0.0    medium             some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
+++ b/cmd/get/clusters/testdata/run_get_cluster_by_id.golden
@@ -1,2 +1,2 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-f930q   0s    n/a         11.0.0    some-other     test cluster 4
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+f930q   0s    n/a         11.0.0    MEDIUM             some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_clusters.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters.golden
@@ -1,3 +1,3 @@
 NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         10.5.0    HIGHEST            some-org       test cluster 3
-f930q   0s    n/a         11.0.0    MEDIUM             some-other     test cluster 4
+1sad2   0s    n/a         10.5.0    highest            some-org       test cluster 3
+f930q   0s    n/a         11.0.0    medium             some-other     test cluster 4

--- a/cmd/get/clusters/testdata/run_get_clusters.golden
+++ b/cmd/get/clusters/testdata/run_get_clusters.golden
@@ -1,3 +1,3 @@
-NAME    AGE   CONDITION   RELEASE   ORGANIZATION   DESCRIPTION
-1sad2   0s    n/a         10.5.0    some-org       test cluster 3
-f930q   0s    n/a         11.0.0    some-other     test cluster 4
+NAME    AGE   CONDITION   RELEASE   SERVICE PRIORITY   ORGANIZATION   DESCRIPTION
+1sad2   0s    n/a         10.5.0    HIGHEST            some-org       test cluster 3
+f930q   0s    n/a         11.0.0    MEDIUM             some-other     test cluster 4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/appcatalog v0.7.0
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.11.0
+	github.com/giantswarm/k8smetadata v0.11.1
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v0.6.0
 	github.com/giantswarm/release-operator/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -410,6 +410,8 @@ github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ij
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.0 h1:XWcN0b6yBm2eH2Ael5SFFR87iRIigI+SRIfuiQBsxZ4=
 github.com/giantswarm/k8smetadata v0.11.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
+github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
+github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,6 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
-github.com/giantswarm/k8smetadata v0.11.0 h1:XWcN0b6yBm2eH2Ael5SFFR87iRIigI+SRIfuiQBsxZ4=
-github.com/giantswarm/k8smetadata v0.11.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.11.1 h1:GYdhg76Slhmm4QvjEn3/iJK9osvLHBZsIkGavDR3Ltg=
 github.com/giantswarm/k8smetadata v0.11.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22332.

This PR adds the `SERVICE PRIORITY` column to the table output of the `get clusters` command:
![Screen Shot 2022-06-08 at 12 18 20](https://user-images.githubusercontent.com/62935115/172593143-086362a8-a708-4598-8595-8fa2ca0a8f94.png)

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [x] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
