### PR TITLE
Adding automatic update stuff

### DIFF
--- a/cmd/gitops/add/app/flag.go
+++ b/cmd/gitops/add/app/flag.go
@@ -39,17 +39,17 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ManagementCluster, flagManagementCluster, "", "Codename of the Management Cluster the Workload Cluster belongs to.")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "Codename of the Management Cluster.")
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Name of the app to use for creating the repository directory structure.")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Name of the Organization the Workload Cluster belongs to.")
-	cmd.Flags().StringVar(&f.WorkloadCluster, flagWorkloadCluster, "", "Name of the Workload Cluster to configure app to.")
+	cmd.Flags().StringVar(&f.WorkloadCluster, flagWorkloadCluster, "", "Name of the Workload Cluster to configure tbe app for.")
 
 	//CAPx only
-	cmd.Flags().StringVar(&f.App, flagApp, "", "App from the catalog to install.")
+	cmd.Flags().StringVar(&f.App, flagApp, "", "App name taken from the catalog.")
 	cmd.Flags().StringVar(&f.Base, flagBase, "", "Path to the base directory. It must be relative to the repository root.")
 	cmd.Flags().StringVar(&f.Catalog, flagCatalog, "", "Catalog to install the app from.")
 	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace to install app into.")
-	cmd.Flags().StringVar(&f.UserValuesConfigMap, flagUserValuesConfigMap, "", "Values to customize the app with as a ConfigMap.")
-	cmd.Flags().StringVar(&f.UserValuesSecret, flagUserValuesSecret, "", "Values to customize the app with as a Secret.")
+	cmd.Flags().StringVar(&f.UserValuesConfigMap, flagUserValuesConfigMap, "", "Values YAML to customize the app with. Will get turn into a ConfigMap.")
+	cmd.Flags().StringVar(&f.UserValuesSecret, flagUserValuesSecret, "", "Values YAML to customize the app with. Will get turn into a Secret.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to install.")
 }
 
@@ -66,19 +66,19 @@ func (f *flag) Validate() error {
 		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagWorkloadCluster)
 	}
 
-	if f.App == "" {
+	if f.Base == "" && f.App == "" {
 		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagApp)
 	}
 
-	if f.Catalog == "" {
+	if f.Base == "" && f.Catalog == "" {
 		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagCatalog)
 	}
 
-	if f.Namespace == "" {
+	if f.Base == "" && f.Namespace == "" {
 		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagNamespace)
 	}
 
-	if f.Version == "" {
+	if f.Base == "" && f.Version == "" {
 		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagVersion)
 	}
 

--- a/cmd/gitops/add/app/runner.go
+++ b/cmd/gitops/add/app/runner.go
@@ -102,7 +102,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if localPathFlag != nil {
 		creatorConfig.Path = fmt.Sprintf("%s/", localPathFlag.Value.String())
 	}
