### PR TITLE
Remove obsolete alias in `gitops add app`

### DIFF
--- a/cmd/gitops/add/app/command.go
+++ b/cmd/gitops/add/app/command.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	name  = "app"
-	alias = "app"
+	name = "app"
 
 	shortDescription = "Adds a new Application to your GitOps directory structure"
 	longDescription  = `Adds a new Application to your GitOps directory structure.
@@ -104,7 +103,6 @@ func New(config Config) (*cobra.Command, error) {
 		Short:   shortDescription,
 		Long:    longDescription,
 		Example: examples,
-		Aliases: []string{alias},
 		RunE:    r.Run,
 	}
 


### PR DESCRIPTION
This PR removes an alias which is the same as the command name.

Before this PR, usage looks like this:

```
Aliases:
  app, app
```

This PR has no effect on the function of the command.