### PR TITLE
Revert "Add `kubeconfig-` prefix to `CertConfig`'s `ClusterComponent` field in login cmd"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Changed
-
-- Add `kubeconfig-` prefix to `CertConfig`'s `ClusterComponent` field in `login` command.
-
 ## [2.28.2] - 2022-11-16
 
 ## [2.28.1] - 2022-11-09

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -83,7 +83,7 @@ func generateClientCertUID() string {
 }
 
 func generateClientCert(config clientCertConfig) (*clientcert.ClientCert, error) {
-	clientCertUID := fmt.Sprintf("kubeconfig-%s", generateClientCertUID())
+	clientCertUID := generateClientCertUID()
 	clientCertName := fmt.Sprintf("%s-%s", config.clusterName, clientCertUID)
 	var clientCertCNPrefix string
 	{


### PR DESCRIPTION
Reverts giantswarm/kubectl-gs#957

this changed introduced a potentially problematic breaking change for customers, reverting