### PR TITLE
Set correct gcp server address when logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Set domain name for the Kubernetes APIs server address when logging in to a GCP workload cluster.
+
+
 ## [2.19.2] - 2022-08-17
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Set domain name for the Kubernetes APIs server address when logging in to a GCP workload cluster.
+- Set domain name for the Kubernetes APIs server address when logging in to CAPI provider workload clusters.
 
 
 ## [2.19.2] - 2022-08-17

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -3,6 +3,7 @@ package login
 import (
 	"context"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -204,12 +205,20 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 		return "", false, microerror.Mask(err)
 	}
 
+	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
+
+	// If the control plane host is an IP address then it is a GCP cluster and
+	// we need to manually set the cluster server to the correct domain
+	if net.ParseIP(c.Cluster.Spec.ControlPlaneEndpoint.Host) != nil {
+		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
+	}
+
 	credentialConfig := credentialConfig{
 		clusterID:     r.flag.WCName,
 		certCRT:       secret.Data[credentialKeyCertCRT],
 		certKey:       secret.Data[credentialKeyCertKey],
 		certCA:        secret.Data[credentialKeyCertCA],
-		clusterServer: fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port),
+		clusterServer: clusterServer,
 		filePath:      r.flag.SelfContained,
 		loginOptions:  r.loginOptions,
 	}

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -207,7 +207,7 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 
-	// If the control plane host is an IP address then it is a GCP cluster and
+	// If the control plane host is an IP address then it is a CAPI cluster and
 	// we need to manually set the cluster server to the correct domain
 	if net.ParseIP(c.Cluster.Spec.ControlPlaneEndpoint.Host) != nil {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)


### PR DESCRIPTION
Description 
---

The GCP ControlPlaneEndpoint.Host is an IP. Since our VPN routes the domain we create for the API, this change is needed in order for us to connect the cluster

Fixes giantswarm/roadmap#1291

Checklist 
---
As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.
- [x] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
_I think this is N/A in this case?_
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
