### PR TITLE
Removed domain restriction from API URL validation in login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed logging in to clusters running on custom domains by removing domain restriction from API URL validation
+
 ## [2.29.2] - 2022-12-02
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,7 @@ require (
 )
 
 replace (
-	github.com/containerd/containerd => github.com/containerd/containerd v1.6.10 // [CVE-2022-31030]
+	github.com/containerd/containerd => github.com/containerd/containerd v1.6.12 // [CVE-2022-31030, CVE-2022-23471]
 	github.com/coreos/etcd => go.etcd.io/etcd/client/v3 v3.5.6
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.8.0+incompatible

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -42,7 +42,7 @@ func GetUrlType(u string) int {
 
 func isK8sApiUrl(u string) bool {
 	u = strings.SplitN(u, ":", 2)[0]
-	return k8sApiURLRegexp.MatchString(u) || (strings.HasPrefix(u, "api.") && strings.HasSuffix(u, ".gigantic.io"))
+	return k8sApiURLRegexp.MatchString(u) || strings.HasPrefix(u, "api.")
 }
 
 func isWcK8sApiUrl(u string) bool {

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -72,6 +72,12 @@ func Test_GetBasePath(t *testing.T) {
 			expectedResult:         "abc12def34.k8s.installation.customer.gigantic.io",
 			expectedInternalResult: "internal-api.abc12def34.k8s.installation.customer.gigantic.io",
 		},
+		{
+			name:                   "case 7: mc k8s api custom domain",
+			url:                    "https://api.installation.xx-xxxx-x.aaa.bbb.ccc.tld",
+			expectedResult:         "installation.xx-xxxx-x.aaa.bbb.ccc.tld",
+			expectedInternalResult: "internal-installation.xx-xxxx-x.aaa.bbb.ccc.tld",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What does this PR do?

It removes domain restriction from API URL validation in the `login` command. Other restrictions on the API URLs remain unchanged.

### What is the effect of this change to users?

Users will be able to use kubectl-gs to log in to clusters with APIs running on custom domains.

### What does it look like?

No visible impact, login process works the same as before.

### Any background context you can provide?

Fixes issue [#1763](https://github.com/giantswarm/roadmap/issues/1763)

### What is needed from the reviewers?

The change can be tested by logging in to clusters with Kubernetes APIs running on different domains (while maintaining the usual format) and verifying that the login process works.

### Do the docs need to be updated?

The change does not modify the behaviour of kubectl-gs, so docs do not need to be updated

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Not a breaking change
