### PR TITLE
`login`: Increase retry interval and overall timeout when creating a workload cluster client certificate

### DIFF
--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	credentialRetryTimeout    = 1 * time.Second
-	credentialMaxRetryTimeout = 10 * time.Second
+	credentialRetryTimeout    = 3 * time.Second
+	credentialMaxRetryTimeout = 30 * time.Second
 
 	credentialKeyCertCRT = "crt"
 	credentialKeyCertKey = "key"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22545

Currently we wait for up to 10 seconds for a created client certificate. This PR increases this to 30. The retry interval is increased to reduce the number of requests issued in a scenario where the process is slow.