### PR TITLE
Separate WC clientcert contexts from WC OIDC contexts in login command

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,3 @@
 # Consul - no fix yet
-CVE-2022-29153 until=2022-07-01
-CVE-2022-24687 until=2022-07-01
+CVE-2022-29153 until=2022-08-01
+CVE-2022-24687 until=2022-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Allow calling `login` command with a second argument to select WC contexts.
+- Add `-clientcert` suffix to WC client certificate contexts created by the `login` command.
+- Use `CertificateAuthorityData` to store CA data and ensure that `CertificateAuthority` is not set when manipulating the kubeconfig in the `login` command.
 
 ## [2.15.0] - 2022-06-22
 

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -256,7 +256,7 @@ func storeWCClientCertCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afe
 	}
 
 	mcContextName := config.CurrentContext
-	contextName := kubeconfig.GenerateWCKubeContextName(mcContextName, c.clusterID)
+	contextName := kubeconfig.GenerateWCClientCertKubeContextName(mcContextName, c.clusterID)
 	userName := fmt.Sprintf("%s-user", contextName)
 	clusterName := contextName
 
@@ -284,6 +284,7 @@ func storeWCClientCertCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afe
 		}
 
 		cluster.Server = c.clusterServer
+		cluster.CertificateAuthority = ""
 		cluster.CertificateAuthorityData = c.certCA
 
 		// Add cluster configuration to config.
@@ -328,7 +329,7 @@ func printWCClientCertCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afe
 	}
 
 	mcContextName := config.CurrentContext
