### PR TITLE
CAPG: Possibility to specify volume size and type for root, etcd, kubelet and containerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Adjusted GCP config to support the volume type for all kind of volumes (root, etcd, kubelet, containerd)
+
 ## [2.28.1] - 2022-11-09
 
 ### Changed

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -58,11 +58,13 @@ func templateClusterGCP(ctx context.Context, k8sClient k8sclient.Interface, outp
 			},
 			MachineDeployments: &[]capg.MachineDeployment{
 				{
-					Name:             config.GCP.MachineDeployment.Name,
-					FailureDomain:    config.GCP.MachineDeployment.FailureDomain,
-					InstanceType:     config.GCP.MachineDeployment.InstanceType,
-					Replicas:         config.GCP.MachineDeployment.Replicas,
-					RootVolumeSizeGB: config.GCP.MachineDeployment.RootVolumeSizeGB,
+					Name:          config.GCP.MachineDeployment.Name,
+					FailureDomain: config.GCP.MachineDeployment.FailureDomain,
+					InstanceType:  config.GCP.MachineDeployment.InstanceType,
+					Replicas:      config.GCP.MachineDeployment.Replicas,
+					RootVolume: capg.Volume{
+						SizeGB: config.GCP.MachineDeployment.RootVolumeSizeGB,
+					},
 					CustomNodeLabels: config.GCP.MachineDeployment.CustomNodeLabels,
 					ServiceAccount: capg.ServiceAccount{
 						Email:  config.GCP.MachineDeployment.ServiceAccount.Email,

--- a/cmd/template/cluster/provider/templates/gcp/types.go
+++ b/cmd/template/cluster/provider/templates/gcp/types.go
@@ -31,8 +31,17 @@ type Network struct {
 type ControlPlane struct {
 	InstanceType     string         `json:"instanceType,omitempty"`
 	Replicas         int            `json:"replicas,omitempty"`
-	RootVolumeSizeGB int            `json:"rootVolumeSizeGB,omitempty"`
+	RootVolume       Volume         `json:"rootVolume,omitempty"`
+	EtcdVolume       Volume         `json:"etcdVolume,omitempty"`
+	ContainerdVolume Volume         `json:"containerdVolume,omitempty"`
+	KubeletVolume    Volume         `json:"kubeletVolume,omitempty"`
 	ServiceAccount   ServiceAccount `json:"serviceAccount,omitempty"`
+}
+
+// Defines the size and disk type for a volume
+type Volume struct {
+	SizeGB   int    `json:"sizeGB,omitempty"`
+	DiskType string `json:"diskType,omitempty"`
 }
 
 type ServiceAccount struct {
@@ -45,7 +54,9 @@ type MachineDeployment struct {
 	FailureDomain    string         `json:"failureDomain,omitempty"`
 	InstanceType     string         `json:"instanceType,omitempty"`
 	Replicas         int            `json:"replicas,omitempty"`
-	RootVolumeSizeGB int            `json:"rootVolumeSizeGB,omitempty"`
+	RootVolume       Volume         `json:"rootVolume,omitempty"`
+	ContainerdVolume Volume         `json:"containerdVolume,omitempty"`
+	KubeletVolume    Volume         `json:"kubeletVolume,omitempty"`
 	CustomNodeLabels []string       `json:"customNodeLabels,omitempty"`
 	ServiceAccount   ServiceAccount `json:"serviceAccount,omitempty"`
 }

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -20,8 +20,7 @@ data:
       maxSize: 5
       minSize: 2
       name: worker1
-      rootVolume:
-        sizeGB: 200
+      rootVolumeSizeGB: 200
     network:
       vpcCIDR: 10.123.0.0/16
     organization: test

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -20,7 +20,8 @@ data:
       maxSize: 5
       minSize: 2
       name: worker1
-      rootVolumeSizeGB: 200
+      rootVolume:
+        sizeGB: 200
     network:
       vpcCIDR: 10.123.0.0/16
     organization: test

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -22,10 +22,9 @@ data:
       project: the-project
       region: the-region
     machineDeployments:
-    - failureDomain: failure-domain2-b
       containerdVolume: {}
+    - failureDomain: failure-domain2-b
       instanceType: very-large
-      kubeletVolume: {}
       name: worker1
       replicas: 7
       rootVolume:

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -22,7 +22,8 @@ data:
       instanceType: very-large
       name: worker1
       replicas: 7
-      rootVolumeSizeGB: 5
+      rootVolume:
+        sizeGB: 5
       serviceAccount:
         email: service-account@email
         scopes:

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -22,9 +22,10 @@ data:
       project: the-project
       region: the-region
     machineDeployments:
-      containerdVolume: {}
-    - failureDomain: failure-domain2-b
+    - containerdVolume: {}
+      failureDomain: failure-domain2-b
       instanceType: very-large
+      kubeletVolume: {}
       name: worker1
       replicas: 7
       rootVolume:

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -5,7 +5,11 @@ data:
     clusterDescription: just a test cluster
     clusterName: test1
     controlPlane:
+      containerdVolume: {}
+      etcdVolume: {}
+      kubeletVolume: {}
       replicas: 3
+      rootVolume: {}
       serviceAccount:
         email: service-account@email
         scopes:

--- a/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_gcp.golden
@@ -23,7 +23,9 @@ data:
       region: the-region
     machineDeployments:
     - failureDomain: failure-domain2-b
+      containerdVolume: {}
       instanceType: very-large
+      kubeletVolume: {}
       name: worker1
       replicas: 7
       rootVolume:


### PR DESCRIPTION
### What does this PR do?

In CAPG is possible to specify both the disk size and the disk type for various kind of volumes, specifically:  
- VM root volume
- Etcd data volume
- Kubelet volume
- Containerd volume

This PR changes the CAPG cluster struct to allow to set those properties for each volume for both:
- the control plane struct
- the machine deployment struct

This is then inline with the `cluster-gcp` repository app, helm chart values.yaml

### What is the effect of this change to users?

When a user generates a new template via:

```bash
kubectl-gs template cluster --provider gcp --gcp-project PROJECT_ID --region europe-west3 --gcp-failure-domains europe-west3-a --gcp-machine-deployment-failure-domain europe-west3-a --description "Test Cluster" --organization test --name dev01 --gcp-control-plane-sa-email SERVICE_ACCOUNT_EMAIL
```

then the generated template will have additional fields and slightly different structure for the volume property.  
Before it was not possible to specify the volume type, so the volume structure was flat and allowed only the size.  
Now the structure is in the form of:
```yaml
rootVolume:
  sizeGB: int
  diskType: string
```

So we expect the output of the CAPG cluster in this form:

```yaml
clusterDescription: Test Cluster
    clusterName: dev01
    controlPlane:
      containerdVolume: {}  # Added in this PR
      etcdVolume: {}  # Added in this PR
      kubeletVolume: {}  # Added in this PR
      replicas: 3
      rootVolume: {}  # Added in this PR
      serviceAccount:
        email: SERVICE_ACCOUNT_EMAIL
        scopes:
        - https://www.googleapis.com/auth/compute
    gcp:
      failureDomains:
      - europe-west3-a
      project: PROJECT_ID
      region: europe-west3
    machineDeployments:
    - containerdVolume: {}  # Added in this PR
      failureDomain: europe-west3-a
      instanceType: n1-standard-4
      kubeletVolume: {}  # Added in this PR
      name: worker0
      replicas: 3
      rootVolume:  # Added in this PR
        sizeGB: 100
      serviceAccount:
        email: default
        scopes:
        - https://www.googleapis.com/auth/compute
    organization: test
```

### What does it look like?

Here a more complete example:

```yaml
clusterDescription: Test Cluster
    clusterName: dev01
    controlPlane:
      containerdVolume:
        sizeGB: 100
        diskType: "pd-ssd"
      etcdVolume:
        sizeGB: 100
        diskType: "local-ssd"
      kubeletVolume:
          sizeGB: 100
          diskType: "pd-ssd"
      replicas: 3
      rootVolume:
        sizeGB: 100
        diskType: "pd-ssd"
      serviceAccount:
        email: SERVICE_ACCOUNT_EMAIL
        scopes:
        - https://www.googleapis.com/auth/compute
    gcp:
      failureDomains:
      - europe-west3-a
      project: PROJECT_ID
      region: europe-west3
    machineDeployments:
    - containerdVolume:
        sizeGB: 100
        diskType: "pd-ssd"
      failureDomain: europe-west3-a
      instanceType: n1-standard-4
      kubeletVolume:
        sizeGB: 100
        diskType: "pd-ssd"
      name: worker0
      replicas: 3
      rootVolume:
        sizeGB: 100
        diskType: "pd-ssd"        
      serviceAccount:
        email: default
        scopes:
        - https://www.googleapis.com/auth/compute
    organization: test
```

### Any background context you can provide?

Allow to set the disk size and disk type for various volumes.  
Etcd requires a different disk type for better performance

### What is needed from the reviewers?
Make sure I did not break anything!

### Do the docs need to be updated?
No changes were introduced in the CLI flag or behaviour

### Should this change be mentioned in the release notes?
Yes it should to notify the end users that is now possible to configure each volume individually.

- [x] CHANGELOG.md has been updated

### Is this a breaking change?
This is not a breaking change in `kubectl-gs`
