### PR TITLE
add missing ConfigFlags in nodepool template cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [2.19.0] - 2022-08-12
+### Fixed
+
+- Fix nil pointer in nodepool template command.
+
+# [2.19.0] - 2022-08-12
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix nil pointer in nodepool template command.
+- Fix nil pointer panic in `template nodepool` command.
 
 # [2.19.0] - 2022-08-12
 

--- a/cmd/template/command.go
+++ b/cmd/template/command.go
@@ -93,6 +93,9 @@ func New(config Config) (*cobra.Command, error) {
 	{
 		c := nodepool.Config{
 			Logger: config.Logger,
+
+			ConfigFlags: config.ConfigFlags,
+
 			Stderr: config.Stderr,
 			Stdout: config.Stdout,
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23273

The regression was introduced in [this PR](https://github.com/giantswarm/kubectl-gs/pull/859) where `template nodepool` was the only one not receiving the original `config.K8sConfigAccess`, therefore was easy to miss.

In this PR I'm including the `config.ConfigFlags` following [this change](https://github.com/giantswarm/kubectl-gs/pull/859/files#diff-fbde5499c435beca0c745466e479985895ca6f27c4b6574aa0b1912509913f45R80)


