### PR TITLE
Prevented unnecessary writes to the main kubeconfig file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Added read header timeout to http server
 
+### Changed
+
+- Adjusted `kubectl gs login` command to ensure that it writes to the main kubeconfig file only in case there are actual changes in the content of the file.
+
 ## [2.24.1] - 2022-10-12
 
 ### Fixed

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -392,8 +392,9 @@ func printWCClientCertCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afe
 	if err != nil {
 		return "", false, microerror.Mask(err)
 	}
-	// Because we are still in the MC context we need to switch back to the origin context after creating the WC kubeconfig file
-	if c.loginOptions.originContext != "" {
+	// Change back to the origin context if needed
+	if c.loginOptions.originContext != "" && config.CurrentContext != "" && c.loginOptions.originContext != config.CurrentContext {
+		// Because we are still in the MC context we need to switch back to the origin context after creating the WC kubeconfig file
 		config.CurrentContext = c.loginOptions.originContext
 		err = clientcmd.ModifyConfig(k8sConfigAccess, *config, false)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Ensures that kubectl-gs writes to the main kubeconfig file only in case there are actual changes in the content of the file.

### What is the effect of this change to users?

No visible impacts on usage. The only effect is that kubectl-gs makes less writes to the main kubeconfig file.

### Any background context you can provide?

Kubectl-gs writes to the main kubeconfig file every time it runs, regardless of which command  is executed. In some cases it may even make several writes during execution, and it is not necessary to overwrite the kubeconfig file every time (sometimes kgs overwrites kubeconfig with content, which is exactly the same as before the write).

In case multiple kgs commands are executed in parallel, some of them may fail when they attempt to make concurrent modifications of the kubeconfig file.

This PR addresses the issue and ensures that writes to the kubeconfig file occur only in case there are actual changes in the file content.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
