### PR TITLE
Fixed common name in wc client certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Fixed common name in certificates generated for workload clusters by stripping https:// prefix from cluster base path
+
 ## [2.19.1] - 2022-08-17
 
 ### Fixed

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -84,7 +84,8 @@ func generateClientCertUID() string {
 func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error) {
 	clientCertUID := generateClientCertUID()
 	clientCertName := fmt.Sprintf("%s-%s", config.clusterName, clientCertUID)
-	commonName := fmt.Sprintf("%s.%s.k8s.%s", clientCertUID, config.clusterName, config.clusterBasePath)
+	sanitizedClusterBasePath := strings.TrimPrefix(config.clusterBasePath, "https://")
+	commonName := fmt.Sprintf("%s.%s.k8s.%s", clientCertUID, config.clusterName, sanitizedClusterBasePath)
 
 	certConfig := &corev1alpha1.CertConfig{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixed common name in client certificates generated for workload clusters:

- stripped `https://` prefix from cluster base path

Fixes https://github.com/giantswarm/roadmap/issues/1323

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
