### PR TITLE
When creating `CertConfig` during `login` use special version `0.0.0` to make dedicated `cert-operator` instance reconcile them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- When creating `CertConfig` during `login` use special version `0.0.0` to make dedicated `cert-operator` instance reconcile them.
+
 ## [2.28.2] - 2022-11-16
 
 ## [2.28.1] - 2022-11-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- When creating `CertConfig` during `login` use special version `0.0.0` to make dedicated `cert-operator` instance reconcile them.
+- Ensure dedicated `cert-operator` version `0.0.0` is used for client certificate creation in `login` command to avoid timeouts.
 
 ## [2.28.2] - 2022-11-16
 

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -558,37 +558,6 @@ func findCluster(ctx context.Context, clusterService cluster.Interface, organiza
 	}
 }
 
-func getClusterReleaseVersion(c *cluster.Cluster, provider string) (string, error) {
-	if c.Cluster.Labels == nil {
-		return "", microerror.Maskf(invalidReleaseVersionError, "The workload cluster %s does not have a release version label.", name)
-	}
-
-	releaseVersion := c.Cluster.Labels[label.ReleaseVersion]
-	if len(releaseVersion) < 1 {
-		return "", microerror.Maskf(invalidReleaseVersionError, "The workload cluster %s has an invalid release version.", name)
-	}
-
-	return releaseVersion, nil
-}
-
-func getCertOperatorVersion(ctx context.Context, releaseService release.Interface, name string) (string, error) {
-	resource, err := releaseService.Get(ctx, release.GetOptions{Name: fmt.Sprintf("v%s", name)})
-	if release.IsNotFound(err) {
-		return "", microerror.Maskf(releaseNotFoundError, "Release v%s could not be found.", name)
-	} else if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	components := resource.(*release.Release).CR.Spec.Components
-	for _, component := range components {
-		if component.Name == "cert-operator" {
-			return component.Version, nil
-		}
-	}
-
-	return "", microerror.Maskf(missingComponentError, "The release v%s does not include the required 'cert-operator' component.", name)
-}
-
 func validateProvider(provider string) error {
 	if provider == key.ProviderKVM {
 		return microerror.Maskf(unsupportedProviderError, "Creating a client certificate for a workload cluster is not supported on provider %s.", provider)

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -110,19 +110,7 @@ func (r *runner) getCertOperatorVersion(c *cluster.Cluster, provider string, ser
 		return "", nil
 	}
 
-	releaseVersion, err := getClusterReleaseVersion(c, provider)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-	certOperatorVersion, err := getCertOperatorVersion(ctx, services.releaseService, releaseVersion)
-	// If the release does not contain cert-operator anymore (e.g. in CAPI versions) we return an empty string
-	// In this case we try to create the client certificate using the MC PKI
-	if IsMissingComponent(err) {
-		return "", nil
-	} else if err != nil {
-		return "", microerror.Mask(err)
-	}
-	return certOperatorVersion, nil
+	return key.CertOperatorVersionKubeconfig, nil
 }
 
 func (r *runner) handleWCClientCert(ctx context.Context) error {

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -35,9 +35,10 @@ const (
 )
 
 const (
-	RoleLabel           = "role"
-	SSHSSOPubKeyLabel   = "ssh-sso-public-key"
-	GiantswarmNamespace = "giantswarm"
+	RoleLabel                     = "role"
+	SSHSSOPubKeyLabel             = "ssh-sso-public-key"
+	GiantswarmNamespace           = "giantswarm"
+	CertOperatorVersionKubeconfig = "0.0.0"
 )
 
 const (


### PR DESCRIPTION
### What does this PR do?

`cert-operator` is now running as a unique app as well as a release app.
The unique instance reconciles only `certconfig` CRs that have `cert-operator.giantswarm.io/version=0.0.0`.

This PR makes `kubectl-gs login` use `cert-operator.giantswarm.io/version=0.0.0` for legacy cert configs.
This way we have a dedicated cert-operator instance just for kubeconfigs and we can avoid timeouts.

### What is the effect of this change to users?

### What does it look like?

no customer-facing change

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/24722#issuecomment-1325153824
https://github.com/giantswarm/giantswarm/issues/24669

### What is needed from the reviewers?

nothing special

### Do the docs need to be updated?

nope

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No customer facing change AFAIK.
