### PR TITLE
capa-changes

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,3 @@
 # Consul - no fix yet
-CVE-2022-29153 until=2022-08-01
-CVE-2022-24687 until=2022-08-01
+CVE-2022-29153 until=2022-12-01
+CVE-2022-24687 until=2022-12-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Remove CAPA templating from `aws` provider.
+- Add new provider `capa` for templating a cluster.
+- Remove fetching ssh sso ca pub key for capa from management cluster.
+
 ## [2.18.0] - 2022-07-08
 
 ### Added

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -17,28 +17,9 @@ import (
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {
 	var err error
 
-	isCapiVersion, err := key.IsCAPIVersion(config.ReleaseVersion)
+	err = WriteGSAWSTemplate(ctx, client, out, config)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-
-	if isCapiVersion {
-		if config.AWS.EKS {
-			err = WriteCAPAEKSTemplate(ctx, client, out, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		} else {
-			err = WriteCAPATemplate(ctx, client, out, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		}
-	} else {
-		err = WriteGSAWSTemplate(ctx, client, out, config)
-		if err != nil {
-			return microerror.Mask(err)
-		}
 	}
 
 	return nil

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -15,9 +15,7 @@ import (
 )
 
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {
-	var err error
-
-	err = WriteGSAWSTemplate(ctx, client, out, config)
+	err := WriteGSAWSTemplate(ctx, client, out, config)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -26,22 +26,22 @@ const (
 func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
 	var err error
 
-	var sshSSOPublicKey string
-	{
-		sshSSOPublicKey, err = key.SSHSSOPublicKey(ctx, client.CtrlClient())
+	if config.AWS.EKS {
+		err = WriteCAPAEKSTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-	}
-	config.AWS.SSHSSOPublicKey = sshSSOPublicKey
+	} else {
+		err = templateClusterAWS(ctx, client, output, config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 
-	err = templateClusterAWS(ctx, client, output, config)
-	if err != nil {
+		err = templateDefaultAppsAWS(ctx, client, output, config)
 		return microerror.Mask(err)
 	}
 
-	err = templateDefaultAppsAWS(ctx, client, output, config)
-	return microerror.Mask(err)
+	return nil
 }
 
 func WriteCAPAEKSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -8,7 +8,6 @@ type ClusterConfig struct {
 	Bastion            *Bastion       `json:"bastion,omitempty"`
 	ControlPlane       *ControlPlane  `json:"controlPlane,omitempty"`
 	MachinePools       *[]MachinePool `json:"machinePools,omitempty"`
-	SSHSSOPublicKey    string         `json:"sshSSOPublicKey,omitempty"`
 	FlatcarAWSAccount  string         `json:"flatcarAWSAccount,omitempty"`
 }
 

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -81,6 +81,11 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
+	case key.ProviderCAPA:
+		err = provider.WriteCAPATemplate(ctx, client, output, config)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	case key.ProviderGCP:
 		err = provider.WriteGCPTemplate(ctx, client, output, config)
 		if err != nil {

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -3,6 +3,7 @@ package key
 const (
 	ProviderAWS       = "aws"
 	ProviderAzure     = "azure"
+	ProviderCAPA      = "capa"
 	ProviderGCP       = "gcp"
 	ProviderKVM       = "kvm"
 	ProviderOpenStack = "openstack"
@@ -12,6 +13,7 @@ const (
 // PureCAPIProviders is the list of all providers which are purely based on or fully migrated to CAPI
 func PureCAPIProviders() []string {
 	return []string{
+		ProviderCAPA,
 		ProviderGCP,
 		ProviderVSphere,
 		ProviderOpenStack,


### PR DESCRIPTION
* remove CAPA from AWS provider - this was done based on the release version but it doesn't make sense anymore as CAPA does not have any release
* add new CAPA provider for creating capa clusters
* remove the fetching of ssh SSO public key from CP