### PR TITLE
Multiple Dex connectors in login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,31 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [2.30.0] - 2023-01-12
 
+### Changed
+
+- Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
+
+### Added
+
+- Introduced a new `--connector-id` flag in the `login` command to specify a Dex connector to use and skip the selection step
+
 ### Added
 
 - Add flags `--cluster-type`, `--https-proxy`, `--http-proxy`, `--no-proxy`, `--api-mode`, `--dns-mode`, `--vpc-mode` and `--topol
 - ogy-mode` to `template cluster` that specify `capa` as provider.
-- Add `gitops add base` command to generate CAP[A,G,O] bases. The values for `--provider` flag is compatible with the `template cluster` command (A: capa, G: gcp, O: openstack). 
+- Add `gitops add base` command to generate CAP[A,G,O] bases. The values for `--provider` flag is compatible with the `template cluster` command (A: capa, G: gcp, O: openstack).
 
 ## [2.29.5] - 2022-12-20
 
 ### Changed
 
-- Extended detection of providers in the login command to take the provider value primarily from Athena with fallback to the original way of inspecting the API URL 
+- Extended detection of providers in the login command to take the provider value primarily from Athena with fallback to the original way of inspecting the API URL
 
 ## [2.29.4] - 2022-12-15
 
 ### Fixed
 
 - Respect `--control-plane-instance-type` for AWS cluster templating. Previously, the default value `m5.xlarge` was always used.
-
-### Changed
-
-- Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
-- Introduced a new flag `--connector-id` in the `login` command to specify a Dex connector to use and skip the selection step 
 
 ## [2.29.3] - 2022-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Respect `--control-plane-instance-type` for AWS cluster templating. Previously, the default value `m5.xlarge` was always used.
 
+### Changed
+
+- Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
+- Introduced a new flag `--connector-id` in the `login` command to specify a Dex connector to use and skip the selection step 
+
 ## [2.29.3] - 2022-12-08
 
 ### Fixed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -21,6 +21,8 @@ const (
 	flagWCCertTTL           = "certificate-ttl"
 	flagSelfContained       = "self-contained"
 	flagWCInsecureNamespace = "insecure-namespace"
+
+	flagConnectorID = "connector-id"
 )
 
 type flag struct {
@@ -36,6 +38,8 @@ type flag struct {
 	WCCertTTL           string
 	SelfContained       string
 	WCInsecureNamespace bool
+
+	ConnectorID string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -51,6 +55,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCCertTTL, flagWCCertTTL, "1h", fmt.Sprintf(`For client certificate creation. How long the client certificate should live for. Valid time units are "ms", "s", "m", "h". Requires --%s.`, flagWCName))
 	cmd.Flags().StringVar(&f.WCCertCNPrefix, flagWCCertCNPrefix, "", fmt.Sprintf(`For client certificate creation. Prefix for the name encoded in the X.509 field "CN". Requires --%s.`, flagWCName))
 	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
+
+	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Identifier of a specific Dex connector to be used for authentication. The connector is selected during the oids authentication process by default. If this flag is specified, the selection step is skipped.")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -56,7 +56,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCCertCNPrefix, flagWCCertCNPrefix, "", fmt.Sprintf(`For client certificate creation. Prefix for the name encoded in the X.509 field "CN". Requires --%s.`, flagWCName))
 	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
-	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Identifier of a specific Dex connector to be used for authentication. The connector is selected during the oidc authentication process by default. If this flag is specified, the selection step is skipped.")
+	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Dex connector to use for authentication. This allows to skip the selection page.")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -56,7 +56,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCCertCNPrefix, flagWCCertCNPrefix, "", fmt.Sprintf(`For client certificate creation. Prefix for the name encoded in the X.509 field "CN". Requires --%s.`, flagWCName))
 	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
-	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Identifier of a specific Dex connector to be used for authentication. The connector is selected during the oids authentication process by default. If this flag is specified, the selection step is skipped.")
+	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Identifier of a specific Dex connector to be used for authentication. The connector is selected during the oidc authentication process by default. If this flag is specified, the selection step is skipped.")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -137,7 +137,8 @@ func (r *runner) loginWithInstallation(ctx context.Context, tokenOverride string
 				token:    tokenOverride,
 			}
 		} else {
-			authResult, err = handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ClusterAdmin, r.flag.CallbackServerPort)
+
+			authResult, err = handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ConnectorID, r.flag.ClusterAdmin, r.flag.CallbackServerPort)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -81,6 +81,18 @@ func (a *Authenticator) GetAuthURL(connectorID string) string {
 	return authURLWithConnectorID
 }
 
+func (a *Authenticator) GetAuthSelectionURL(connectorType string) string {
+	authURL := a.clientConfig.AuthCodeURL(a.challenge, oauth2.AccessTypeOffline)
+
+	// connector_type is specific to GS. It is resolved in the custom Dex frontend.
+	// It allows user filter the available connectors and only display the relevant ones
+	if connectorType != "" {
+		return fmt.Sprintf("%s&connector_filter=%s", authURL, connectorType)
+	}
+
+	return authURL
+}
+
 func (a *Authenticator) RenewToken(ctx context.Context, refreshToken string) (idToken string, rToken string, err error) {
 	s := a.clientConfig.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken})
 	t, err := s.Token()


### PR DESCRIPTION
### What does this PR do?

Adds support to select a specific Dex from a list when running `kubectl-gs login` command
Introduces a new `--connector-id` flag, which allows the user to specify the preferred connector. When provided, the user is not prompted to select a connector from a list.

### What is the effect of this change to users?

Selection of the Dex connector is an extra step in the login process. It can be overridden by specifying the new `--connector-id` flag.

The extra step and/or the flag are only needed during the first login. Maintenance of existing logins (i.e. rotation of ID and Refresh tokens) remains unchanged.

### What does it look like?

Unless the `login` command is executed with the `--connector-id` flag, Dex opens a page, which prompts the user to select a preferred connector. After that the login process continues without any additional changes.

`kubectl gs login installation-name --connector-id dex-connector-identifier`

### Any background context you can provide?

Works towards [#1592](https://github.com/giantswarm/roadmap/issues/1592)

### What is needed from the reviewers?

The changes can be tested by executing the `login` command with different inputs (new login, connector id flag, existing login) and verifying that the login process runs as expected and succeeds.

### Do the docs need to be updated?

The new flag definitely needs to be documented.
And maybe the extra connector selection step can be documented somewhere as well.

### Should this change be mentioned in the release notes?

Yes

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Debatable
