### PR TITLE
When templating Vintage Azure Cluster, use Flatcar version from the Release CR rather than hardcoded one.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- When templating Vintage Azure Cluster, use Flatcar version from the Release CR rather than hardcoded one.
+
 ## [2.26.0] - 2022-10-20
 
 ### Fixed

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -169,7 +169,7 @@ func newAzureMasterMachineCR(config ClusterConfig) *capz.AzureMachine {
 					Publisher: "kinvolk",
 					Offer:     "flatcar-container-linux-free",
 					SKU:       "stable",
-					Version:   "2345.3.1",
+					Version:   config.ReleaseComponents["containerlinux"],
 				},
 			},
 			OSDisk: capz.OSDisk{


### PR DESCRIPTION
### What does this PR do?

there was an hardcoded value, now it's taken from release CR

### What is the effect of this change to users?

None, field is unused.

### What does it look like?

Release CR:

```
$ kubectl get release v18.0.1 -o yaml | grep containerlinux -A1
  name: containerlinux
  version: 3227.2.1
```

Before:

```
$ kubectl gs template cluster --provider azure --organization=giantswarm --release=18.0.1 --description lorenzo-test --control-plane-az 1
...
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureMachine
...
spec:
  ...
  image:
    marketplace:
      ...
      version: 2345.3.1
```

After:

```
$ kubectl gs template cluster --provider azure --organization=giantswarm --release=18.0.1 --description lorenzo-test --control-plane-az 1
...
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: AzureMachine
...
spec:
  ...
  image:
    marketplace:
      ...
      version: 3227.2.1
```

### Any background context you can provide?

https://github.com/giantswarm/ista/issues/302

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

no
