### PR TITLE
template/app: Update deprecated flag name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- `kubectl gs template app` help text: Replace deprecated `--cluster` flag by new `--cluster-name`.
+
 ## [2.23.0] - 2022-09-22
 
 ### Added

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -59,7 +59,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ClusterName, flagClusterName, "", "Name of the cluster the app will be deployed to.")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().BoolVar(&f.DefaultingEnabled, flagDefaultingEnabled, true, "Don't template fields that will be defaulted.")
-	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, false, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagCluster))
+	cmd.Flags().BoolVar(&f.InCluster, flagInCluster, false, fmt.Sprintf("Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --%s will be ignored.", flagClusterName))
 	cmd.Flags().StringVar(&f.flagUserConfigMap, flagUserConfigMap, "", "Path to the user values configmap YAML file.")
 	cmd.Flags().StringVar(&f.flagUserSecret, flagUserSecret, "", "Path to the user secrets YAML file.")
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")


### PR DESCRIPTION
### What does this PR do?

This PR replaces the formerly used `--cluster` flag in the help text by the new `--cluster-name` flag.

### What is the effect of this change to users?

Reducing confusion, probably.

### What does it look like?

Before:
```
Usage:
  kubectl gs template app [flags]

Flags:
      [...]
      --in-cluster                      Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --cluster will be ignored.
      [...]
```

After:
```
Usage:
  kubectl gs template app [flags]

Flags:
      [...]
      --in-cluster                      Deploy the app in the current management cluster rather than in a workload cluster. If this is set, --cluster-name will be ignored.
      [...]
```

### Any background context you can provide?

None.

### What is needed from the reviewers?

### Do the docs need to be updated?

Probably not.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)

### Is this a breaking change?

No.