-	contextName := kubeconfig.GenerateWCKubeContextName(mcContextName, c.clusterID)
+	contextName := kubeconfig.GenerateWCClientCertKubeContextName(mcContextName, c.clusterID)
 
 	kubeconfig := clientcmdapi.Config{
 		APIVersion: "v1",

--- a/cmd/login/command.go
+++ b/cmd/login/command.go
@@ -15,21 +15,31 @@ import (
 )
 
 const (
-	name = `login <management-cluster> [flags]
+	name = `login <arg1> <arg2> [flags]
 
-The <management-cluster> argument can take several forms:
+Arguments <arg1> and <arg2> are optional and can take several forms.
+No arguments means that the currently selected context will be used.
 
-  - the URL of the management cluster Kubernetes endpoint
+Use <arg1> alone for:
+
+  - the URL of the cluster Kubernetes endpoint
   - the URL of the Giant Swarm web UI
-  - a previously generated context name, with or without the prefix "gs-"`
+  - A Giant Swarm management cluster with an existing context (SSO only)
+  - a previously generated context name
+  
+Use <arg1> <arg2> for
+
+  -  A Giant Swarm management cluster and a Giant Swarm workload cluster with an existing context (SSO only)
+  `
 	shortDescription = "Ensures an authenticated context for a Giant Swarm management or workload cluster"
 	longDescription  = `Ensure an authenticated context for a Giant Swarm management or workload cluster
 
 Use this command to set up a kubectl context to work with:
   (1) a management cluster, using OIDC authentication
-  (2) a workload cluster on AWS or Azure, using client certificate auth
+  (2) a workload cluster, using OIDC authentication
+  (3) a workload cluster, using client certificate auth. Not supported on kvm.
 
-Note that (2) implies (1). When setting up workload cluster access,
+Note that (3) implies (1). When creating a workload cluster client certificate,
 management cluster access will be set up as well, if that is not yet done.
 
 Security notes:
@@ -51,6 +61,14 @@ Management cluster:
   kubectl gs login mymc
 
 Workload cluster:
+
+  kubectl gs login https://example.g8s.test.eu-west-1.aws.gigantic.io
+
+  kubectl gs login gs-mymc-mywc
+
+  kubectl gs login mymc mywc
+
+Workload cluster client ce:
 
   kubectl gs login mymc \
     --` + flagWCName + ` gir0y \

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -46,11 +46,11 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.SelfContained, flagSelfContained, "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")
 	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
 
-	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
-	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("Organization that owns the workload cluster. Requires --%s.", flagWCName))
-	cmd.Flags().StringSliceVar(&f.WCCertGroups, flagWCCertGroups, nil, fmt.Sprintf("RBAC group name to be encoded into the X.509 field \"O\". Requires --%s.", flagWCName))
-	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf(`How long the client certificate should live for. Valid time units are "ms", "s", "m", "h". Requires --%s.`, flagWCName))
-	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
+	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "For client certificate creation. Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
+	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("For client certificate creation. Organization that owns the workload cluster. Requires --%s.", flagWCName))
+	cmd.Flags().StringSliceVar(&f.WCCertGroups, flagWCCertGroups, nil, fmt.Sprintf("For client certificate creation. RBAC group name to be encoded into the X.509 field \"O\". Requires --%s.", flagWCName))
+	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf(`For client certificate creation. How long the client certificate should live for. Valid time units are "ms", "s", "m", "h". Requires --%s.`, flagWCName))
+	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
 	f.config = genericclioptions.NewConfigFlags(true)
 	f.config.(*genericclioptions.ConfigFlags).AddFlags(cmd.Flags())

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -75,7 +75,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the management cluster of installation '%s'.\n", codeName))
+	fmt.Fprint(r.stdout, color.GreenString("You are logged in to the cluster '%s'.\n", codeName))
 	return nil
 }
 
@@ -150,16 +150,16 @@ func (r *runner) loginWithInstallation(ctx context.Context, tokenOverride string
 		}
 	} else {
 		// Store kubeconfig and CA certificate.
-		err = storeMCCredentials(r.k8sConfigAccess, i, authResult, r.fs, r.flag.InternalAPI, r.loginOptions.switchToContext)
+		err = storeMCCredentials(r.k8sConfigAccess, i, authResult, r.flag.InternalAPI, r.loginOptions.switchToContext)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
 	if len(authResult.email) > 0 {
-		fmt.Fprint(r.stdout, color.GreenString("Logged in successfully as '%s' on installation '%s'.\n\n", authResult.email, i.Codename))
+		fmt.Fprint(r.stdout, color.GreenString("Logged in successfully as '%s' on cluster '%s'.\n\n", authResult.email, i.Codename))
 	} else {
-		fmt.Fprint(r.stdout, color.GreenString("Logged in successfully as '%s' on installation '%s'.\n\n", authResult.username, i.Codename))
+		fmt.Fprint(r.stdout, color.GreenString("Logged in successfully as '%s' on cluster '%s'.\n\n", authResult.username, i.Codename))
 	}
 	return nil
 }

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -144,6 +144,6 @@ func (r *runner) tryToReuseExistingContext(ctx context.Context) error {
 	if currentContext != "" {
 		return r.loginWithKubeContextName(ctx, currentContext)
 	} else {
-		return microerror.Maskf(selectedContextNonCompatibleError, "The current context does not seem to belong to a Giant Swarm management cluster.\nPlease run 'kubectl gs login --help' to find out how to log in to a particular management cluster.")
+		return microerror.Maskf(selectedContextNonCompatibleError, "The current context does not seem to belong to a Giant Swarm cluster.\nPlease run 'kubectl gs login --help' to find out how to log in to a particular cluster.")
 	}
 }

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -255,6 +255,24 @@ func TestLogin(t *testing.T) {
 			},
 			expectError: invalidConfigError,
 		},
+		// Existing WC clientcert context
+		{
+			name:        "case 23",
+			startConfig: createValidTestConfig("-cluster-clientcert", false),
+			mcArg:       []string{"gs-codename-cluster-clientcert"},
+			flags: &flag{
+				WCCertTTL: "8h",
+			},
+		},
+		{
+			name:        "case 24",
+			startConfig: createValidTestConfig("-cluster-clientcert", false),
+			mcArg:       []string{"codename", "cluster"},
+			flags: &flag{
+				WCCertTTL: "8h",
+			},
+			expectError: contextDoesNotExistError,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/kubeconfig/context.go
+++ b/pkg/kubeconfig/context.go
@@ -30,6 +30,10 @@ func GenerateWCKubeContextName(mcKubeContextName string, wcName string) string {
 	return fmt.Sprintf("%s-%s", mcKubeContextName, wcName)
 }
 
+func GenerateWCClientCertKubeContextName(mcKubeContextName string, wcName string) string {
+	return fmt.Sprintf("%s-%s-clientcert", mcKubeContextName, wcName)
+}
+
 // IsKubeContext checks whether the name provided,
 // matches our pattern for naming kubernetes contexts.
 func IsKubeContext(s string) (bool, ContextType) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1164

_Description goes here_

---

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
