### PR TITLE
Rewrite the kubectl gs URL with new slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ kubectl krew install gs
 kubectl gs
 ```
 
-Check the [installation docs](https://docs.giantswarm.io/ui-api/kubectl-gs/installation/) for details on installation with and without Krew.
+Check the [installation docs](https://docs.giantswarm.io/use-the-api/kubectl-gs/installation/) for details on installation with and without Krew.
 
 ## Features
 
@@ -25,7 +25,7 @@ Check the [installation docs](https://docs.giantswarm.io/ui-api/kubectl-gs/insta
 
 ## Documentation
 
-Find the [kubectl gs reference](https://docs.giantswarm.io/ui-api/kubectl-gs/) in our documentation site.
+Find the [kubectl gs reference](https://docs.giantswarm.io/use-the-api/kubectl-gs/) in our documentation site.
 
 ## Publishing a release
 

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -96,7 +96,7 @@ func (r *runner) printOutput(orgResource organization.Resource) error {
 func (r *runner) printNoResourcesOutput() {
 	fmt.Fprintf(r.stdout, "No organizations found.\n")
 	fmt.Fprintf(r.stdout, "No resources of type organizations.security.giantswarm.io available. To create one, please check\n\n")
-	fmt.Fprintf(r.stdout, "  https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/\n")
+	fmt.Fprintf(r.stdout, "  https://docs.giantswarm.io/use-the-api/management-api/crd/organizations.security.giantswarm.io/\n")
 }
 
 func getTableRow(org organization.Organization) metav1.TableRow {

--- a/cmd/get/orgs/testdata/run_get_orgs_empty.golden
+++ b/cmd/get/orgs/testdata/run_get_orgs_empty.golden
@@ -1,4 +1,4 @@
 No organizations found.
 No resources of type organizations.security.giantswarm.io available. To create one, please check
 
-  https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/
+  https://docs.giantswarm.io/use-the-api/management-api/crd/organizations.security.giantswarm.io/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ const (
 	name        = "kubectl\u00a0gs"
 	description = `Your user-friendly kubectl plug-in for the Giant Swarm management cluster.
 
-Get more information at https://docs.giantswarm.io/ui-api/kubectl-gs/
+Get more information at https://docs.giantswarm.io/use-the-api/kubectl-gs/
 `
 )
 

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -102,7 +102,7 @@ func newAWSClusterCR(c ClusterCRsConfig) *v1alpha3.AWSCluster {
 			Name:      c.ClusterName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awsclusters.infrastructure.giantswarm.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/awsclusters.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
 				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
@@ -158,7 +158,7 @@ func newAWSControlPlaneCR(c ClusterCRsConfig) *v1alpha3.AWSControlPlane {
 			Name:      c.ControlPlaneName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/awscontrolplanes.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
 				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
@@ -209,7 +209,7 @@ func newClusterCR(obj *v1alpha3.AWSCluster, c ClusterCRsConfig) *capi.Cluster {
 			Name:      c.ClusterName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/clusters.cluster.x-k8s.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/clusters.cluster.x-k8s.io/",
 			},
 			Labels: clusterLabels,
 		},
@@ -240,7 +240,7 @@ func newG8sControlPlaneCR(obj *v1alpha3.AWSControlPlane, c ClusterCRsConfig) *v1
 			Name:      c.ControlPlaneName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/g8scontrolplanes.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
 				label.ClusterOperatorVersion: c.ReleaseComponents["cluster-operator"],

--- a/cmd/template/cluster/util/networkpool.go
+++ b/cmd/template/cluster/util/networkpool.go
@@ -50,7 +50,7 @@ func newNetworkPoolCR(c NetworkPoolCRsConfig) *v1alpha3.NetworkPool {
 			Name:      c.NetworkPoolID,
 			Namespace: c.Namespace,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/networkpools.infrastructure.giantswarm.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/networkpools.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
 				label.Organization: c.Owner,

--- a/cmd/template/nodepool/provider/templates/aws/nodepool.go
+++ b/cmd/template/nodepool/provider/templates/aws/nodepool.go
@@ -85,7 +85,7 @@ func newAWSMachineDeploymentCR(c NodePoolCRsConfig) *v1alpha3.AWSMachineDeployme
 			Name:      c.MachineDeploymentName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/awsmachinedeployments.infrastructure.giantswarm.io/",
 			},
 			Labels: map[string]string{
 				label.AWSOperatorVersion: c.ReleaseComponents["aws-operator"],
@@ -133,7 +133,7 @@ func newMachineDeploymentCR(obj *v1alpha3.AWSMachineDeployment, c NodePoolCRsCon
 			Name:      c.MachineDeploymentName,
 			Namespace: metav1.NamespaceDefault,
 			Annotations: map[string]string{
-				annotation.Docs: "https://docs.giantswarm.io/ui-api/management-api/crd/machinedeployments.cluster.x-k8s.io/",
+				annotation.Docs: "https://docs.giantswarm.io/use-the-api/management-api/crd/machinedeployments.cluster.x-k8s.io/",
 			},
 			Labels: map[string]string{
 				label.Cluster:                c.ClusterName,


### PR DESCRIPTION
### What does this PR do?

Rewrite Kubectl-gs reference page in docs and annotiations after a change performed in our official docs

(Please set a descriptive PR title. Use this space for additional explanations.)

### What is the effect of this change to users?

Nothing, they are pointed to correct URL

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Towards [this internal ticket](https://github.com/giantswarm/giantswarm/issues/20188) that explain how new Docs structure will be
(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

Check URL is fine

### Do the docs need to be updated?

yes

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
