### PR TITLE
Fixes for internal API domain creation

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,6 +1,7 @@
 # Consul - no fix yet
 CVE-2022-29153 until=2022-12-01
 CVE-2022-24687 until=2022-12-01
+CVE-2021-41803 until=2022-12-01
 sonatype-2020-1055 until=2022-12-01
 sonatype-2022-5277 until=2022-12-01
 # Vault API & Vault SDK (sub-deps of SOPS) - no fix in SOPS yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- Fixed deriving internal API hostname from workload cluster main API URL
+- Added support for deriving internal API hostname from workload cluster main API URLs
 
 ## [2.23.1] - 2022-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed deriving internal API hostname from workload cluster main API URL
+
 ## [2.23.1] - 2022-09-27
 
 ### Fixed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -41,7 +41,7 @@ type flag struct {
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.CallbackServerPort, callbackServerPort, 0, "TCP port to use by the OIDC callback server. If not specified, a free port will be selected randomly.")
 	cmd.Flags().BoolVar(&f.ClusterAdmin, flagClusterAdmin, false, "Login with cluster-admin access.")
-	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config.")
+	cmd.Flags().BoolVar(&f.InternalAPI, flagInternalAPI, false, "Use Internal API in the kube config. Please check the documentation for more details.")
 	cmd.Flags().StringVar(&f.SelfContained, flagSelfContained, "", "Create a self-contained kubectl config with embedded credentials and write it to this path.")
 	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, false, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
 

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -13,9 +13,6 @@ import (
 
 const (
 	requestTimeout = 15 * time.Second
-
-	// management cluster internal api prefix
-	internalAPIPrefix = "internal"
 )
 
 type Installation struct {
@@ -28,7 +25,7 @@ type Installation struct {
 }
 
 func New(ctx context.Context, fromUrl string) (*Installation, error) {
-	basePath, err := GetBasePath(fromUrl)
+	basePath, internalApiPath, err := GetBaseAndInternalPath(fromUrl)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -54,7 +51,7 @@ func New(ctx context.Context, fromUrl string) (*Installation, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	k8sInternalAPI := fmt.Sprintf("https://%s-%s", internalAPIPrefix, basePath)
+	k8sInternalAPI := fmt.Sprintf("https://%s", internalApiPath)
 	i := &Installation{
 		K8sApiURL:         info.Kubernetes.ApiUrl,
 		K8sInternalApiURL: k8sInternalAPI,

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -10,24 +10,29 @@ import (
 )
 
 const (
-	k8sApiUrlPrefix = "g8s"
-	happaUrlPrefix  = "happa"
-	athenaUrlPrefix = "athena"
-	internalPrefix  = "internal"
+	wcK8sApiUrlPrefix = "k8s"
+	k8sApiUrlPrefix   = "g8s"
+	happaUrlPrefix    = "happa"
+	athenaUrlPrefix   = "athena"
+	internalPrefix    = "internal"
 )
 
 const (
 	UrlTypeInvalid = iota
 	UrlTypeK8sApi
 	UrlTypeHappa
+	UrlTypeWcK8sApi
 )
 
 var k8sApiURLRegexp = regexp.MustCompile(fmt.Sprintf("([^.]*)%s.*$", k8sApiUrlPrefix))
+var wcK8sApiUrlRegexp = regexp.MustCompile(fmt.Sprintf("^api\\.[0-9a-zA-Z]{5,10}\\.%s.*$", wcK8sApiUrlPrefix))
 
 func GetUrlType(u string) int {
 	switch {
 	case isHappaUrl(u):
 		return UrlTypeHappa
+	case isWcK8sApiUrl(u):
+		return UrlTypeWcK8sApi
 	case isK8sApiUrl(u):
 		return UrlTypeK8sApi
 	default:
@@ -38,6 +43,11 @@ func GetUrlType(u string) int {
 func isK8sApiUrl(u string) bool {
 	u = strings.SplitN(u, ":", 2)[0]
 	return k8sApiURLRegexp.MatchString(u) || (strings.HasPrefix(u, "api.") && strings.HasSuffix(u, ".gigantic.io"))
+}
+
+func isWcK8sApiUrl(u string) bool {
+	u = strings.SplitN(u, ":", 2)[0]
+	return wcK8sApiUrlRegexp.MatchString(u)
 }
 
 func isHappaUrl(u string) bool {
@@ -56,20 +66,27 @@ func GetBaseAndInternalPath(u string) (string, string, error) {
 		return "", "", microerror.Mask(err)
 	}
 
-	switch GetUrlType(path.Host) {
+	urlType := GetUrlType(path.Host)
+	switch urlType {
+	case UrlTypeWcK8sApi:
+		return getSanitizedApiPath(path.Host), getInternalPath(path.Host), nil
 	case UrlTypeK8sApi:
 		if p := k8sApiURLRegexp.FindString(path.Host); len(p) > 0 {
-			return p, getInternalPath(path.Host), nil
+			return p, getInternalPath(p), nil
 		}
-		p := strings.SplitN(path.Host, ":", 2)[0]
-		p = strings.SplitN(p, ".", 2)[1]
-		return p, getInternalPath(path.Host), nil
+		p := getSanitizedApiPath(path.Host)
+		return p, getInternalPath(p), nil
 	case UrlTypeHappa:
 		basePath := strings.Replace(path.Host, fmt.Sprintf("%s.", happaUrlPrefix), "", -1)
 		return basePath, getInternalPath(basePath), nil
 	default:
 		return "", "", microerror.Mask(unknownUrlTypeError)
 	}
+}
+
+func getSanitizedApiPath(u string) string {
+	p := strings.SplitN(u, ":", 2)[0]
+	return strings.SplitN(p, ".", 2)[1]
 }
 
 func getInternalPath(u string) string {

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -8,30 +8,35 @@ import (
 
 func Test_GetBasePath(t *testing.T) {
 	testCases := []struct {
-		name           string
-		url            string
-		expectedResult string
-		errorMatcher   func(error) bool
+		name                   string
+		url                    string
+		expectedResult         string
+		expectedInternalResult string
+		errorMatcher           func(error) bool
 	}{
 		{
-			name:           "case 0: using k8s api url",
-			url:            "https://g8s.test.eu-west-1.aws.coolio.com",
-			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
+			name:                   "case 0: using k8s api url",
+			url:                    "https://g8s.test.eu-west-1.aws.coolio.com",
+			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
-			name:           "case 1: using k8s api url, without scheme",
-			url:            "g8s.test.eu-west-1.aws.coolio.com",
-			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
+			name:                   "case 1: using k8s api url, without scheme",
+			url:                    "g8s.test.eu-west-1.aws.coolio.com",
+			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
-			name:           "case 2: using k8s api url, with trailing slash",
-			url:            "g8s.test.eu-west-1.aws.coolio.com/",
-			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
+			name:                   "case 2: using k8s api url, with trailing slash",
+			url:                    "g8s.test.eu-west-1.aws.coolio.com/",
+			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
-			name:           "case 3: using happa url",
-			url:            "happa.g8s.test.eu-west-1.aws.coolio.com/",
-			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
+			name:                   "case 3: using happa url",
+			url:                    "happa.g8s.test.eu-west-1.aws.coolio.com/",
+			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:         "case 4: using invalid url",
@@ -44,20 +49,22 @@ func Test_GetBasePath(t *testing.T) {
 			errorMatcher: IsUnknownUrlType,
 		},
 		{
-			name:           "case 5: using giant swarm api url",
-			url:            "https://api.g8s.test.eu-west-1.aws.coolio.com",
-			expectedResult: "g8s.test.eu-west-1.aws.coolio.com",
+			name:                   "case 5: using giant swarm api url",
+			url:                    "https://api.g8s.test.eu-west-1.aws.coolio.com",
+			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-api.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
-			name:           "case 5: new style url",
-			url:            "https://api.installation.customer.gigantic.io:6443",
-			expectedResult: "installation.customer.gigantic.io",
+			name:                   "case 5: new style url",
+			url:                    "https://api.installation.customer.gigantic.io:6443",
+			expectedResult:         "installation.customer.gigantic.io",
+			expectedInternalResult: "internal-api.installation.customer.gigantic.io",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			basePath, err := GetBasePath(tc.url)
+			basePath, internalPath, err := GetBaseAndInternalPath(tc.url)
 			if tc.errorMatcher != nil {
 				if !tc.errorMatcher(err) {
 					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
@@ -70,6 +77,9 @@ func Test_GetBasePath(t *testing.T) {
 
 			if basePath != tc.expectedResult {
 				t.Fatalf("base path not expected, got: %s, want: %s", basePath, tc.expectedResult)
+			}
+			if internalPath != tc.expectedInternalResult {
+				t.Fatalf("internal path not expected, got: %s, want: %s", internalPath, tc.expectedInternalResult)
 			}
 		})
 	}

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -52,13 +52,25 @@ func Test_GetBasePath(t *testing.T) {
 			name:                   "case 5: using giant swarm api url",
 			url:                    "https://api.g8s.test.eu-west-1.aws.coolio.com",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
-			expectedInternalResult: "internal-api.g8s.test.eu-west-1.aws.coolio.com",
+			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:                   "case 5: new style url",
 			url:                    "https://api.installation.customer.gigantic.io:6443",
 			expectedResult:         "installation.customer.gigantic.io",
-			expectedInternalResult: "internal-api.installation.customer.gigantic.io",
+			expectedInternalResult: "internal-installation.customer.gigantic.io",
+		},
+		{
+			name:                   "case 6: wc k8s api url",
+			url:                    "https://api.abc12.k8s.installation.customer.gigantic.io:6443",
+			expectedResult:         "abc12.k8s.installation.customer.gigantic.io",
+			expectedInternalResult: "internal-api.abc12.k8s.installation.customer.gigantic.io",
+		},
+		{
+			name:                   "case 6: wc k8s api long url",
+			url:                    "https://api.abc12def34.k8s.installation.customer.gigantic.io:6443",
+			expectedResult:         "abc12def34.k8s.installation.customer.gigantic.io",
+			expectedInternalResult: "internal-api.abc12def34.k8s.installation.customer.gigantic.io",
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds support for creation of internal API hostnames from workload cluster main API URLs.

### Any background context you can provide?

Adds a possibility to log in to workload clusters using their internal APIs.
