### PR TITLE
Respect `--control-plane-instance-type` for AWS cluster templating instead of using default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect `--control-plane-instance-type` for AWS cluster templating. Previously, the default value `m5.xlarge` was always used.
+
 ## [2.29.3] - 2022-12-08
 
 ### Fixed

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -29,14 +29,15 @@ func WriteGSAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.
 	crsConfig := aws.ClusterCRsConfig{
 		ClusterName: config.Name,
 
-		ExternalSNAT:    config.AWS.ExternalSNAT,
-		ControlPlaneAZ:  config.ControlPlaneAZ,
-		Description:     config.Description,
-		PodsCIDR:        config.PodsCIDR,
-		Owner:           config.Organization,
-		ReleaseVersion:  config.ReleaseVersion,
-		Labels:          config.Labels,
-		ServicePriority: config.ServicePriority,
+		ExternalSNAT:             config.AWS.ExternalSNAT,
+		ControlPlaneAZ:           config.ControlPlaneAZ,
+		ControlPlaneInstanceType: config.ControlPlaneInstanceType,
+		Description:              config.Description,
+		PodsCIDR:                 config.PodsCIDR,
+		Owner:                    config.Organization,
+		ReleaseVersion:           config.ReleaseVersion,
+		Labels:                   config.Labels,
+		ServicePriority:          config.ServicePriority,
 	}
 
 	crsConfig.ReleaseComponents, err = key.GetReleaseComponents(ctx, client.CtrlClient(), config.ReleaseVersion)

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -13,31 +13,32 @@ import (
 )
 
 const (
-	defaultMasterInstanceType = "m5.xlarge"
-	kindAWSCluster            = "AWSCluster"
-	kindAWSControlPlane       = "AWSControlPlane"
-	kindG8sControlPlane       = "G8sControlPlane"
+	defaultControlPlaneInstanceType = "m5.xlarge"
+	kindAWSCluster                  = "AWSCluster"
+	kindAWSControlPlane             = "AWSControlPlane"
+	kindG8sControlPlane             = "G8sControlPlane"
 )
 
 // +k8s:deepcopy-gen=false
 
 type ClusterCRsConfig struct {
-	ClusterName       string
-	ControlPlaneName  string
-	Credential        string
-	Domain            string
-	EnableLongNames   bool
-	ExternalSNAT      bool
-	ControlPlaneAZ    []string
-	Description       string
-	PodsCIDR          string
-	Owner             string
-	Region            string
-	ReleaseComponents map[string]string
-	ReleaseVersion    string
-	Labels            map[string]string
-	NetworkPool       string
-	ServicePriority   string
+	ClusterName              string
+	ControlPlaneName         string
+	Credential               string
+	Domain                   string
+	EnableLongNames          bool
+	ExternalSNAT             bool
+	ControlPlaneAZ           []string
+	ControlPlaneInstanceType string
+	Description              string
+	PodsCIDR                 string
+	Owner                    string
+	Region                   string
+	ReleaseComponents        map[string]string
+	ReleaseVersion           string
+	Labels                   map[string]string
+	NetworkPool              string
+	ServicePriority          string
 }
 
 // +k8s:deepcopy-gen=false
@@ -69,6 +70,10 @@ func NewClusterCRs(config ClusterCRsConfig) (ClusterCRs, error) {
 			}
 
 			config.ControlPlaneName = generatedName
+		}
+
+		if config.ControlPlaneInstanceType == "" {
+			config.ControlPlaneInstanceType = defaultControlPlaneInstanceType
 		}
 	}
 
@@ -136,7 +141,7 @@ func newAWSClusterCR(c ClusterCRsConfig) *v1alpha3.AWSCluster {
 	if len(c.ControlPlaneAZ) == 1 {
 		awsClusterCR.Spec.Provider.Master = v1alpha3.AWSClusterSpecProviderMaster{
 			AvailabilityZone: c.ControlPlaneAZ[0],
-			InstanceType:     defaultMasterInstanceType,
+			InstanceType:     c.ControlPlaneInstanceType,
 		}
 	}
 
@@ -166,7 +171,7 @@ func newAWSControlPlaneCR(c ClusterCRsConfig) *v1alpha3.AWSControlPlane {
 		},
 		Spec: v1alpha3.AWSControlPlaneSpec{
 			AvailabilityZones: c.ControlPlaneAZ,
-			InstanceType:      defaultMasterInstanceType,
+			InstanceType:      c.ControlPlaneInstanceType,
 		},
 	}
 }

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -107,16 +107,17 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 
 func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 	config := provider.ClusterConfig{
-		ControlPlaneAZ:    r.flag.ControlPlaneAZ,
-		Description:       r.flag.Description,
-		KubernetesVersion: r.flag.KubernetesVersion,
-		Name:              r.flag.Name,
-		Organization:      r.flag.Organization,
-		PodsCIDR:          r.flag.PodsCIDR,
-		ReleaseVersion:    r.flag.Release,
-		Namespace:         metav1.NamespaceDefault,
-		Region:            r.flag.Region,
-		ServicePriority:   r.flag.ServicePriority,
+		ControlPlaneAZ:           r.flag.ControlPlaneAZ,
+		ControlPlaneInstanceType: r.flag.ControlPlaneInstanceType,
+		Description:              r.flag.Description,
+		KubernetesVersion:        r.flag.KubernetesVersion,
+		Name:                     r.flag.Name,
+		Organization:             r.flag.Organization,
+		PodsCIDR:                 r.flag.PodsCIDR,
+		ReleaseVersion:           r.flag.Release,
+		Namespace:                metav1.NamespaceDefault,
+		Region:                   r.flag.Region,
+		ServicePriority:          r.flag.ServicePriority,
 
 		App:       r.flag.App,
 		AWS:       r.flag.AWS,

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -74,11 +74,12 @@ func Test_run(t *testing.T) {
 		{
 			name: "case 1: template cluster capa",
 			flags: &flag{
-				Name:         "test1",
-				Provider:     "capa",
-				Description:  "just a test cluster",
-				Region:       "the-region",
-				Organization: "test",
+				Name:                     "test1",
+				Provider:                 "capa",
+				Description:              "just a test cluster",
+				Region:                   "the-region",
+				Organization:             "test",
+				ControlPlaneInstanceType: "control-plane-instance-type",
 				App: provider.AppConfig{
 					ClusterVersion:     "1.0.0",
 					ClusterCatalog:     "the-catalog",
@@ -153,7 +154,7 @@ func Test_run(t *testing.T) {
 
 			diff := cmp.Diff(string(expectedResult), out.String())
 			if diff != "" {
-				t.Fatalf("value not expected, got:\n %s", diff)
+				t.Fatalf("no difference from golden file %s expected, got:\n %s", tc.expectedGoldenFile, diff)
 			}
 		})
 	}

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -9,6 +9,7 @@ data:
     clusterDescription: just a test cluster
     clusterName: test1
     controlPlane:
+      instanceType: control-plane-instance-type
       replicas: 3
     machinePools:
     - availabilityZones:


### PR DESCRIPTION
### What does this PR do?

Fix passing on this flag so it ends up in the manifest. Previously, the flag was ignored in favor of the default `m5.xlarge`.

### What is the effect of this change to users?

The flag `--control-plane-instance-type` becomes effective for AWS cluster templating.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

I'll let you decide to add the label or not. I believe it can be surprising if someone used the flag and thought it was effective.