### PR TITLE
Fix `update cluster` command when scheduling an upgrade for a Cluster when the Cluster CR had no previous annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `update cluster` command when scheduling an upgrade for a Cluster when the Cluster CR had no previous annotations.
+
 ## [2.29.0] - 2022-11-24
 
 - Ensure dedicated `cert-operator` version `0.0.0` is used for client certificate creation in `login` command to avoid timeouts.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that prevented to schedule a cluster upgrade using `update cluster` when the Cluster CR had no `annotations` set.

### What is the effect of this change to users?

Makes it possible to schedule a cluster upgrade using `update cluster` when the Cluster CR has no `annotations` set.

### What does it look like?

No UX changes

### Any background context you can provide?

https://github.com/giantswarm/vodafone/issues/590

### What is needed from the reviewers?

N/A

### Do the docs need to be updated?

N/A

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Nope
