### PR TITLE
Provider resolution improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Extended detection of providers in the login command to take the provider value primarily from Athena with fallback to the original way of inspecting the API URL 
+
 ## [2.29.4] - 2022-12-15
 
 ### Fixed

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProvider()
+			r.provider, err = r.commonConfig.GetProviderFromConfig()
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/get/nodepools/runner.go
+++ b/cmd/get/nodepools/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProvider()
+			r.provider, err = r.commonConfig.GetProviderFromConfig()
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/get/releases/runner.go
+++ b/cmd/get/releases/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProvider()
+			r.provider, err = r.commonConfig.GetProviderFromConfig()
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -82,7 +82,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 // loginWithURL performs the OIDC login into an installation's
 // k8s api with a happa/k8s api URL.
 func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool, tokenOverride string) error {
-	i, err := installation.New(ctx, path)
+	i, err := installation.New(ctx, path, "")
 	if installation.IsUnknownUrlType(err) {
 		return microerror.Maskf(unknownUrlError, "'%s' is not a valid Giant Swarm Management API URL. Please check the spelling.\nIf not sure, pass the web UI URL of the installation or the installation handle as an argument instead.", path)
 	} else if err != nil {

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -114,8 +114,7 @@ func (r *runner) getCertOperatorVersion(c *cluster.Cluster, provider string, ser
 }
 
 func (r *runner) handleWCClientCert(ctx context.Context) error {
-
-	provider, err := r.commonConfig.GetProvider()
+	provider, err := r.commonConfig.GetProviderFromInstallation(ctx, "", true)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/commonconfig/commonconfig.go
+++ b/pkg/commonconfig/commonconfig.go
@@ -1,8 +1,11 @@
 package commonconfig
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+
+	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -34,28 +37,47 @@ func (cc *CommonConfig) GetConfigFlags() genericclioptions.RESTClientGetter {
 	return *cc.ConfigFlags
 }
 
-func (cc *CommonConfig) GetProvider() (string, error) {
+func (cc *CommonConfig) GetProviderFromConfig() (string, error) {
+	config, err := cc.GetConfigFlags().ToRESTConfig()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	return cc.extractProviderFromUrl(config.Host), nil
+}
+
+func (cc *CommonConfig) GetProviderFromInstallation(ctx context.Context, athenaUrl string, fallbackToConfig bool) (string, error) {
 	config, err := cc.GetConfigFlags().ToRESTConfig()
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
 
+	i, err := installation.New(ctx, config.Host, athenaUrl)
+	if err == nil {
+		return i.Provider, nil
+	}
+	if fallbackToConfig {
+		return cc.extractProviderFromUrl(config.Host), nil
+	}
+	return "", microerror.Mask(err)
+}
+
+func (cc *CommonConfig) extractProviderFromUrl(url string) string {
 	awsRegexp := regexp.MustCompile(fmt.Sprintf(providerRegexpPattern, key.ProviderAWS))
 	azureRegexp := regexp.MustCompile(fmt.Sprintf(providerRegexpPattern, key.ProviderAzure))
 
 	var provider string
 	switch {
-	case awsRegexp.MatchString(config.Host):
+	case awsRegexp.MatchString(url):
 		provider = key.ProviderAWS
 
-	case azureRegexp.MatchString(config.Host):
+	case azureRegexp.MatchString(url):
 		provider = key.ProviderAzure
 
 	default:
 		provider = key.ProviderOpenStack
 	}
 
-	return provider, nil
+	return provider
 }
 
 func (cc *CommonConfig) GetClient(logger micrologger.Logger) (k8sclient.Interface, error) {

--- a/pkg/commonconfig/commonconfig.go
+++ b/pkg/commonconfig/commonconfig.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
 )
 

--- a/pkg/commonconfig/commonconfig_test.go
+++ b/pkg/commonconfig/commonconfig_test.go
@@ -1,6 +1,10 @@
 package commonconfig
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -8,7 +12,7 @@ import (
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 )
 
-func TestCommonConfig_GetProvider(t *testing.T) {
+func TestCommonConfig_GetProviderFromConfig(t *testing.T) {
 	testCases := []struct {
 		name           string
 		k8sApiURL      string
@@ -47,7 +51,7 @@ func TestCommonConfig_GetProvider(t *testing.T) {
 			*cflags.APIServer = tc.k8sApiURL
 
 			cc := New(cflags)
-			result, err := cc.GetProvider()
+			result, err := cc.GetProviderFromConfig()
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
@@ -57,4 +61,82 @@ func TestCommonConfig_GetProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommonConfig_GetProviderFromInstallation(t *testing.T) {
+	testCases := []struct {
+		name             string
+		k8sApiURL        string
+		resolvedProvider string
+		expectedResult   string
+		expectedError    bool
+		fallbackToConfig bool
+	}{
+		{
+			name:             "case 0: AWS URL resolved as Capa",
+			k8sApiURL:        "https://g8s.test.eu-west-1.aws.coolio.com",
+			resolvedProvider: key.ProviderCAPA,
+			expectedResult:   key.ProviderCAPA,
+		},
+		{
+			name:             "case 1: Unknown URL resolved as Azure",
+			k8sApiURL:        "https://api.azure12.customer.coolio.com",
+			resolvedProvider: key.ProviderAzure,
+			expectedResult:   key.ProviderAzure,
+		},
+		{
+			name:          "case 2: Azure URL resolved with no fallback as error",
+			k8sApiURL:     "https://g8s.test.eu-west-1.azure.coolio.com",
+			expectedError: true,
+		},
+		{
+			name:             "case 3: Azure URL resolved to error with fallback",
+			k8sApiURL:        "https://g8s.test.eu-west-1.azure.coolio.com",
+			fallbackToConfig: true,
+			expectedResult:   key.ProviderAzure,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hf := func(w http.ResponseWriter, r *http.Request) {
+				body := graphqlResponseBody(tc.resolvedProvider)
+				if len(body) == 0 {
+					w.WriteHeader(404)
+				} else {
+					w.WriteHeader(200)
+					w.Header().Set("Content-Type", "application/json")
+				}
+				_, _ = w.Write(graphqlResponseBody(tc.resolvedProvider))
+			}
+			mockAthenaServer := httptest.NewServer(http.HandlerFunc(hf))
+			defer mockAthenaServer.Close()
+
+			cflags := genericclioptions.NewConfigFlags(false)
+			*cflags.APIServer = tc.k8sApiURL
+
+			ctx := context.TODO()
+
+			cc := New(cflags)
+			result, err := cc.GetProviderFromInstallation(ctx, mockAthenaServer.URL, tc.fallbackToConfig)
+
+			if err != nil && !tc.expectedError {
+				t.Fatal(err)
+			}
+			if tc.expectedError && err == nil {
+				t.Fatal("Expected error, received success")
+			}
+			if tc.expectedResult != result {
+				t.Fatalf("Incorrect provider: expected %s, received %s", tc.expectedResult, result)
+			}
+
+		})
+	}
+}
+
+func graphqlResponseBody(provider string) []byte {
+	if provider == "" {
+		return []byte{}
+	}
+	return []byte(fmt.Sprintf(`{"data":{"identity":{"provider":"%s","codename":"codename"}}}`, provider))
 }

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -48,7 +48,7 @@ func (s *Service) getByName(ctx context.Context, provider, name, namespace strin
 				return nil, microerror.Mask(err)
 			}
 
-		case key.ProviderOpenStack:
+		case key.ProviderOpenStack, key.ProviderCAPA, key.ProviderKVM, key.ProviderVSphere:
 			cluster, err = s.getByNameOpenStack(ctx, name, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -24,7 +24,7 @@ type Installation struct {
 	CACert            string
 }
 
-func New(ctx context.Context, fromUrl string) (*Installation, error) {
+func New(ctx context.Context, fromUrl string, athenaUrl string) (*Installation, error) {
 	basePath, internalApiPath, err := GetBaseAndInternalPath(fromUrl)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -35,7 +35,9 @@ func New(ctx context.Context, fromUrl string) (*Installation, error) {
 		httpClient := http.DefaultClient
 		httpClient.Timeout = requestTimeout
 
-		athenaUrl := getAthenaUrl(basePath)
+		if athenaUrl == "" {
+			athenaUrl = getAthenaUrl(basePath)
+		}
 		config := graphql.ClientImplConfig{
 			HttpClient: httpClient,
 			Url:        fmt.Sprintf("%s/graphql", athenaUrl),


### PR DESCRIPTION
### What does this PR do?

It improves detection of providers in kubectl-gs login command. The providers are extracted from Kubernetes API URLs. This PR adds a new method and takes the providers from Athena responses. The original detection is kept as a fallback.

### What is the effect of this change to users?

No visible impact on users

### What does it look like?

No visible changes

### Any background context you can provide?

It is needed to handle a case when e.g. a CAPI URL would be resolved as vintage AWS because of its format.

### What is needed from the reviewers?

Log in to workload clusters in installations of different providers and check that it works

### Do the docs need to be updated?

No need to update docs

### Should this change be mentioned in the release notes?

Debatable

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
