### PR TITLE
add --cn-prefix flag to login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added `--cn-prefix` flag to `login` command which allows setting a specific CN prefix for workload cluster client certificates.
+
 ## [2.22.0] - 2022-09-14
 
 ### Changed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -16,6 +16,7 @@ const (
 
 	flagWCName              = "workload-cluster"
 	flagWCOrganization      = "organization"
+	flagWCCertCNPrefix      = "cn-prefix"
 	flagWCCertGroups        = "certificate-group"
 	flagWCCertTTL           = "certificate-ttl"
 	flagSelfContained       = "self-contained"
@@ -30,6 +31,7 @@ type flag struct {
 
 	WCName              string
 	WCOrganization      string
+	WCCertCNPrefix      string
 	WCCertGroups        []string
 	WCCertTTL           string
 	SelfContained       string
@@ -47,6 +49,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("For client certificate creation. Organization that owns the workload cluster. Requires --%s.", flagWCName))
 	cmd.Flags().StringSliceVar(&f.WCCertGroups, flagWCCertGroups, nil, fmt.Sprintf("For client certificate creation. RBAC group name to be encoded into the X.509 field \"O\". Requires --%s.", flagWCName))
 	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf(`For client certificate creation. How long the client certificate should live for. Valid time units are "ms", "s", "m", "h". Requires --%s.`, flagWCName))
+	cmd.Flags().StringVar(&f.WCCertCNPrefix, flagWCCertCNPrefix, "", fmt.Sprintf(`For client certificate creation. Prefix for the name encoded in the X.509 field "CN". Requires --%s.`, flagWCName))
 	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -198,6 +198,7 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 		groups:              r.flag.WCCertGroups,
 		clusterBasePath:     clusterBasePath,
 		certOperatorVersion: certOperatorVersion,
+		cnPrefix:            r.flag.WCCertCNPrefix,
 	}
 
 	clientCertResource, secret, err := r.getCredentials(ctx, services.clientCertService, certConfig)

--- a/cmd/login/wc_test.go
+++ b/cmd/login/wc_test.go
@@ -213,6 +213,31 @@ func TestWCClientCert(t *testing.T) {
 				},
 			},
 		},
+		// Logging into WC using cn prefix flag
+		{
+			name:                 "case 11",
+			clustersInNamespaces: map[string]string{"cluster": "org-organization"},
+			flags: &flag{
+				WCName:         "cluster",
+				WCCertTTL:      "8h",
+				WCCertCNPrefix: "some-prefix",
+			},
+			provider: "aws",
+			isAdmin:  true,
+		},
+		// Logging into WC using cn prefix flag in capi
+		{
+			name:                 "case 12",
+			clustersInNamespaces: map[string]string{"cluster": "org-organization"},
+			flags: &flag{
+				WCName:         "cluster",
+				WCCertTTL:      "8h",
+				WCCertCNPrefix: "some-prefix",
+			},
+			provider: "openstack",
+			capi:     true,
+			isAdmin:  true,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/771
This adds the --cn-prefix flag to the login command which allows users to use a specific prefix for the CN value in the subject line of their workload cluster client certificate.

---

As the creator of a pull request, please consider:

- [ ] Describe the goal you are trying to accomplish here, above the line.
- [ ] Add a user-friendly description of your change to `CHANGELOG.md`.
- [ ] Provide a link to the issue you are solving or working towards, if available.
- [ ] Request SIG UX for review. They care about almost all user-facing changes.
- [ ] Update the public [kubectl-gs documentation](https://docs.giantswarm.io/ui-api/kubectl-gs/) to reflect the changes here.
- [ ] add the `breaking-change` label to the PR if the change you are making changes the existing behaviour. Examples: removal of a flag, removal of a command, change of a default value. (Such changes should be released with a **major version** bump.)

Feel free to remove this checklist when done.
