### PR TITLE
Add flag to specify gcp control plane sa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add flags `--gcp-control-plane-sa-email` and `--gcp-control-plane-sa-scopes` to `template cluster` that specify a GCP Service Account and it's scopes to a cluster's control plane nodes
+
 ## [2.14.0] - 2022-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add flags `--gcp-control-plane-sa-email` and `--gcp-control-plane-sa-scopes` to `template cluster` that specify a GCP Service Account and it's scopes to a cluster's control plane nodes
+- Add flags `--gcp-control-plane-sa-email` and `--gcp-control-plane-sa-scopes` to `template cluster` that specify a Google Cloud Platform service account and its scopes to a cluster's control plane nodes
 
 ## [2.14.0] - 2022-06-15
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -38,13 +38,15 @@ const (
 	flagAWSMachinePoolCustomNodeLabels = "machine-pool-custom-node-labels"
 
 	// GCP only.
-	flagGCPProject                        = "project"
-	flagGCPFailureDomains                 = "gcp-failure-domains"
-	flagGCPMachineDeploymentName          = "gcp-machine-deployment-name"
-	flagGCPMachineDeploymentInstanceType  = "gcp-machine-deployment-instance-type"
-	flagGCPMachineDeploymentFailureDomain = "gcp-machine-deployment-failure-domain"
-	flagGCPMachineDeploymentReplicas      = "gcp-machine-deployment-replicas"
-	flagGCPMachineDeploymentRootDiskSize  = "gcp-machine-deployment-disk-size"
+	flagGCPProject                          = "project"
+	flagGCPFailureDomains                   = "gcp-failure-domains"
+	flagGCPControlPlaneServiceAccountEmail  = "gcp-control-plane-sa-email"
+	flagGCPControlPlaneServiceAccountScopes = "gcp-control-plane-sa-scopes"
+	flagGCPMachineDeploymentName            = "gcp-machine-deployment-name"
+	flagGCPMachineDeploymentInstanceType    = "gcp-machine-deployment-instance-type"
+	flagGCPMachineDeploymentFailureDomain   = "gcp-machine-deployment-failure-domain"
+	flagGCPMachineDeploymentReplicas        = "gcp-machine-deployment-replicas"
+	flagGCPMachineDeploymentRootDiskSize    = "gcp-machine-deployment-disk-size"
 
 	// App-based clusters only.
 	flagClusterCatalog     = "cluster-catalog"
@@ -152,6 +154,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// GCP only.
 	cmd.Flags().StringVar(&f.GCP.Project, flagGCPProject, "", "GCP project name")
 	cmd.Flags().StringSliceVar(&f.GCP.FailureDomains, flagGCPFailureDomains, nil, "GCP cluster failure domains")
+
+	cmd.Flags().StringVar(&f.GCP.ControlPlane.ServiceAccount.Email, flagGCPControlPlaneServiceAccountEmail, "default", "GCP Service Account used by the control plane")
+	cmd.Flags().StringSliceVar(&f.GCP.ControlPlane.ServiceAccount.Scopes, flagGCPControlPlaneServiceAccountScopes, []string{"https://www.googleapis.com/auth/compute"}, "Scope of the control plane's GCP Service Account")
 
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.Name, flagGCPMachineDeploymentName, "worker0", "GCP project name")
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n1-standard-2", "GCP worker instance type")

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -38,7 +38,7 @@ const (
 	flagAWSMachinePoolCustomNodeLabels = "machine-pool-custom-node-labels"
 
 	// GCP only.
-	flagGCPProject                          = "project"
+	flagGCPProject                          = "gcp-project"
 	flagGCPFailureDomains                   = "gcp-failure-domains"
 	flagGCPControlPlaneServiceAccountEmail  = "gcp-control-plane-sa-email"
 	flagGCPControlPlaneServiceAccountScopes = "gcp-control-plane-sa-scopes"

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -152,17 +152,17 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&f.AWS.MachinePool.CustomNodeLabels, flagAWSMachinePoolCustomNodeLabels, []string{}, "AWS Machine pool custom node labels")
 
 	// GCP only.
