### PR TITLE
Fix login failing to access callback server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix login command failing because opening the browser blocks and callback webserver does not start on some operating systems
+
 ## [2.24.0] - 2022-10-10
 
 ### Changed

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -82,7 +82,7 @@ func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *install
 
 	// Open the authorization url in the user's browser, which will eventually
 	// redirect the user to the local web server we'll create next.
-	err = open.Run(authURL)
+	err = open.Start(authURL)
 	if err != nil {
 		fmt.Fprintf(errOut, "%s\n\n", color.YellowString("Couldn't open the default browser. Please access the URL above to continue logging in."))
 	}


### PR DESCRIPTION
### What does this PR do?
On some OS `open.Run` blocks until the opened application (e.g. chrome) is closed again.
This leads to a situation where the callback server is not started yet and the login fails.
Replacing `Run` with `Start` leads to a non-blocking behavior. Therefore, this problem does not occur.

Fixes https://github.com/giantswarm/roadmap/issues/1500

### What is the effect of this change to users?

`kubectl gs login` now works on operating systems where `open.Run` blocks.

### Do the docs need to be updated?
No.

### Should this change be mentioned in the release notes?
No (?)

### Is this a breaking change?
No.

