### PR TITLE
WC name extended length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Add `giantswarm.io/cluster` label to the 'default-apps' bundle so that it's deleted when a `Cluster` is deleted.
+- Deprecated `--enable-long-names` flag and added support for generating and validating long resource names (up to 10 characters) by default
 
 ## [2.23.2] - 2022-10-04
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	flagProvider = "provider"
+	flagEnableLongNames = "enable-long-names"
+	flagProvider        = "provider"
 
 	// AWS only.
 	flagAWSExternalSNAT       = "external-snat"
@@ -129,6 +130,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.
@@ -262,6 +264,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// bastion
 	cmd.Flags().StringVar(&f.BastionInstanceType, flagBastionInstanceType, "", "Instance type used for the bastion node.")
 	cmd.Flags().IntVar(&f.BastionReplicas, flagBastionReplicas, 1, "Replica count for the bastion node")
+
+	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
+	_ = cmd.Flags().MarkDeprecated(flagEnableLongNames, "Long names are supported by default, so this flag is not needed anymore and will be removed in the next major version.")
 
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
 	_ = cmd.Flags().MarkHidden(flagAWSEKS)

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	flagEnableLongNames = "enable-long-names"
-	flagProvider        = "provider"
+	flagProvider = "provider"
 
 	// AWS only.
 	flagAWSExternalSNAT       = "external-snat"
@@ -130,7 +129,6 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.
@@ -265,8 +263,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.BastionInstanceType, flagBastionInstanceType, "", "Instance type used for the bastion node.")
 	cmd.Flags().IntVar(&f.BastionReplicas, flagBastionReplicas, 1, "Replica count for the bastion node")
 
-	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
-
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
 	_ = cmd.Flags().MarkHidden(flagAWSEKS)
 