-	cmd.Flags().StringVar(&f.GCP.Project, flagGCPProject, "", "GCP project name")
-	cmd.Flags().StringSliceVar(&f.GCP.FailureDomains, flagGCPFailureDomains, nil, "GCP cluster failure domains")
+	cmd.Flags().StringVar(&f.GCP.Project, flagGCPProject, "", "Google Cloud Platform project name")
+	cmd.Flags().StringSliceVar(&f.GCP.FailureDomains, flagGCPFailureDomains, nil, "Google Cloud Platform cluster failure domains")
 
-	cmd.Flags().StringVar(&f.GCP.ControlPlane.ServiceAccount.Email, flagGCPControlPlaneServiceAccountEmail, "default", "GCP Service Account used by the control plane")
-	cmd.Flags().StringSliceVar(&f.GCP.ControlPlane.ServiceAccount.Scopes, flagGCPControlPlaneServiceAccountScopes, []string{"https://www.googleapis.com/auth/compute"}, "Scope of the control plane's GCP Service Account")
+	cmd.Flags().StringVar(&f.GCP.ControlPlane.ServiceAccount.Email, flagGCPControlPlaneServiceAccountEmail, "default", "Google Cloud Platform Service Account used by the control plane")
+	cmd.Flags().StringSliceVar(&f.GCP.ControlPlane.ServiceAccount.Scopes, flagGCPControlPlaneServiceAccountScopes, []string{"https://www.googleapis.com/auth/compute"}, "Scope of the control plane's Google Cloud Platform Service Account")
 
-	cmd.Flags().StringVar(&f.GCP.MachineDeployment.Name, flagGCPMachineDeploymentName, "worker0", "GCP project name")
-	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n1-standard-2", "GCP worker instance type")
-	cmd.Flags().IntVar(&f.GCP.MachineDeployment.Replicas, flagGCPMachineDeploymentReplicas, 3, "GCP worker replicas")
-	cmd.Flags().StringVar(&f.GCP.MachineDeployment.FailureDomain, flagGCPMachineDeploymentFailureDomain, "europe-west6-a", "GCP worker failure domain")
-	cmd.Flags().IntVar(&f.GCP.MachineDeployment.RootVolumeSizeGB, flagGCPMachineDeploymentRootDiskSize, 100, "GCP worker root disk size")
+	cmd.Flags().StringVar(&f.GCP.MachineDeployment.Name, flagGCPMachineDeploymentName, "worker0", "Google Cloud Platform project name")
+	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n1-standard-2", "Google Cloud Platform worker instance type")
+	cmd.Flags().IntVar(&f.GCP.MachineDeployment.Replicas, flagGCPMachineDeploymentReplicas, 3, "Google Cloud Platform worker replicas")
+	cmd.Flags().StringVar(&f.GCP.MachineDeployment.FailureDomain, flagGCPMachineDeploymentFailureDomain, "europe-west6-a", "Google Cloud Platform worker failure domain")
+	cmd.Flags().IntVar(&f.GCP.MachineDeployment.RootVolumeSizeGB, flagGCPMachineDeploymentRootDiskSize, 100, "Google Cloud Platform worker root disk size")
 
 	// OpenStack only.
 	cmd.Flags().StringVar(&f.OpenStack.Cloud, flagOpenStackCloud, "", "Name of cloud (OpenStack only).")

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"io"
-	"os"
 	"text/template"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -15,7 +14,7 @@ import (
 	"github.com/giantswarm/kubectl-gs/internal/key"
 )
 
