### PR TITLE
Set default value of enable-long-names to true

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -130,7 +130,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, true, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.

--- a/cmd/template/networkpool/flag.go
+++ b/cmd/template/networkpool/flag.go
@@ -27,7 +27,7 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.CIDRBlock, flagCIDRBlock, "", "Installation infrastructure provider.")
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, true, "Allow long names.")
 	cmd.Flags().StringVar(&f.NetworkPoolName, flagNetworkPoolName, "", "NetworkPool identifier.")
 	cmd.Flags().StringVar(&f.Output, flagOutput, "", "File path for storing CRs. (default: stdout)")
 	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Workload cluster organization.")

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -77,7 +77,7 @@ type flag struct {
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, false, "Allow long names.")
+	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, true, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
 
 	// AWS only.


### PR DESCRIPTION
This PR changes the default value of the `--enable-long-names` flag to `true`. Without this, the error message for the `--name` flag validation contains the old valid length (5 chars) instead of the new 10 character limit.

![image](https://user-images.githubusercontent.com/1494211/199486343-cd16c8a3-957a-4437-8598-fe033bcd46d8.png)

Found this together with @Gacko 

### Do the docs need to be updated?

no

### Should this change be mentioned in the release notes?

no

### Is this a breaking change?

no

Closes https://github.com/giantswarm/roadmap/issues/1590.
