### PR TITLE
Add cluster label to default-apps bundle so that it's deleted when Cluster is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add `giantswarm.io/cluster` label to the 'default-apps' bundle so that it's deleted when a `Cluster` is deleted.
+
 ## [2.23.2] - 2022-10-04
 
 ### Added

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -228,6 +228,7 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 		var err error
 		appYAML, err = templateapp.NewAppCR(templateapp.Config{
 			AppName:                 appName,
+			Cluster:                 config.Name,
 			Catalog:                 config.App.DefaultAppsCatalog,
 			InCluster:               true,
 			Name:                    DefaultAppsRepoName,

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -176,6 +176,7 @@ func templateDefaultAppsGCP(ctx context.Context, k8sClient k8sclient.Interface, 
 		var err error
 		appYAML, err = templateapp.NewAppCR(templateapp.Config{
 			AppName:                 appName,
+			Cluster:                 config.Name,
 			Catalog:                 config.App.DefaultAppsCatalog,
 			InCluster:               true,
 			Name:                    DefaultAppsGCPRepoName,

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -184,6 +184,7 @@ func templateDefaultAppsOpenstack(ctx context.Context, k8sClient k8sclient.Inter
 		var err error
 		appYAML, err = templateapp.NewAppCR(templateapp.Config{
 			AppName:                 appName,
+			Cluster:                 config.Name,
 			Catalog:                 config.App.DefaultAppsCatalog,
 			InCluster:               true,
 			Name:                    "default-apps-openstack",

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -81,6 +81,7 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: test1
   name: test1-default-apps
   namespace: org-test
 spec:

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -81,6 +81,7 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: test1
   name: test1-default-apps
   namespace: org-test
 spec:


### PR DESCRIPTION
### What does this PR do?

When a `Cluster` CR is deleted, [`cluster-apps-operator` then takes care of deleting all the `App` CRs labeled with that cluster name](https://github.com/giantswarm/cluster-apps-operator/blob/64e85e1901f8352efa25cfb31f58714ee2a1d72d/service/controller/resource/app/delete.go#L149). We want it to also delete the `default-apps-$provider` bundle.

### What is the effect of this change to users?

Users no longer would have to manually delete the `default-apps-$provider` bundle when deleting a `Cluster` CR.

### What does it look like?

n/a

### Any background context you can provide?

Up until now when we want to delete a `Cluster` we manually delete the `App` representing the cluster **and the default apps bundle**. It's not only cumbersome but users may forget.

### What is needed from the reviewers?

Can you think of any downside of labeling the default apps bundle with the cluster id? any side effects?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)

### Is this a breaking change?

No
