### PR TITLE
Change default GCP machine instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Use `n2-standard-4` as default instance types for GAPG worker nodes.
+- Use `n1-standard-4` as default instance types for GAPG worker nodes.
 
 ## [2.28.0] - 2022-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use `n2-standard-4` as default instance types for GAPG worker nodes.
+
 ## [2.28.0] - 2022-11-09
 
 ### Fixed

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -160,7 +160,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&f.GCP.ControlPlane.ServiceAccount.Scopes, flagGCPControlPlaneServiceAccountScopes, []string{"https://www.googleapis.com/auth/compute"}, "Scope of the control plane's Google Cloud Platform Service Account")
 
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.Name, flagGCPMachineDeploymentName, "worker0", "Google Cloud Platform project name")
-	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n1-standard-2", "Google Cloud Platform worker instance type")
+	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n2-standard-4", "Google Cloud Platform worker instance type")
 	cmd.Flags().IntVar(&f.GCP.MachineDeployment.Replicas, flagGCPMachineDeploymentReplicas, 3, "Google Cloud Platform worker replicas")
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.FailureDomain, flagGCPMachineDeploymentFailureDomain, "europe-west6-a", "Google Cloud Platform worker failure domain")
 	cmd.Flags().IntVar(&f.GCP.MachineDeployment.RootVolumeSizeGB, flagGCPMachineDeploymentRootDiskSize, 100, "Google Cloud Platform worker root disk size")

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -160,7 +160,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&f.GCP.ControlPlane.ServiceAccount.Scopes, flagGCPControlPlaneServiceAccountScopes, []string{"https://www.googleapis.com/auth/compute"}, "Scope of the control plane's Google Cloud Platform Service Account")
 
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.Name, flagGCPMachineDeploymentName, "worker0", "Google Cloud Platform project name")
-	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n2-standard-4", "Google Cloud Platform worker instance type")
+	cmd.Flags().StringVar(&f.GCP.MachineDeployment.InstanceType, flagGCPMachineDeploymentInstanceType, "n1-standard-4", "Google Cloud Platform worker instance type")
 	cmd.Flags().IntVar(&f.GCP.MachineDeployment.Replicas, flagGCPMachineDeploymentReplicas, 3, "Google Cloud Platform worker replicas")
 	cmd.Flags().StringVar(&f.GCP.MachineDeployment.FailureDomain, flagGCPMachineDeploymentFailureDomain, "europe-west6-a", "Google Cloud Platform worker failure domain")
 	cmd.Flags().IntVar(&f.GCP.MachineDeployment.RootVolumeSizeGB, flagGCPMachineDeploymentRootDiskSize, 100, "Google Cloud Platform worker root disk size")


### PR DESCRIPTION
### What does this PR do?

Use n1-standard-4 - 4cpus 15GB (see https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines)

### What does it look like?

This just changes the default that ends up in the `<cluster-name>-uservalues` ConfigMap

### What is the effect of this change to users?

This is needed because the `n1-standard-2` has only 2 cpus.
The nginx-ingress-controller (which is a commonly used app) has a cpu request of 2, which makes it impossible to schedule.

### Any background context you can provide?

N/A

### What is needed from the reviewers?

N/A

### Do the docs need to be updated?

Yes

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
