### PR TITLE
Add option to reference 'cluster-values' configmap when creating CAPA App CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Add option to reference the `cluster-values` configmap in the `App` CR created for CAPA clusters.
+
 ## [2.26.1] - 2022-10-24
 
 ### Fixed

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -162,6 +162,11 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,
+			DefaultingEnabled:       false,
+			UseClusterValuesConfig:  true,
+			ExtraLabels: map[string]string{
+				k8smetadata.ManagedBy: "cluster",
+			},
 		}
 
 		var err error


### PR DESCRIPTION
### What does this PR do?

Implements same logic introduced in https://github.com/giantswarm/kubectl-gs/pull/906 but for CAPA clusters also.

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No