### PR TITLE
Add `kubeconfig-` prefix to `CertConfig`'s `ClusterComponent` field in login cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add `kubeconfig-` prefix to `CertConfig`'s `ClusterComponent` field in `login` command.
+
 ## [2.28.2] - 2022-11-16
 
 ## [2.28.1] - 2022-11-09

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -83,7 +83,7 @@ func generateClientCertUID() string {
 }
 
 func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error) {
-	clientCertUID := generateClientCertUID()
+	clientCertUID := fmt.Sprintf("kubeconfig-%s", generateClientCertUID())
 	clientCertName := fmt.Sprintf("%s-%s", config.clusterName, clientCertUID)
 	var clientCertCNPrefix string
 	{


### PR DESCRIPTION
### What does this PR do?

the `ClusterComponent` field of `CertConfig` CRs is used by cert-operator to calculate the name of the `vault` PKI `role` to be used for certificate generation.
Since kubectl-gs sets the `ClusterComponent` field as a random string, this lead to leaking of vault pki roles and performance issues.

This PR adds the `kubectl-` prefix to the `ClusterComponent` field value so in cert operator we can skip using this random field for vault role name calculation (see https://github.com/giantswarm/cert-operator/pull/531)

### What is the effect of this change to users?

none

### What does it look like?

no visual changes

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/24722

### What is needed from the reviewers?

Nothing special

### Do the docs need to be updated?

no

### Should this change be mentioned in the release notes?

Not really

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

no