-func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out *os.File, config ClusterConfig) error {
+func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {
 	var err error
 
 	isCapiVersion, err := key.IsCAPIVersion(config.ReleaseVersion)

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"text/template"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -24,7 +23,7 @@ const (
 	ClusterAWSRepoName  = "cluster-aws"
 )
 
-func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	var err error
 
 	var sshSSOPublicKey string
@@ -43,7 +42,6 @@ func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output *
 
 	err = templateDefaultAppsAWS(ctx, client, output, config)
 	return microerror.Mask(err)
-
 }
 
 func WriteCAPAEKSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {
@@ -78,7 +76,7 @@ func WriteCAPAEKSTemplate(ctx context.Context, client k8sclient.Interface, out i
 	return nil
 }
 
-func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := config.Name
 	configMapName := userConfigMapName(appName)
 
@@ -135,8 +133,8 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			return microerror.Mask(err)
 		}
 
-		userConfigMap.ObjectMeta.Labels = map[string]string{}
-		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {
@@ -184,7 +182,7 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 	return microerror.Mask(err)
 }
 
-func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := fmt.Sprintf("%s-default-apps", config.Name)
 	configMapName := userConfigMapName(appName)
 
@@ -209,8 +207,8 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			return microerror.Mask(err)
 		}
 
-		userConfigMap.ObjectMeta.Labels = map[string]string{}
-		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"text/template"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -21,7 +21,7 @@ const (
 	ClusterGCPRepoName     = "cluster-gcp"
 )
 
-func WriteGCPTemplate(ctx context.Context, client k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func WriteGCPTemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	var err error
 
 	var sshSSOPublicKey string
@@ -42,7 +42,7 @@ func WriteGCPTemplate(ctx context.Context, client k8sclient.Interface, output *o
 	return microerror.Mask(err)
 }
 
-func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := config.Name
 	configMapName := userConfigMapName(appName)
 
@@ -93,8 +93,8 @@ func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, outp
 			return microerror.Mask(err)
 		}
 
-		userConfigMap.ObjectMeta.Labels = map[string]string{}
-		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {
@@ -142,7 +142,7 @@ func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, outp
 	return microerror.Mask(err)
 }
 
-func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := fmt.Sprintf("%s-default-apps", config.Name)
 	configMapName := userConfigMapName(appName)
 
@@ -167,8 +167,8 @@ func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, 
 			return microerror.Mask(err)
 		}
 
-		userConfigMap.ObjectMeta.Labels = map[string]string{}
-		userConfigMap.ObjectMeta.Labels[k8smetadata.Cluster] = config.Name
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
 
 		configMapYAML, err = yaml.Marshal(userConfigMap)
 		if err != nil {
@@ -211,5 +211,6 @@ func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, 
 		UserConfigConfigMap: string(configMapYAML),
 		AppCR:               string(appYAML),
 	})
+
 	return microerror.Mask(err)
 }

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -40,7 +40,6 @@ func WriteGCPTemplate(ctx context.Context, client k8sclient.Interface, output *o
 
 	err = templateDefaultAppsGCP(ctx, client, output, config)
 	return microerror.Mask(err)
-
 }
 
 func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
