### PR TITLE
Use the cluster-values configmap when templating the cluster-aws app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use the `cluster-values` configmap when templating the `default-apps-aws` app.
+
 ## [2.24.2] - 2022-10-13
 
 ### Fixed

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -230,11 +230,16 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			AppName:                 appName,
 			Cluster:                 config.Name,
 			Catalog:                 config.App.DefaultAppsCatalog,
+			DefaultingEnabled:       false,
 			InCluster:               true,
 			Name:                    DefaultAppsRepoName,
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			UseClusterValuesConfig:  true,
+			ExtraLabels: map[string]string{
+				k8smetadata.ManagedBy: "cluster",
+			},
 		})
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -82,14 +82,15 @@ metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
     giantswarm.io/cluster: test1
+    giantswarm.io/managed-by: cluster
   name: test1-default-apps
   namespace: org-test
 spec:
   catalog: the-default-catalog
   config:
     configMap:
-      name: ""
-      namespace: ""
+      name: test1-cluster-values
+      namespace: org-test
     secret:
       name: ""
       namespace: ""


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/1455

We need the default-apps-$provider app bundle to use the cluster-values configmap, because some of the apps included in the bundle rely on cluster values like `baseDomain`.

### What is the effect of this change to users?

The default apps included in `default-apps-$provider` app bundle can consume values from the shared configmap.

### Any background context you can provide?
I forgot to do it for CAPA clusters [on a previous PR](https://github.com/giantswarm/kubectl-gs/pull/906).

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated (if it exists)