@@ -300,7 +296,7 @@ func (f *flag) Validate() error {
 	}
 
 	if f.Name != "" {
-		valid, err := key.ValidateName(f.Name, f.EnableLongNames)
+		valid, err := key.ValidateName(f.Name, true)
 		if err != nil {
 			return microerror.Mask(err)
 		} else if !valid {

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -54,7 +54,7 @@ func NewClusterCRs(config ClusterCRsConfig) (ClusterCRs, error) {
 	// the workload cluster name may be provided by the user.
 	{
 		if config.ClusterName == "" {
-			generatedName, err := key.GenerateName(config.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return ClusterCRs{}, microerror.Mask(err)
 			}
@@ -63,7 +63,7 @@ func NewClusterCRs(config ClusterCRsConfig) (ClusterCRs, error) {
 		}
 
 		if config.ControlPlaneName == "" {
-			generatedName, err := key.GenerateName(config.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return ClusterCRs{}, microerror.Mask(err)
 			}

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -126,7 +126,7 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 	}
 
 	if config.Name == "" {
-		generatedName, err := key.GenerateName(r.flag.EnableLongNames)
+		generatedName, err := key.GenerateName(true)
 		if err != nil {
 			return provider.ClusterConfig{}, microerror.Mask(err)
 		}

--- a/cmd/template/networkpool/flag.go
+++ b/cmd/template/networkpool/flag.go
@@ -10,7 +10,6 @@ import (
 const (
 	// Common.
 	flagCIDRBlock       = "cidr-block"
-	flagEnableLongNames = "enable-long-names"
 	flagNetworkPoolName = "networkpool-name"
 	flagOutput          = "output"
 	flagOrganization    = "organization"
@@ -19,7 +18,6 @@ const (
 type flag struct {
 	// Common.
 	CIDRBlock       string
-	EnableLongNames bool
 	NetworkPoolName string
 	Output          string
 	Organization    string
@@ -27,12 +25,9 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.CIDRBlock, flagCIDRBlock, "", "Installation infrastructure provider.")
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.NetworkPoolName, flagNetworkPoolName, "", "NetworkPool identifier.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
-
-	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/networkpool/flag.go
+++ b/cmd/template/networkpool/flag.go
@@ -10,6 +10,7 @@ import (
 const (
 	// Common.
 	flagCIDRBlock       = "cidr-block"
+	flagEnableLongNames = "enable-long-names"
 	flagNetworkPoolName = "networkpool-name"
 	flagOutput          = "output"
 	flagOrganization    = "organization"
@@ -18,6 +19,7 @@ const (
 type flag struct {
 	// Common.
 	CIDRBlock       string
+	EnableLongNames bool
 	NetworkPoolName string
 	Output          string
 	Organization    string
@@ -25,9 +27,13 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.CIDRBlock, flagCIDRBlock, "", "Installation infrastructure provider.")
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.NetworkPoolName, flagNetworkPoolName, "", "NetworkPool identifier.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
+
+	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
+	_ = cmd.Flags().MarkDeprecated(flagEnableLongNames, "Long names are supported by default, so this flag is not needed anymore and will be removed in the next major version.")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/template/networkpool/runner.go
+++ b/cmd/template/networkpool/runner.go
@@ -53,7 +53,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 
 		if config.NetworkPoolName == "" {
-			generatedName, err := key.GenerateName(r.flag.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	flagProvider = "provider"
+	flagEnableLongNames = "enable-long-names"
+	flagProvider        = "provider"
 
 	// AWS only.
 	flagAWSInstanceType                     = "aws-instance-type"
@@ -45,7 +46,8 @@ const (
 )
 
 type flag struct {
-	Provider string
+	EnableLongNames bool
+	Provider        string
 
 	// AWS only.
 	AWSInstanceType                     string
@@ -75,6 +77,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.
@@ -100,6 +103,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
+
+	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
+	_ = cmd.Flags().MarkDeprecated(flagEnableLongNames, "Long names are supported by default, so this flag is not needed anymore and will be removed in the next major version.")
 
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
 	_ = cmd.Flags().MarkHidden(flagEKS)

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	flagEnableLongNames = "enable-long-names"
-	flagProvider        = "provider"
+	flagProvider = "provider"
 
 	// AWS only.
 	flagAWSInstanceType                     = "aws-instance-type"
@@ -46,8 +45,7 @@ const (
 )
 
 type flag struct {
-	EnableLongNames bool
-	Provider        string
+	Provider string
 
 	// AWS only.
 	AWSInstanceType                     string
@@ -77,7 +75,6 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.
@@ -103,8 +100,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
-
-	_ = cmd.Flags().MarkHidden(flagEnableLongNames)
 
 	// TODO: Make this flag visible when we roll CAPA/EKS out for customers
 	_ = cmd.Flags().MarkHidden(flagEKS)

--- a/cmd/template/nodepool/provider/templates/aws/nodepool.go
+++ b/cmd/template/nodepool/provider/templates/aws/nodepool.go
@@ -24,7 +24,6 @@ type NodePoolCRsConfig struct {
 	ClusterName                         string
 	MachineDeploymentName               string
 	Description                         string
-	EnableLongNames                     bool
 	NodesMax                            int
 	NodesMin                            int
 	OnDemandBaseCapacity                int
@@ -47,7 +46,7 @@ func NewNodePoolCRs(config NodePoolCRsConfig) (NodePoolCRs, error) {
 	// the workload cluster name may be provided by the user.
 	{
 		if config.ClusterName == "" {
-			generatedName, err := key.GenerateName(config.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return NodePoolCRs{}, microerror.Mask(err)
 			}
@@ -56,7 +55,7 @@ func NewNodePoolCRs(config NodePoolCRsConfig) (NodePoolCRs, error) {
 		}
 
 		if config.MachineDeploymentName == "" {
-			generatedName, err := key.GenerateName(config.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return NodePoolCRs{}, microerror.Mask(err)
 			}

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -68,7 +68,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 
 		if config.NodePoolName == "" {
-			generatedName, err := key.GenerateName(r.flag.EnableLongNames)
+			generatedName, err := key.GenerateName(true)
 			if err != nil {
 				return microerror.Mask(err)
 			}


### PR DESCRIPTION
### What does this PR do?

- Changes required length of resource names in validation and auto-generated name lengths of clusters, node pools and network pools to 10 characters
- Deprecates `--enable-long-names` flag from `template cluter`, `template nodepool` and `template networkpool` commands

### What is the effect of this change to users?

Kgs allows users to configure longer names for resources without adding a special flag.
Auto-generated names of certain resource are longer.

### What does it look like?

Auto-generated names of Cluster, Nodepool and Neteworkpool resources are 10 characters long:
```
kind: Cluster
metadata:
  name: abc1234567
```

instead of 
```
kind: Cluster
metadata:
  name: abc12
```

Names provided manually can be shorter.

Deprecated `--enable-long-names` flag warning:

```
Flag --enable-long-names has been deprecated, Long names are supported by default, so this flag is not needed anymore and will be removed in the next major version.
```

### Any background context you can provide?

When creating a template for (not only) a Cluster resource, Kubectl-gs fails in case a name longer than 5 characters is configured for the resource, unless a flag called `--enable-long-names` is provided.

Longer resource names are becoming more common, and since the `--enable-long-names` flag is not even visible in usage instructions, the flag is no longer needed and instead longer resource names should be supported by default.

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