@@ -63,6 +62,10 @@ func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, outp
 			ControlPlane: &capg.ControlPlane{
 				InstanceType: config.ControlPlaneInstanceType,
 				Replicas:     3,
+				ServiceAccount: capg.ServiceAccount{
+					Email:  config.GCP.ControlPlane.ServiceAccount.Email,
+					Scopes: config.GCP.ControlPlane.ServiceAccount.Scopes,
+				},
 			},
 			MachineDeployments: &[]capg.MachineDeployment{
 				{

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"text/template"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -15,7 +15,7 @@ import (
 	templateapp "github.com/giantswarm/kubectl-gs/pkg/template/app"
 )
 
-func WriteOpenStackTemplate(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func WriteOpenStackTemplate(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	err := templateClusterOpenstack(ctx, k8sClient, output, config)
 	if err != nil {
 		return microerror.Mask(err)
@@ -25,7 +25,7 @@ func WriteOpenStackTemplate(ctx context.Context, k8sClient k8sclient.Interface, 
 	return microerror.Mask(err)
 }
 
-func templateClusterOpenstack(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateClusterOpenstack(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := config.Name
 	configMapName := fmt.Sprintf("%s-cluster-userconfig", appName)
 
@@ -139,7 +139,7 @@ func templateClusterOpenstack(ctx context.Context, k8sClient k8sclient.Interface
 	return microerror.Mask(err)
 }
 
-func templateDefaultAppsOpenstack(ctx context.Context, k8sClient k8sclient.Interface, output *os.File, config ClusterConfig) error {
+func templateDefaultAppsOpenstack(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	appName := fmt.Sprintf("%s-default-apps", config.Name)
 	configMapName := fmt.Sprintf("%s-userconfig", appName)
 

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -52,7 +52,17 @@ type AWSMachinePoolConfig struct {
 type GCPConfig struct {
 	Project           string
 	FailureDomains    []string
+	ControlPlane      GCPControlPlane
 	MachineDeployment GCPMachineDeployment
+}
+
+type GCPControlPlane struct {
+	ServiceAccount ServiceAccount
+}
+
+type ServiceAccount struct {
+	Email  string
+	Scopes []string
 }
 
 type GCPMachineDeployment struct {

--- a/cmd/template/cluster/provider/templates/gcp/types.go
+++ b/cmd/template/cluster/provider/templates/gcp/types.go
@@ -29,9 +29,15 @@ type Network struct {
 }
 
 type ControlPlane struct {
-	InstanceType     string `json:"instanceType,omitempty"`
-	Replicas         int    `json:"replicas,omitempty"`
-	RootVolumeSizeGB int    `json:"rootVolumeSizeGB,omitempty"`
+	InstanceType     string         `json:"instanceType,omitempty"`
+	Replicas         int            `json:"replicas,omitempty"`
+	RootVolumeSizeGB int            `json:"rootVolumeSizeGB,omitempty"`
+	ServiceAccount   ServiceAccount `json:"serviceAccount,omitempty"`
+}
+
+type ServiceAccount struct {
+	Email  string   `json:"email,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 type MachineDeployment struct {

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -1,0 +1,142 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	goflag "flag"
+	"testing"
+
+	"github.com/giantswarm/micrologger"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	//nolint:staticcheck
+	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/internal/key"
+	"github.com/giantswarm/kubectl-gs/pkg/output"
+	"github.com/giantswarm/kubectl-gs/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/test/kubeclient"
+)
+
+var update = goflag.Bool("update", false, "update .golden reference test files")
+
+// Test_run uses golden files.
+//
+//  go test ./cmd/template/cluster -run Test_run -update
+//
+func Test_run(t *testing.T) {
+	testCases := []struct {
+		name               string
+		flags              *flag
+		args               []string
+		clusterName        string
+		expectedGoldenFile string
+		errorMatcher       func(error) bool
+	}{
+		{
+			name: "case 0: template cluster gcp",
+			flags: &flag{
+				Name:         "test1",
+				Provider:     "gcp",
+				Description:  "just a test cluster",
+				Region:       "the-region",
+				Organization: "test",
+				App: provider.AppConfig{
+					ClusterVersion:     "1.0.0",
+					ClusterCatalog:     "the-catalog",
+					DefaultAppsCatalog: "the-default-catalog",
+					DefaultAppsVersion: "2.0.0",
+				},
+				GCP: provider.GCPConfig{
+					Project:        "the-project",
+					FailureDomains: []string{"failure-domain1-a", "failure-domain1-b"},
+					ControlPlane: provider.GCPControlPlane{
+						ServiceAccount: provider.ServiceAccount{
+							Email:  "service-account@email",
+							Scopes: []string{"scope1", "scope2"},
+						},
+					},
+					MachineDeployment: provider.GCPMachineDeployment{
+						Name:             "worker1",
+						FailureDomain:    "failure-domain2-b",
+						InstanceType:     "very-large",
+						Replicas:         7,
+						RootVolumeSizeGB: 5,
+					},
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_gcp.golden",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			out := new(bytes.Buffer)
+			tc.flags.print = genericclioptions.NewPrintFlags("").WithDefaultOutput(output.TypeDefault)
+
+			logger, err := micrologger.New(micrologger.Config{})
+			if err != nil {
+				t.Fatalf("failed to create logger: %s", err.Error())
+			}
+
+			runner := &runner{
+				flag:   tc.flags,
+				logger: logger,
+				stdout: out,
+			}
+
+			ssoSecret := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "sso-secret",
+					Namespace: key.GiantswarmNamespace,
+					Labels: map[string]string{
+						key.RoleLabel: key.SSHSSOPubKeyLabel,
+					},
+				},
+				Data: map[string][]byte{
+					"value": []byte("the-sso-secret"),
+				},
+			}
+
+			k8sClient := kubeclient.FakeK8sClient(ssoSecret)
+			err = runner.run(ctx, k8sClient)
+			if tc.errorMatcher != nil {
+				if !tc.errorMatcher(err) {
+					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
+				}
+
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			var expectedResult []byte
+			{
+				gf := goldenfile.New("testdata", tc.expectedGoldenFile)
+				if *update {
+					err = gf.Update(out.Bytes())
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+					expectedResult = out.Bytes()
+				} else {
+					expectedResult, err = gf.Read()
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+				}
+			}
+
+			diff := cmp.Diff(string(expectedResult), out.String())
+			if diff != "" {
+				t.Fatalf("value not expected, got:\n %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+data:
+  values: |
+    clusterDescription: just a test cluster
+    clusterName: test1
+    controlPlane:
+      replicas: 3
+      serviceAccount:
+        email: service-account@email
+        scopes:
+        - scope1
+        - scope2
+    gcp:
+      failureDomains:
+      - failure-domain1-a
+      - failure-domain1-b
+      project: the-project
+      region: the-region
+    machineDeployments:
+    - failureDomain: failure-domain2-b
+      instanceType: very-large
+      name: worker1
+      replicas: 7
+      rootVolumeSizeGB: 5
+    organization: test
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    giantswarm.io/cluster: test1
+  name: test1-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: test1
+  name: test1
+  namespace: org-test
+spec:
+  catalog: the-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: cluster-gcp
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test1-userconfig
+      namespace: org-test
+  version: 1.0.0
+---
+apiVersion: v1
+data:
+  values: |
+    clusterName: test1
+    organization: test
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    giantswarm.io/cluster: test1
+  name: test1-default-apps-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: test1
+  name: test1-default-apps
+  namespace: org-test
+spec:
+  catalog: the-default-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: default-apps-gcp
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test1-default-apps-userconfig
+      namespace: org-test
+  version: 2.0.0

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -1,0 +1,71 @@
+package kubeclient
+
+import (
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/giantswarm/kubectl-gs/pkg/scheme"
+)
+
+type fakeK8sClient struct {
+	ctrlClient client.Client
+	k8sClient  *fakek8s.Clientset
+}
+
+func FakeK8sClient(objects ...runtime.Object) k8sclient.Interface {
+	var k8sClient k8sclient.Interface
+	{
+		scheme, err := scheme.NewScheme()
+		if err != nil {
+			panic(err)
+		}
+		client := fakek8s.NewSimpleClientset(objects...)
+
+		k8sClient = &fakeK8sClient{
+			ctrlClient: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build(),
+			k8sClient:  client,
+		}
+	}
+
+	return k8sClient
+}
+
+func (f *fakeK8sClient) CRDClient() k8scrdclient.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) CtrlClient() client.Client {
+	return f.ctrlClient
+}
+
+func (f *fakeK8sClient) DynClient() dynamic.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) ExtClient() apiextensionsclient.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) K8sClient() kubernetes.Interface {
+	return f.k8sClient
+}
+
+func (f *fakeK8sClient) RESTClient() rest.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) RESTConfig() *rest.Config {
+	return nil
+}
+
+func (f *fakeK8sClient) Scheme() *runtime.Scheme {
+	return nil
+}


### PR DESCRIPTION
## Description

This change adds two flags to specify the GCP service account used for a cluster's control plane nodes and the api scopes that SA can access.
It also introduces a test for `kubectl gs template cluster --provider gcp`. I had to refactor a bit to get the test to run. 

## Checklist
As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available
**This needed to be done as part of this story giantswarm/giantswarm#22036**
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
**There doesn't seem to be documentation about GCP in there in the first place.**
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)
