### PR TITLE
Removing label

### DIFF
--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -59,7 +59,6 @@ func NewAppCR(config Config) ([]byte, error) {
 	if config.InCluster {
 		crNamespace = config.Namespace
 		appLabels[label.AppOperatorVersion] = "0.0.0"
-		appLabels[label.ManagedBy] = "flux"
 
 		// Feels like the best place to add this label to the in-cluster
 		// App CR, since it is not technically required, because unique


### PR DESCRIPTION
## Description

Ok, missed this in my previous PR. In the `cluster-apps-operator` we decided to skip Flux-managed app when deleting clusters, so even though we added `giantswar.io/cluster` label to the unique App CRs, `giantswarm.io/managed-by: flux` will block its deletion. Ideally we would have `extra-labels` flag to pass this label on demand, but this label is prohibited to set according to the https://github.com/giantswarm/kubectl-gs/blob/0dec849aad4637838cead0039617528bb6c2a3d7/internal/label/label.go#L27, so best way to fix it quickly is to remove it completely. We should then point users to the `gitops-template` repository when looking for correct references, rather advise them to generate resources with `kgs`.

Towards: https://github.com/giantswarm/cluster-apps-operator/pull/232