-	creatorConfig.Path += key.WorkloadClusterAppDirectory(
+	creatorConfig.Path += key.GetRootWorkloadClusterDirectory(
 		r.flag.ManagementCluster,
 		r.flag.Organization,
 		r.flag.WorkloadCluster,

--- a/cmd/gitops/add/automatic-updates/command.go
+++ b/cmd/gitops/add/automatic-updates/command.go
@@ -1,4 +1,4 @@
-package app
+package autoupdate
 
 import (
 	"io"
@@ -12,60 +12,32 @@ import (
 )
 
 const (
-	name  = "app"
-	alias = "app"
+	name  = "automatic-update"
+	alias = "update"
 
-	shortDescription = "Adds a new Application to your GitOps directory structure"
-	longDescription  = `Adds a new Application to your GitOps directory structure.
+	shortDescription = "Enable automatic updates for an app."
+	longDescription  = `Enable automatic updates for an app.
 
 app \
---app <app_to_install> \
---catalog <app_catalog> \
---name <app_cr_name> \
---namespace <app_namespace> \
+--app <app_to_configure_updates_for> \
+--version-repository <repository_to_track_version_in> \
 --management-cluster <mc_code_name> \
 --organization <org_name> \
---user-configmap <path_to_values_yaml> \
---user-secret <path_to_values_yaml> \
---version <app_version> \
 --workload-cluster <wc_name>
 
 It respects the Giantswarm's GitOps repository structure recommendation:
 https://github.com/giantswarm/gitops-template/blob/main/docs/repo_structure.md.
 
 Steps it implements:
-https://github.com/giantswarm/gitops-template/blob/main/docs/apps/add_appcr.md`
+https://github.com/giantswarm/gitops-template/blob/main/docs/apps/automatic_updates_appcr.md`
 
-	examples = `  # Add hello-world App to dummy Workload Cluster
-  kubectl gs gitops add app \
-  --app hello-world-app \
-  --catalog giantswarm \
-  --name hello-world \
-  --namespace default \
-  --management-cluster demowc \
-  --organization demoorg \
-  --version 0.3.0 \
-  --workload-cluster demowc
-
-  # Add hello-world App to dummy Workload Cluster, include user configuration
-  kubectl gs gitops add app \
-  --app hello-world-app \
-  --catalog giantswarm \
-  --name hello-world \
-  --namespace default \
-  --management-cluster demomc \
-  --organization demoorg \
-  --user-configmap /tmp/hello-world-app-values.yaml \
-  --version 0.3.0 \
-  --workload-cluster demowc
-
-  # Add hello-world App from the base
-  kubectl gs gitops add app \
-  --base base/apps/hello-world \
-  --management-cluster demomc \
-  --organization demoorg \
-  --user-configmap /tmp/hello-world-app-values.yaml \
-  --workload-cluster demowc`
+	examples = `  # Enable automatic updates for hello-world app
+    kubectl gs gitops add app \
+    --app hello-world \
+	--version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
+    --management-cluster demomc \
+    --organization demoorg \
+    --workload-cluster demowc`
 )
 
 type Config struct {

--- a/cmd/gitops/add/automatic-updates/error.go
+++ b/cmd/gitops/add/automatic-updates/error.go
@@ -1,0 +1,21 @@
+package autoupdate
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidFlagsError = &microerror.Error{
+	Kind: "invalidFlagsError",
+}
+
+// IsInvalidFlags asserts invalidFlagsError.
+func IsInvalidFlags(err error) bool {
+	return microerror.Cause(err) == invalidFlagsError
+}

--- a/cmd/gitops/add/automatic-updates/flag.go
+++ b/cmd/gitops/add/automatic-updates/flag.go
@@ -1,0 +1,69 @@
+package autoupdate
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagManagementCluster = "management-cluster"
+	flagName              = "name"
+	flagOrganization      = "organization"
+	flagWorkloadCluster   = "workload-cluster"
+
+	// App CR part
+	flagApp               = "app"
+	flagRepository        = "repository"
+	flagVersionRepository = "version-repository"
+)
+
+type flag struct {
+	ManagementCluster string
+	Name              string
+	Organization      string
+	WorkloadCluster   string
+
+	// App CR part
+	App               string
+	Repository        string
+	VersionRepository string
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.ManagementCluster, flagManagementCluster, "", "Codename of the Management Cluster the Workload Cluster belongs to.")
+	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Name of the Organization the Workload Cluster belongs to.")
+	cmd.Flags().StringVar(&f.WorkloadCluster, flagWorkloadCluster, "", "Name of the Workload Cluster the app belongs to.")
+
+	//App stuff
+	cmd.Flags().StringVar(&f.App, flagApp, "", "App in the repository to configure automatic updates for.")
+	cmd.Flags().StringVar(&f.Repository, flagRepository, "", "The gitops repository to update application in.")
+	cmd.Flags().StringVar(&f.VersionRepository, flagVersionRepository, "", "Tbe OCR repository to update the version from.")
+}
+
+func (f *flag) Validate() error {
+	if f.ManagementCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagManagementCluster)
+	}
+
+	if f.Organization == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagOrganization)
+	}
+
+	if f.WorkloadCluster == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagWorkloadCluster)
+	}
+
+	if f.App == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagApp)
+	}
+
+	if f.Repository == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagRepository)
+	}
+
+	if f.VersionRepository == "" {
+		return microerror.Maskf(invalidFlagsError, "--%s must not be empty", flagVersionRepository)
+	}
+
+	return nil
+}

--- a/cmd/gitops/add/command.go
+++ b/cmd/gitops/add/command.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	app "github.com/giantswarm/kubectl-gs/cmd/gitops/add/app"
+	autoup "github.com/giantswarm/kubectl-gs/cmd/gitops/add/automatic-updates"
 	mc "github.com/giantswarm/kubectl-gs/cmd/gitops/add/management-cluster"
 	org "github.com/giantswarm/kubectl-gs/cmd/gitops/add/organization"
 	wc "github.com/giantswarm/kubectl-gs/cmd/gitops/add/workload-cluster"
