### PR TITLE
Adding cluster label when used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `SERVICE PRIORITY` column to `get clusters` command table output.
-- Add `giantswarm.io/cluster` label to in-cluster App CR when requested by the user.
+- In the `template app` command, add the `giantswarm.io/cluster` label to in-cluster App CR when requested by the user.
 
 ## [2.12.1] - 2022-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `SERVICE PRIORITY` column to `get clusters` command table output.
+- Add `giantswarm.io/cluster` label to in-cluster App CR when requested by the user.
 
 ## [2.12.1] - 2022-06-08
 

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -61,6 +61,9 @@ func NewAppCR(config Config) ([]byte, error) {
 		appLabels[label.AppOperatorVersion] = "0.0.0"
 		appLabels[label.ManagedBy] = "flux"
 
+		// Feels like the best place to add this label to the in-cluster
+		// App CR, since it is not technically required, because unique
+		// App CRs are not technically tied to any workload cluster.
 		if config.Cluster != "" {
 			appLabels[label.Cluster] = config.Cluster
 		}

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -60,6 +60,10 @@ func NewAppCR(config Config) ([]byte, error) {
 		crNamespace = config.Namespace
 		appLabels[label.AppOperatorVersion] = "0.0.0"
 		appLabels[label.ManagedBy] = "flux"
+
+		if config.Cluster != "" {
+			appLabels[label.Cluster] = config.Cluster
+		}
 	} else if config.Organization != "" {
 		crNamespace = fmt.Sprintf("org-%s", config.Organization)
 		appLabels[label.Cluster] = config.Cluster


### PR DESCRIPTION
## Description

Add the `giantswarm.io/cluster` label when `cluster` flag is used with `in-cluster` flag. We use `in-cluster` apps to deliver other App CRs to configure clusters, for example `default-apps-app`, `security-pack`, etc., in order for the `cluster-apps-operator` to remove all the corresponding apps when removing cluster, we need to label them as well.

Towards: https://github.com/giantswarm/cluster-apps-operator/pull/232

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [x] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [x] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
