### PR TITLE
Avoid panic in `get nodepools` when node pool is lacking the release version label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid panic in `get nodepools` when node pool is lacking the release version label.
+
 ## [2.26.0] - 2022-10-20
 
 ### Fixed

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -37,6 +37,10 @@ func (s *Service) Supports(featureName string, releaseVersion string) bool {
 		return false
 	}
 
+	if releaseVersion == "" || capability.MinVersion == "" {
+		return false
+	}
+
 	releaseVersion = strings.TrimPrefix(releaseVersion, "v")
 	inputVersion := semver.MustParse(releaseVersion)
 	featureMinVersion := semver.MustParse(capability.MinVersion)


### PR DESCRIPTION
### What does this PR do?

If a NodePool has no release label, there was a panic in `kubectl gs get nodepool`.
This PR fixes that panic

### What is the effect of this change to users?

Avoid a possible error

### What does it look like?

N/A

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/1522

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

no