@@ -63,6 +64,24 @@ func New(config Config) (*cobra.Command, error) {
 		}
 
 		appCmd, err = app.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var autoUpdateCmd *cobra.Command
+	{
+		c := autoup.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			K8sConfigAccess: config.K8sConfigAccess,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		autoUpdateCmd, err = autoup.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -141,6 +160,7 @@ func New(config Config) (*cobra.Command, error) {
 	f.Init(c)
 
 	c.AddCommand(appCmd)
+	c.AddCommand(autoUpdateCmd)
 	c.AddCommand(mcCmd)
 	c.AddCommand(orgCmd)
 	c.AddCommand(wcCmd)

--- a/cmd/gitops/add/management-cluster/flag.go
+++ b/cmd/gitops/add/management-cluster/flag.go
@@ -24,11 +24,11 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().DurationVar(&f.Interval, flagInterval, time.Minute, "Source synchronization interval")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "Codename of the Management Cluster")
-	cmd.Flags().StringVar(&f.RepositoryName, flagRepositoryName, "", "Name of the GitOps repository")
-	cmd.Flags().StringVar(&f.ServiceAccount, flagServiceAccount, "automation", "Service Account for Flux to impersonate")
-	cmd.Flags().DurationVar(&f.Timeout, flagTimeout, 2*time.Minute, "Synchronization timeout")
+	cmd.Flags().DurationVar(&f.Interval, flagInterval, time.Minute, "Source synchronization interval.")
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Codename of the Management Cluster.")
+	cmd.Flags().StringVar(&f.RepositoryName, flagRepositoryName, "", "Name of the gitops repository.")
+	cmd.Flags().StringVar(&f.ServiceAccount, flagServiceAccount, "automation", "Service Account for Flux to impersonate.")
+	cmd.Flags().DurationVar(&f.Timeout, flagTimeout, 2*time.Minute, "Synchronization timeout.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gitops/add/organization/flag.go
+++ b/cmd/gitops/add/organization/flag.go
@@ -16,8 +16,8 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&f.MCName, flagMCName, "", "Management Cluster the Organization belongs to")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "Organization name")
+	cmd.Flags().StringVar(&f.MCName, flagMCName, "", "Management Cluster the Organization belongs to.")
+	cmd.Flags().StringVar(&f.Name, flagName, "", "Organization name.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gitops/add/workload-cluster/runner.go
+++ b/cmd/gitops/add/workload-cluster/runner.go
@@ -97,7 +97,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	if localPathFlag != nil {
 		creatorConfig.Path = fmt.Sprintf("%s/", localPathFlag.Value.String())
 	}
-	creatorConfig.Path += key.WorkloadClustersDirectory(r.flag.ManagementCluster, r.flag.Organization)
+	creatorConfig.Path += key.GetRootOrganizationDirectory(r.flag.ManagementCluster, r.flag.Organization)
 
 	creator := creator.NewCreator(creatorConfig)
 

--- a/internal/gitops/filesystem/creator/modifier_test.go
+++ b/internal/gitops/filesystem/creator/modifier_test.go
@@ -49,6 +49,58 @@ resources:
 				},
 			},
 		},
