### PR TITLE
use server address instead of issuer address when retrying login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug in `login` command where the `issuer` URL was used instead of the `server` address in login retry attempt.
+
 ## [2.24.0] - 2022-10-10
 
 ### Changed

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -47,10 +47,9 @@ func (r *runner) loginWithKubeContextName(ctx context.Context, contextName strin
 		authType := kubeconfig.GetAuthType(config, contextName)
 		if authType == kubeconfig.AuthTypeAuthProvider {
 			// If we get here, we are sure that the kubeconfig context exists.
-			authProvider, _ := kubeconfig.GetAuthProvider(config, contextName)
-			issuer := authProvider.Config[Issuer]
+			server, _ := kubeconfig.GetClusterServer(config, contextName)
 
-			err = r.loginWithURL(ctx, issuer, false, "")
+			err = r.loginWithURL(ctx, server, false, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}


### PR DESCRIPTION
### What does this PR do?

This fixes a bug where `login` command is called using the issuer URL on retry which always fails.

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
