### PR TITLE
Don't get SSH SSO public key when templating gcp cluster

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,3 @@
 # Consul - no fix yet
-CVE-2022-29153 until=2022-07-01
-CVE-2022-24687 until=2022-07-01
+CVE-2022-29153 until=2022-08-01
+CVE-2022-24687 until=2022-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Command `template cluster --provider gcp` no longer tries to get SSH SSO public key secret in the `giantswarm` namespace
+
 ## [2.15.0] - 2022-06-22
 
 ### Added

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -22,18 +22,7 @@ const (
 )
 
 func WriteGCPTemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
-	var err error
-
-	var sshSSOPublicKey string
-	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-	config.AWS.SSHSSOPublicKey = sshSSOPublicKey
-
-	err = templateClusterGCP(ctx, client, output, config)
+	err := templateClusterGCP(ctx, client, output, config)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -9,13 +9,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	//nolint:staticcheck
 	"github.com/giantswarm/kubectl-gs/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/internal/key"
 	"github.com/giantswarm/kubectl-gs/pkg/output"
 	"github.com/giantswarm/kubectl-gs/test/goldenfile"
 	"github.com/giantswarm/kubectl-gs/test/kubeclient"
@@ -91,20 +88,7 @@ func Test_run(t *testing.T) {
 				stdout: out,
 			}
 
-			ssoSecret := &corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "sso-secret",
-					Namespace: key.GiantswarmNamespace,
-					Labels: map[string]string{
-						key.RoleLabel: key.SSHSSOPubKeyLabel,
-					},
-				},
-				Data: map[string][]byte{
-					"value": []byte("the-sso-secret"),
-				},
-			}
-
-			k8sClient := kubeclient.FakeK8sClient(ssoSecret)
+			k8sClient := kubeclient.FakeK8sClient()
 			err = runner.run(ctx, k8sClient)
 			if tc.errorMatcher != nil {
 				if !tc.errorMatcher(err) {


### PR DESCRIPTION
This value will be defaulted in the `cluster-gcp` helm chart.

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
giantswarm/giantswarm#22640
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