+		{
+			name: "add comment for automatic updates",
+			expected: []byte(`apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demowc-hello-world
+spec:
+  version: 0.3.0 # {"$imagepolicy": "default:demowc-hello-world:tag"}
+  catalog: giantswarm
+  name: hello-world
+  namespace: default
+`),
+			input: []byte(`apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demowc-hello-world
+spec:
+  version: 0.3.0
+  catalog: giantswarm
+  name: hello-world
+  namespace: default
+`),
+			modifier: AppModifier{
+				ImagePolicy: "demowc-hello-world",
+			},
+		},
+		{
+			name: "do not change already existing automatic updates",
+			expected: []byte(`apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demowc-hello-world
+spec:
+  version: 0.3.0 # {"$imagepolicy": "default:demowc-hello-world:tag"}
+  catalog: giantswarm
+  name: hello-world
+  namespace: default
+`),
+			input: []byte(`apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: demowc-hello-world
+spec:
+  version: 0.3.0 # {"$imagepolicy": "default:demowc-hello-world:tag"}
+  catalog: giantswarm
+  name: hello-world
+  namespace: default
+`),
+			modifier: AppModifier{
+				ImagePolicy: "demowc-hello-world",
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/internal/gitops/key/key.go
+++ b/internal/gitops/key/key.go
@@ -7,6 +7,7 @@ import (
 const (
 	DirectoryClusterApps        = "apps"
 	DirectoryClusterDefinition  = "cluster"
+	DirectoryAutomaticUpdates   = "automatic-updates"
 	DirectoryManagementClusters = "management-clusters"
 	DirectoryOrganizations      = "organizations"
 	DirectorySecrets            = "secrets"
@@ -16,58 +17,111 @@ const (
 	FileKustomization = "kustomization.yaml"
 )
 
-// TBD: Better naming of the functions and explanations, right now it may be confusing,
-// because names are sometimes very similar, also paths themselves are relative what may
-// be extra confusing.
-func GetAppsKustomization() string {
+// Naming convention and explanation
+//
+// Since the `gitops/structure` package does not operate on absolute paths,
+// the functions here must return paths relative to the layer currently
+// being configure by the structure, e.g. Management Cluster. This however
+// may be a bit confusing from the naming perspective because different
+// commands must sometimes operate on the same directory, e.g. `add app` and
+// `add image-update` both operate on the `apps` directory, but relatively seen
+// slightly different, what is hard to capture in the function name. Hence the
+// proposed naming convention is:
+//
+// Get + BASE + TARGET, where
+// BASE - directory where we relatively starts building the path, not being part of the path.
+// TARGET - directory or file we are targeting with the path.
+//
+// Examples:
+// GetWcAppsKustomization - we start at `WC_NAME` and targets `apps/kustomization.yaml`
+// GetMCsOrgDir - we start at `management-clusters` and targets `MC_NAME/organizations`
+// GetAnySecretsDir - we start at any place and targets `ANY/secrets`
+
+// GetWcAppsKustomization
+// Base: WC_NAME
+// Target: apps/kustomization.yaml
+func GetWcAppsKustomizationFile() string {
 	return fmt.Sprintf("%s/%s", DirectoryClusterApps, FileKustomization)
 }
 
-func GetOrgDir(path string) string {
-	return fmt.Sprintf("%s/%s", path, DirectoryOrganizations)
+// GetAnySecretsDir
+// Base: management-clusters
+// Target: MC_NAME/organizations
+func GetMCsOrgsDir(mc string) string {
+	return fmt.Sprintf("%s/%s", mc, DirectoryOrganizations)
 }
 
-func GetSecretsDir(path string) string {
+// GetAnySecretsDir
+// Base: any
+// Target: any/secrets
+func GetAnySecretsDir(path string) string {
 	return fmt.Sprintf("%s/%s", path, DirectorySecrets)
 }
 
-func GetSopsDir(path string) string {
-	return fmt.Sprintf("%s/%s", path, DirectorySOPSPublicKeys)
+// GetMCsSopsDir
+// Base: management-clusters
+// Target: MC_NAME/.sops.keys
+func GetMCsSopsDir(mc string) string {
+	return fmt.Sprintf("%s/%s", mc, DirectorySOPSPublicKeys)
 }
 
-func GetWCDir(name string) string {
-	return fmt.Sprintf("%s/%s", DirectoryWorkloadClusters, name)
+// GetOrgWcDir
+// Base: ORG_NAME
+// Target: workload-clusters/WC_NAME
+func GetOrgWcDir(wc string) string {
+	return fmt.Sprintf("%s/%s", DirectoryWorkloadClusters, wc)
 }
 
-func GetWCAppDir(name string) string {
+// GetWcAppDir
+// Base: WC_NAME
+// Target: apps/APP_NAME
+func GetWcAppDir(name string) string {
 	return fmt.Sprintf("%s/%s", DirectoryClusterApps, name)
 }
 
-func GetWCAppsDir(name string) string {
+// GetOrgWcAppsDir
+// Base: ORG_NAME
+// Target: workload-clusters/WC_NAME/apps
+func GetOrgWcAppsDir(name string) string {
 	return fmt.Sprintf("%s/%s/%s", DirectoryWorkloadClusters, name, DirectoryClusterApps)
 }
 
-func GetWCClusterDir(name string) string {
-	return fmt.Sprintf("%s/%s/%s", DirectoryWorkloadClusters, name, DirectoryClusterDefinition)
+// GetOrgWcClusterDir
+// Base: ORG_NAME
+// Target: workload-clusters/WC_NAME/cluster
+func GetOrgWcClusterDir(wc string) string {
+	return fmt.Sprintf("%s/%s/%s", DirectoryWorkloadClusters, wc, DirectoryClusterDefinition)
 }
 
-func GetWCsDir(path string) string {
-	return fmt.Sprintf("%s/%s", path, DirectoryWorkloadClusters)
+// GetOrgWCsDir
+// Base: organizations
+// Target: ORG_NAME/workload-clusters
+func GetOrgWCsDir(org string) string {
+	return fmt.Sprintf("%s/%s", org, DirectoryWorkloadClusters)
 }
 
-func GetWCsKustomization() string {
+// GetOrgWCsKustomizationFile
+// Base: ORG_NAME
+// Target: workload-clusters/kustomization.yaml
+func GetOrgWCsKustomizationFile() string {
 	return fmt.Sprintf("%s/%s", DirectoryWorkloadClusters, FileKustomization)
 }
 
-func FileName(name string) string {
-	return fmt.Sprintf("%s.yaml", name)
+// GetRootOrganizationsDirectory
+// Base: repository root
+// Target: management-clusters/MC_NAME/organizations
+func GetRootOrganizationsDirectory(mc string) string {
+	return fmt.Sprintf("%s/%s/%s",
+		DirectoryManagementClusters,
+		mc,
+		DirectoryOrganizations,
+	)
 }
 
-func OrganizationsDirectory(mc string) string {
-	return fmt.Sprintf("%s/%s/%s", DirectoryManagementClusters, mc, DirectoryOrganizations)
-}
-
-func WorkloadClusterAppDirectory(mc, org, wc string) string {
+// GetRootWorkloadClusterDirectory
+// Base: repository root
+// Target: management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME
+func GetRootWorkloadClusterDirectory(mc, org, wc string) string {
 	return fmt.Sprintf(
 		"%s/%s/%s/%s/%s/%s",
 		DirectoryManagementClusters,
@@ -79,7 +133,10 @@ func WorkloadClusterAppDirectory(mc, org, wc string) string {
 	)
 }
 
-func WorkloadClustersDirectory(mc, org string) string {
+// GetRootOrganizationDirectory
+// Base: repository root
+// Target: management-clusters/MC_NAME/organizations/ORG_NAME
+func GetRootOrganizationDirectory(mc, org string) string {
 	return fmt.Sprintf(
 		"%s/%s/%s/%s",
 		DirectoryManagementClusters,

--- a/internal/gitops/structure/templates/automatic-updates/imagepolicy.yaml.tmpl
+++ b/internal/gitops/structure/templates/automatic-updates/imagepolicy.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: {{ .WorkloadCluster }}-{{ .App }}
+spec:
+  imageRepositoryRef:
+    name: {{ .WorkloadCluster }}-{{ .App }}
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/internal/gitops/structure/templates/automatic-updates/imagerepository.yaml.tmpl
+++ b/internal/gitops/structure/templates/automatic-updates/imagerepository.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: {{ .WorkloadCluster }}-{{ .App }}
+spec:
+  image: {{ .VersionRepository }}
+  interval: 10m0s

--- a/internal/gitops/structure/templates/automatic-updates/imageupdate.yaml.tmpl
+++ b/internal/gitops/structure/templates/automatic-updates/imageupdate.yaml.tmpl
@@ -1,0 +1,28 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: {{ .ManagementCluster}}-updates
+  namespace: default
+spec:
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        automated app upgrades:
+        {{ "{{ range $image, $_ := .Updated.Images -}}" }}
+        - {{ "{{ $image.Repository }} to {{ $image.Identifier }}" }}
+        {{ "{{ end -}}" }}
+    push:
+      branch: main
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: {{ .Repository }}
+  update:
+    path: ./management-clusters/{{ .ManagementCluster }}
+    strategy: Setters

--- a/internal/gitops/structure/templates/automatic-updates/template.go
+++ b/internal/gitops/structure/templates/automatic-updates/template.go
@@ -1,0 +1,30 @@
+package organization
+
+import (
+	_ "embed"
+
+	"github.com/giantswarm/kubectl-gs/internal/gitops/structure/templates/common"
+)
+
+//go:embed imagepolicy.yaml.tmpl
+var imagepolicy string
+
+//go:embed imagerepository.yaml.tmpl
+var imagerepository string
+
+//go:embed imageupdate.yaml.tmpl
+var imageupdate string
+
+// GetAutomaticUpdatesTemplates returns organization directory layout.
+func GetAutomaticUpdatesTemplates() []common.Template {
+	return []common.Template{
+		common.Template{Name: "imageupdate.yaml", Data: imageupdate},
+	}
+}
+
+func GetAppImageUpdatesTemplates() []common.Template {
+	return []common.Template{
+		common.Template{Name: "imagepolicy.yaml", Data: imagepolicy},
+		common.Template{Name: "imagerepository.yaml", Data: imagerepository},
+	}
+}

--- a/internal/gitops/structure/testdata/expected/0-imagepolicy.golden
+++ b/internal/gitops/structure/testdata/expected/0-imagepolicy.golden
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: demowc-hello-world
+spec:
+  imageRepositoryRef:
+    name: demowc-hello-world
+  policy:
+    semver:
+      range: '>=0.0.0'

--- a/internal/gitops/structure/testdata/expected/0-imagerepository.golden
+++ b/internal/gitops/structure/testdata/expected/0-imagerepository.golden
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: demowc-hello-world
+spec:
+  image: quay.io/giantswarm/hello-world
+  interval: 10m0s

--- a/internal/gitops/structure/testdata/expected/0-imageupdate.golden
+++ b/internal/gitops/structure/testdata/expected/0-imageupdate.golden
@@ -1,0 +1,28 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageUpdateAutomation
+metadata:
+  name: demomc-updates
+  namespace: default
+spec:
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        automated app upgrades:
+        {{ range $image, $_ := .Updated.Images -}}
+        - {{ $image.Repository }} to {{ $image.Identifier }}
+        {{ end -}}
+    push:
+      branch: main
+  interval: 1m0s
+  sourceRef:
+    kind: GitRepository
+    name: gitops-demo
+  update:
+    path: ./management-clusters/demomc
+    strategy: Setters

--- a/internal/gitops/structure/types.go
+++ b/internal/gitops/structure/types.go
@@ -18,6 +18,15 @@ type AppConfig struct {
 	Version             string
 }
 
+type AutomaticUpdateConfig struct {
+	App               string
+	ManagementCluster string
+	Organization      string
+	Repository        string
+	WorkloadCluster   string
+	VersionRepository string
+}
+
 type McConfig struct {
 	Name            string
 	RefreshInterval string


### PR DESCRIPTION
## Description

Command enables automatic updates for the given app.

**Note**: eventually this command should also account for the mapi and out-of-band directories.

## ToDos

- [ ] take into account that some apps may be created from a base, in such case automatic updates configuration should be aborted and user should get informed that he must configure automatic updates in his base instead

## Examples 

```sh
kubectl gs gitops add update \
--management-cluster demomc \
--organization demoorg \
--workload-cluster demowc \
--app hello-world \
--version-repository quay.io/giantswarm/hello-world \
--repository gitops-demo \
--local-path /tmp/gitops-demo \
--dry-run

/tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/automatic-updates
/tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/automatic-updates/imageupdate.yaml
apiVersion: image.toolkit.fluxcd.io/v1beta1
kind: ImageUpdateAutomation
metadata:
  name: demomc-updates
  namespace: default
spec:
  git:
    checkout:
      ref:
        branch: main
    commit:
      author:
        email: fluxcdbot@users.noreply.github.com
        name: fluxcdbot
      messageTemplate: |
        automated app upgrades:
        {{ range $image, $_ := .Updated.Images -}}
        - {{ $image.Repository }} to {{ $image.Identifier }}
        {{ end -}}
    push:
      branch: main
  interval: 1m0s
  sourceRef:
    kind: GitRepository
    name: gitops-demo
  update:
    path: ./management-clusters/demomc
    strategy: Setters

/tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/apps/hello-world/imagepolicy.yaml
apiVersion: image.toolkit.fluxcd.io/v1beta1
kind: ImagePolicy
metadata:
  name: demowc-hello-world
spec:
  imageRepositoryRef:
    name: demowc-hello-world
  policy:
    semver:
      range: '>=0.0.0'

/tmp/gitops-demo/management-clusters/demomc/organizations/demoorg/workload-clusters/demowc/apps/hello-world/imagerepository.yaml
apiVersion: image.toolkit.fluxcd.io/v1beta1
kind: ImageRepository
metadata:
  name: demowc-hello-world
spec:
  image: quay.io/giantswarm/hello-world
  interval: 10m0s
```