### PR TITLE
Add option to reference 'cluster-values' configmap when creating App CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Add `giantswarm.io/cluster` label to the 'default-apps' bundle so that it's deleted when a `Cluster` is deleted.
+- Add option to reference the `cluster-values` configmap in the `App` CR created for CAPI clusters.
 
 ## [2.23.2] - 2022-10-04
 

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -183,6 +183,11 @@ func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, 
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			DefaultingEnabled:       false,
+			UseClusterValuesConfig:  true,
+			ExtraLabels: map[string]string{
+				k8smetadata.ManagedBy: "cluster",
+			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
@@ -191,6 +192,11 @@ func templateDefaultAppsOpenstack(ctx context.Context, k8sClient k8sclient.Inter
 			Namespace:               fmt.Sprintf("org-%s", config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			DefaultingEnabled:       false,
+			UseClusterValuesConfig:  true,
+			ExtraLabels: map[string]string{
+				k8smetadata.ManagedBy: "cluster",
+			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -82,14 +82,15 @@ metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
     giantswarm.io/cluster: test1
+    giantswarm.io/managed-by: cluster
   name: test1-default-apps
   namespace: org-test
 spec:
   catalog: the-default-catalog
   config:
     configMap:
-      name: ""
-      namespace: ""
+      name: test1-cluster-values
+      namespace: org-test
     secret:
       name: ""
       namespace: ""

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -36,6 +36,7 @@ type Config struct {
 	Version                    string
 	ExtraLabels                map[string]string
 	ExtraAnnotations           map[string]string
+	UseClusterValuesConfig     bool
 }
 
 type UserConfig struct {
@@ -127,12 +128,8 @@ func NewAppCR(config Config) ([]byte, error) {
 	}
 
 	if !config.DefaultingEnabled && !config.InCluster {
-		appCR.Spec.Config = applicationv1alpha1.AppSpecConfig{
-			ConfigMap: applicationv1alpha1.AppSpecConfigConfigMap{
-				Name:      config.Cluster + "-cluster-values",
-				Namespace: crNamespace,
-			},
-		}
+		config.UseClusterValuesConfig = true
+
 		appCR.Spec.KubeConfig = applicationv1alpha1.AppSpecKubeConfig{
 			Context: applicationv1alpha1.AppSpecKubeConfigContext{
 				Name: config.Cluster + "-kubeconfig",
@@ -140,6 +137,15 @@ func NewAppCR(config Config) ([]byte, error) {
 			InCluster: false,
 			Secret: applicationv1alpha1.AppSpecKubeConfigSecret{
 				Name:      config.Cluster + "-kubeconfig",
+				Namespace: crNamespace,
+			},
+		}
+	}
+
+	if config.UseClusterValuesConfig {
+		appCR.Spec.Config = applicationv1alpha1.AppSpecConfig{
+			ConfigMap: applicationv1alpha1.AppSpecConfigConfigMap{
+				Name:      config.Cluster + "-cluster-values",
 				Namespace: crNamespace,
 			},
 		}

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -129,6 +129,21 @@ func Test_NewAppCR(t *testing.T) {
 			},
 			expectedGoldenFile: "app_flawless_flow_timeouts_yaml_output.golden",
 		},
+		{
+			name: "case 8: app config points to cluster-values configmap",
+			config: Config{
+				AppName:                "eggs2-default-apps",
+				Catalog:                "cluster",
+				Cluster:                "eggs2",
+				DefaultingEnabled:      false,
+				InCluster:              true,
+				Name:                   "default-apps-gcp",
+				Namespace:              "org-giantswarm",
+				Version:                "0.13.0",
+				UseClusterValuesConfig: true,
+			},
+			expectedGoldenFile: "app_config_cluster_values_yaml_output.golden",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/template/app/testdata/app_config_cluster_values_yaml_output.golden
+++ b/pkg/template/app/testdata/app_config_cluster_values_yaml_output.golden
@@ -1,0 +1,27 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: eggs2
+  name: eggs2-default-apps
+  namespace: org-giantswarm
+spec:
+  catalog: cluster
+  config:
+    configMap:
+      name: eggs2-cluster-values
+      namespace: org-giantswarm
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: default-apps-gcp
+  namespace: org-giantswarm
+  version: 0.13.0


### PR DESCRIPTION
### What does this PR do?

We need the `default-apps-$provider` app bundle to use the `cluster-values` configmap. 

### What is the effect of this change to users?

The default apps included in `default-apps-$provider` app bundle can consume values from the shared configmap.

### What does it look like?

example output

```
./kubectl-gs template cluster --context gs-gunther --provider gcp --organization giantswarm --name jos18 --description "jose test" --gcp-project giantswarm-352614 --region europe-west6 --gcp-failure-domains europe-west6-a,europe-west6-b,europe-west6-c --gcp-machine-deployment-failure-domain europe-west6-a
---
apiVersion: v1
data:
  values: |
    clusterDescription: jose test
    clusterName: jos18
    controlPlane:
      replicas: 3
      serviceAccount:
        email: default
        scopes:
        - https://www.googleapis.com/auth/compute
    gcp:
      failureDomains:
      - europe-west6-a
      - europe-west6-b
      - europe-west6-c
      project: giantswarm-352614
      region: europe-west6
    machineDeployments:
    - failureDomain: europe-west6-a
      instanceType: n1-standard-2
      name: worker0
      replicas: 3
      rootVolumeSizeGB: 100
    organization: giantswarm
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: jos18
  name: jos18-userconfig
  namespace: org-giantswarm
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
  name: jos18
  namespace: org-giantswarm
spec:
  catalog: cluster
  config:
    configMap:
      name: ""
      namespace: ""
    secret:
      name: ""
      namespace: ""
  kubeConfig:
    context:
      name: ""
    inCluster: true
    secret:
      name: ""
      namespace: ""
  name: cluster-gcp
  namespace: org-giantswarm
  userConfig:
    configMap:
      name: jos18-userconfig
      namespace: org-giantswarm
  version: 0.28.0
---
apiVersion: v1
data:
  values: |
    clusterName: jos18
    organization: giantswarm
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: jos18
  name: jos18-default-apps-userconfig
  namespace: org-giantswarm
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    giantswarm.io/cluster: jos18
    giantswarm.io/managed-by: cluster
  name: jos18-default-apps
  namespace: org-giantswarm
spec:
  catalog: cluster
  config:
    configMap:
      name: jos18-cluster-values
      namespace: org-giantswarm
    secret:
      name: ""
      namespace: ""
  kubeConfig:
    context:
      name: ""
    inCluster: true
    secret:
      name: ""
      namespace: ""
  name: default-apps-gcp
  namespace: org-giantswarm
  userConfig:
    configMap:
      name: jos18-default-apps-userconfig
      namespace: org-giantswarm
  version: 0.13.2
```

### Any background context you can provide?

The `cluster-values` configmap contains values that are related to the cluster and shared among different apps. Different apps may consume these values. We want our apps/charts to be close to upstream helm charts, so we don't want to change the value names on all apps so that they match the values inside the `cluster-values` configmap. Instead the app bundle can act as a translation layer between our `cluster-values` configmap and whatever value is required by the different apps.
For example, the `baseDomain` value that we have in the `cluster-values` configmap could be passed to the cilium app which expects the value to be called `k8sServiceHost` instead of `baseDomain`.

### What is needed from the reviewers?

Do you foresee any unwanted side effects because of this change?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)

### Is this a breaking change?

No
