### PR TITLE
Remove 'giantswarm.io/cluster' label from cluster and default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add flags `--gcp-control-plane-sa-email` and `--gcp-control-plane-sa-scopes` to `template cluster` that specify a Google Cloud Platform service account and its scopes to a cluster's control plane nodes
 
+### Removed
+
+- Removed `giantswarm.io/cluster` label from the default apps bundle and the `App` representing a CAPI cluster. 
+
 ## [2.14.0] - 2022-06-15
 
 ### Added

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -161,9 +161,6 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
-			ExtraLabels: map[string]string{
-				k8smetadata.Cluster: config.Name,
-			},
 		}
 
 		var err error
@@ -236,9 +233,6 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
-			ExtraLabels: map[string]string{
-				k8smetadata.Cluster: config.Name,
-			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -121,9 +121,6 @@ func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, outp
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
-			ExtraLabels: map[string]string{
-				k8smetadata.Cluster: config.Name,
-			},
 		}
 
 		var err error
@@ -196,9 +193,6 @@ func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, 
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
-			ExtraLabels: map[string]string{
-				k8smetadata.Cluster: config.Name,
-			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -37,7 +37,6 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
-    giantswarm.io/cluster: test1
   name: test1
   namespace: org-test
 spec:
@@ -82,7 +81,6 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
-    giantswarm.io/cluster: test1
   name: test1-default-apps
   namespace: org-test
 spec:


### PR DESCRIPTION
This label was preventing CAPI clusters of being removed because `cluster-apps-operator` finalizer was never removed from the `Cluster` CR. 