### PR TITLE
Fixed extracting WC base domain from MC API url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - `kubectl gs template app` help text: Replace deprecated `--cluster` flag by new `--cluster-name`.
+- Fixed generating common names for workload cluster certificates from internal management cluster API URLs in `kubectl gs login --workload-cluster --internal-api ...`
 
 ## [2.23.0] - 2022-09-22
 

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -85,7 +85,6 @@ func generateClientCertUID() string {
 func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error) {
 	clientCertUID := generateClientCertUID()
 	clientCertName := fmt.Sprintf("%s-%s", config.clusterName, clientCertUID)
-	sanitizedClusterBasePath := strings.TrimPrefix(config.clusterBasePath, "https://")
 	var clientCertCNPrefix string
 	{
 		if config.cnPrefix != "" {
@@ -94,7 +93,7 @@ func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error)
 			clientCertCNPrefix = clientCertUID
 		}
 	}
-	commonName := fmt.Sprintf("%s.%s.k8s.%s", clientCertCNPrefix, config.clusterName, sanitizedClusterBasePath)
+	commonName := fmt.Sprintf("%s.%s.k8s.%s", clientCertCNPrefix, config.clusterName, config.clusterBasePath)
 
 	certConfig := &corev1alpha1.CertConfig{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -299,18 +299,22 @@ func getWCBasePath(k8sConfigAccess clientcmd.ConfigAccess, provider string) (str
 	reg := regexp.MustCompile(`:[0-9]+$`)
 	clusterServer = reg.ReplaceAllString(clusterServer, "")
 
-	// Some management clusters might have 'api.g8s' as prefix (example: Viking).
-	clusterServer = strings.TrimPrefix(clusterServer, "https://api.g8s.")
+	// Sanitize the cluster server address and extract base domain name
+	clusterServer = strings.TrimPrefix(clusterServer, "https://")
+
+	clusterServer = strings.TrimPrefix(clusterServer, "internal-")
+
+	clusterServer = strings.TrimPrefix(clusterServer, "api.")
 
 	// pure CAPI clusters have an api.$INSTALLATION prefix
 	if key.IsPureCAPIProvider(provider) {
 		if _, contextType := kubeconfig.IsKubeContext(config.CurrentContext); contextType == kubeconfig.ContextTypeMC {
 			clusterName := kubeconfig.GetCodeNameFromKubeContext(config.CurrentContext)
-			clusterServer = strings.TrimPrefix(clusterServer, "https://api."+clusterName+".")
+			clusterServer = strings.TrimPrefix(clusterServer, clusterName+".")
 		} else {
 			return "", microerror.Maskf(selectedContextNonCompatibleError, "Can not parse MC codename from context %v. Valid MC context schema is `gs-$CODENAME`.", config.CurrentContext)
 		}
 	}
 
-	return strings.TrimPrefix(clusterServer, "https://g8s."), nil
+	return strings.TrimPrefix(clusterServer, "g8s."), nil
 }


### PR DESCRIPTION
`kubectl gs login --workload-cluster --internal-api ...`: Fixed generating common names for workload cluster certificates from internal management cluster API URLs.

When kubectl-gs makes a request to generate a certificate for a workload cluster, it provides an invalid common name in case the `--internal-api` flag is set.

The common name is created by extracting base domain name from the management cluster API URL and prefixing it with parts specific to the workload cluster. The base domain name extraction does not work correctly in case the management cluster API is internal.

https://github.com/giantswarm/roadmap/issues/1323

This PR addresses the issue.

---

As the creator of a pull request, please consider:

- [x] Describe the goal you are trying to accomplish here, above the line.
- [x] Add a user-friendly description of your change to `CHANGELOG.md`.
- [x] Provide a link to the issue you are solving or working towards, if available.

Feel free to remove this checklist when done.
