### PR TITLE
Add `gitops add base` command

### DIFF
--- a/cmd/gitops/add/base/command.go
+++ b/cmd/gitops/add/base/command.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"io"
+	"os"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+const (
+	name = "base"
+
+	shortDescription = "Adds a new base to your GitOps directory structure"
+	longDescription  = `Adds a new base to your GitOps directory structure.
+
+...
+`
+
+	examples = ``
+)
+
+type Config struct {
+	Logger     micrologger.Logger
+	FileSystem afero.Fs
+
+	Stderr io.Writer
+	Stdout io.Writer
+}
+
+func New(config Config) (*cobra.Command, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.FileSystem == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.FileSystem must not be empty", config)
+	}
+	if config.Stderr == nil {
+		config.Stderr = os.Stderr
+	}
+	if config.Stdout == nil {
+		config.Stdout = os.Stdout
+	}
+
+	f := &flag{}
+
+	r := &runner{
+		flag:   f,
+		logger: config.Logger,
+		stderr: config.Stderr,
+		stdout: config.Stdout,
+	}
+
+	c := &cobra.Command{
+		Use:     name,
+		Short:   shortDescription,
+		Long:    longDescription,
+		Example: examples,
+		RunE:    r.Run,
+	}
+
+	f.Init(c)
+
+	return c, nil
+}

--- a/cmd/gitops/add/base/error.go
+++ b/cmd/gitops/add/base/error.go
@@ -1,0 +1,21 @@
+package app
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+//// IsInvalidConfig asserts invalidConfigError.
+//func IsInvalidConfig(err error) bool {
+//	return microerror.Cause(err) == invalidConfigError
+//}
+
+//var invalidFlagsError = &microerror.Error{
+//	Kind: "invalidFlagsError",
+//}
+//
+//// IsInvalidFlags asserts invalidFlagsError.
+//func IsInvalidFlags(err error) bool {
+//	return microerror.Cause(err) == invalidFlagsError
+//}

--- a/cmd/gitops/add/base/flag.go
+++ b/cmd/gitops/add/base/flag.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"github.com/spf13/cobra"
+)
+
+//const ()
+
+type flag struct {
+}
+
+func (f *flag) Init(cmd *cobra.Command) {
+
+}
+
+func (f *flag) Validate() error {
+	return nil
+}

--- a/cmd/gitops/add/base/runner.go
+++ b/cmd/gitops/add/base/runner.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/spf13/cobra"
+	"io"
+)
+
+type runner struct {
+	flag   *flag
+	logger micrologger.Logger
+	stdout io.Writer
+	stderr io.Writer
+}
+
+func (r *runner) Run(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	err := r.flag.Validate()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.run(ctx, cmd, args)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
+	fmt.Println("Hello world!")
+	return nil
+}

--- a/cmd/gitops/add/command.go
+++ b/cmd/gitops/add/command.go
@@ -11,6 +11,7 @@ import (
 
 	app "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/app"
 	autoup "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/automatic-updates"
+	base "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/base"
 	enc "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/encryption"
 	mc "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/management-cluster"
 	org "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/organization"
@@ -45,6 +46,22 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	var err error
+
+	var baseCmd *cobra.Command
+	{
+		c := base.Config{
+			Logger:     config.Logger,
+			FileSystem: config.FileSystem,
+
+			Stderr: config.Stderr,
+			Stdout: config.Stdout,
+		}
+
+		baseCmd, err = base.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var appCmd *cobra.Command
 	{
@@ -160,6 +177,7 @@ func New(config Config) (*cobra.Command, error) {
 
 	f.Init(c)
 
+	c.AddCommand(baseCmd)
 	c.AddCommand(appCmd)
 	c.AddCommand(autoUpdateCmd)
 	c.AddCommand(encryptionCmd)


### PR DESCRIPTION
### What does this PR do?

Add `gitops add base` command.

Towards: https://github.com/giantswarm/roadmap/issues/1828

### What is the effect of this change to users?

Have a new command to create bases for CAPx clusters.

### What does it look like?

...

### Any background context you can provide?

See: https://github.com/giantswarm/roadmap/issues/1828

### What is needed from the reviewers?

...

### Do the docs need to be updated?

...

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

Nope.