### PR TITLE
New provider & improved provider detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Modified detection of installation providers - downloading the provider information from Athena with a fallback to the old detection from API URLs
+- Added a new provider - `cloud-director`
+
 ## [2.30.0] - 2023-01-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Modified detection of installation providers - downloading the provider information from Athena with a fallback to the old detection from API URLs
 - Added a new provider - `cloud-director`
 
+### Added
+
+- Introduced a new `--connector-id` flag in the `login` command to specify a Dex connector to use and skip the selection step
+
 ## [2.30.0] - 2023-01-12
 
 ### Changed
 
 - Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
-
-### Added
-
-- Introduced a new `--connector-id` flag in the `login` command to specify a Dex connector to use and skip the selection step
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
 - Modified detection of installation providers - downloading the provider information from Athena with a fallback to the old detection from API URLs
 - Added a new provider - `cloud-director`
 
@@ -17,10 +18,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Introduced a new `--connector-id` flag in the `login` command to specify a Dex connector to use and skip the selection step
 
 ## [2.30.0] - 2023-01-12
-
-### Changed
-
-- Adjusted communication with Dex in the `login` command to provide an option to choose from multiple connectors
 
 ### Added
 

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -29,6 +29,8 @@ func (r *runner) printOutput(clusterResource cluster.Resource) error {
 			resource = provider.GetAzureTable(clusterResource)
 		case key.ProviderOpenStack:
 			resource = provider.GetOpenStackTable(clusterResource)
+		default:
+			resource = provider.GetCommonClusterTable(clusterResource)
 		}
 
 		printOptions := printers.PrintOptions{

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -1,13 +1,16 @@
 package provider
 
 import (
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"strings"
+
+	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
+
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProviderFromConfig()
+			r.provider, err = r.commonConfig.GetProviderFromConfig(ctx, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -66,7 +66,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	var resource cluster.Resource
 	{
 		options := cluster.GetOptions{
-			Provider: r.provider,
+			Provider:       r.provider,
+			FallbackToCapi: true,
 		}
 		{
 			if len(args) > 0 {

--- a/cmd/get/nodepools/runner.go
+++ b/cmd/get/nodepools/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProviderFromConfig()
+			r.provider, err = r.commonConfig.GetProviderFromConfig(ctx, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/get/releases/runner.go
+++ b/cmd/get/releases/runner.go
@@ -51,7 +51,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	{
 		if r.provider == "" {
-			r.provider, err = r.commonConfig.GetProviderFromConfig()
+			r.provider, err = r.commonConfig.GetProviderFromConfig(ctx, "")
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -467,9 +467,10 @@ func getAllOrganizationNamespaces(ctx context.Context, organizationService organ
 
 func fetchCluster(ctx context.Context, clusterService cluster.Interface, provider, namespace, name string) (*cluster.Cluster, error) {
 	o := cluster.GetOptions{
-		Namespace: namespace,
-		Name:      name,
-		Provider:  provider,
+		Namespace:      namespace,
+		Name:           name,
+		Provider:       provider,
+		FallbackToCapi: true,
 	}
 
 	c, err := clusterService.Get(ctx, o)

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -82,7 +82,7 @@ func (r *runner) loginWithCodeName(ctx context.Context, codeName string) error {
 // loginWithURL performs the OIDC login into an installation's
 // k8s api with a happa/k8s api URL.
 func (r *runner) loginWithURL(ctx context.Context, path string, firstLogin bool, tokenOverride string) error {
-	i, err := installation.New(ctx, path, "")
+	i, err := r.commonConfig.GetInstallation(ctx, path, "")
 	if installation.IsUnknownUrlType(err) {
 		return microerror.Maskf(unknownUrlError, "'%s' is not a valid Giant Swarm Management API URL. Please check the spelling.\nIf not sure, pass the web UI URL of the installation or the installation handle as an argument instead.", path)
 	} else if err != nil {

--- a/cmd/login/runner_config_modify_test.go
+++ b/cmd/login/runner_config_modify_test.go
@@ -394,6 +394,8 @@ func mockKubernetesAndAuthServer(org securityv1alpha.Organization, wc v1beta1.Cl
 		var responseData interface{}
 
 		switch r.URL.Path {
+		case "/graphql":
+			responseData = createAthenaGraphQL("", issuer)
 		case "/api":
 			responseData = apiVersions
 		case "/apis":
@@ -610,6 +612,42 @@ func createApiVersions() v1.APIVersions {
 		Versions: []string{"v1"},
 		ServerAddressByClientCIDRs: []v1.ServerAddressByClientCIDR{
 			{ServerAddress: "127.0.0.1:8000"},
+		},
+	}
+}
+
+type athenaIdentity struct {
+	Provider string `json:"provider"`
+	Codename string `json:"codename"`
+}
+
+type athenaKubernetes struct {
+	ApiUrl  string `json:"apiUrl"`
+	AuthUrl string `json:"authUrl"`
+	CaCert  string `json:"caCert"`
+}
+
+type athenaData struct {
+	Identity   athenaIdentity   `json:"identity"`
+	Kubernetes athenaKubernetes `json:"kubernetes"`
+}
+
+type athenaContent struct {
+	Data athenaData `json:"data"`
+}
+
+func createAthenaGraphQL(codename string, url string) athenaContent {
+	return athenaContent{
+		Data: athenaData{
+			Identity: athenaIdentity{
+				Provider: "capa",
+				Codename: codename,
+			},
+			Kubernetes: athenaKubernetes{
+				ApiUrl:  url,
+				AuthUrl: url,
+				CaCert:  "-----BEGIN CERTIFICATE-----\\n\\n-----END CERTIFICATE-----",
+			},
 		},
 	}
 }

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -114,7 +114,7 @@ func (r *runner) getCertOperatorVersion(c *cluster.Cluster, provider string, ser
 }
 
 func (r *runner) handleWCClientCert(ctx context.Context) error {
-	provider, err := r.commonConfig.GetProviderFromInstallation(ctx, "", true)
+	provider, err := r.commonConfig.GetProviderFromConfig(ctx, "")
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -316,6 +316,7 @@ func (f *flag) Validate() error {
 		key.ProviderGCP,
 		key.ProviderOpenStack,
 		key.ProviderVSphere,
+		key.ProviderCloudDirector,
 	}
 	isValidProvider := false
 	for _, p := range validProviders {

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -1,13 +1,14 @@
 package key
 
 const (
-	ProviderAWS       = "aws"
-	ProviderAzure     = "azure"
-	ProviderCAPA      = "capa"
-	ProviderGCP       = "gcp"
-	ProviderKVM       = "kvm"
-	ProviderOpenStack = "openstack"
-	ProviderVSphere   = "vsphere"
+	ProviderAWS           = "aws"
+	ProviderAzure         = "azure"
+	ProviderCAPA          = "capa"
+	ProviderGCP           = "gcp"
+	ProviderKVM           = "kvm"
+	ProviderOpenStack     = "openstack"
+	ProviderVSphere       = "vsphere"
+	ProviderCloudDirector = "cloud-director"
 )
 
 // PureCAPIProviders is the list of all providers which are purely based on or fully migrated to CAPI

--- a/pkg/commonconfig/commonconfig.go
+++ b/pkg/commonconfig/commonconfig.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"

--- a/pkg/commonconfig/commonconfig.go
+++ b/pkg/commonconfig/commonconfig.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"

--- a/pkg/commonconfig/commonconfig_test.go
+++ b/pkg/commonconfig/commonconfig_test.go
@@ -12,65 +12,12 @@ import (
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 )
 
-func TestCommonConfig_GetProviderFromConfig(t *testing.T) {
-	testCases := []struct {
-		name           string
-		k8sApiURL      string
-		expectedResult string
-	}{
-		{
-			name:           "case 0: AWS url",
-			k8sApiURL:      "https://g8s.test.eu-west-1.aws.coolio.com",
-			expectedResult: key.ProviderAWS,
-		},
-		{
-			name:           "case 1: Azure url",
-			k8sApiURL:      "https://g8s.test.eu-west-1.azure.coolio.com",
-			expectedResult: key.ProviderAzure,
-		},
-		{
-			name:           "case 2: OpenStack url",
-			k8sApiURL:      "https://test12.customer.coolio.com",
-			expectedResult: key.ProviderOpenStack,
-		},
-		{
-			name:           "case 3: URL containing 'aws', but not AWS",
-			k8sApiURL:      "https://aws12.customer.coolio.com",
-			expectedResult: key.ProviderOpenStack,
-		},
-		{
-			name:           "case 4: URL containing 'azure', but not Azure",
-			k8sApiURL:      "https://azure12.customer.coolio.com",
-			expectedResult: key.ProviderOpenStack,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cflags := genericclioptions.NewConfigFlags(false)
-			*cflags.APIServer = tc.k8sApiURL
-
-			cc := New(cflags)
-			result, err := cc.GetProviderFromConfig()
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err.Error())
-			}
-
-			if result != tc.expectedResult {
-				t.Fatalf("value not expected, got: %s", result)
-			}
-		})
-	}
-}
-
 func TestCommonConfig_GetProviderFromInstallation(t *testing.T) {
 	testCases := []struct {
 		name             string
 		k8sApiURL        string
 		resolvedProvider string
 		expectedResult   string
-		expectedError    bool
-		fallbackToConfig bool
 	}{
 		{
 			name:             "case 0: AWS URL resolved as Capa",
@@ -85,15 +32,29 @@ func TestCommonConfig_GetProviderFromInstallation(t *testing.T) {
 			expectedResult:   key.ProviderAzure,
 		},
 		{
-			name:          "case 2: Azure URL resolved with no fallback as error",
-			k8sApiURL:     "https://g8s.test.eu-west-1.azure.coolio.com",
-			expectedError: true,
+			name:           "case 2: AWS url",
+			k8sApiURL:      "https://g8s.test.eu-west-1.aws.coolio.com",
+			expectedResult: key.ProviderAWS,
 		},
 		{
-			name:             "case 3: Azure URL resolved to error with fallback",
-			k8sApiURL:        "https://g8s.test.eu-west-1.azure.coolio.com",
-			fallbackToConfig: true,
-			expectedResult:   key.ProviderAzure,
+			name:           "case 3: Azure url",
+			k8sApiURL:      "https://g8s.test.eu-west-1.azure.coolio.com",
+			expectedResult: key.ProviderAzure,
+		},
+		{
+			name:           "case 4: OpenStack url",
+			k8sApiURL:      "https://test12.customer.coolio.com",
+			expectedResult: key.ProviderOpenStack,
+		},
+		{
+			name:           "case 5: URL containing 'aws', but not AWS",
+			k8sApiURL:      "https://aws12.customer.coolio.com",
+			expectedResult: key.ProviderOpenStack,
+		},
+		{
+			name:           "case 6: URL containing 'azure', but not Azure",
+			k8sApiURL:      "https://azure12.customer.coolio.com",
+			expectedResult: key.ProviderOpenStack,
 		},
 	}
 
@@ -118,13 +79,10 @@ func TestCommonConfig_GetProviderFromInstallation(t *testing.T) {
 			ctx := context.TODO()
 
 			cc := New(cflags)
-			result, err := cc.GetProviderFromInstallation(ctx, mockAthenaServer.URL, tc.fallbackToConfig)
+			result, err := cc.GetProviderFromConfig(ctx, mockAthenaServer.URL)
 
-			if err != nil && !tc.expectedError {
+			if err != nil {
 				t.Fatal(err)
-			}
-			if tc.expectedError && err == nil {
-				t.Fatal("Expected error, received success")
 			}
 			if tc.expectedResult != result {
 				t.Fatalf("Incorrect provider: expected %s, received %s", tc.expectedResult, result)

--- a/pkg/data/domain/cluster/openstack.go
+++ b/pkg/data/domain/cluster/openstack.go
@@ -13,7 +13,7 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (s *Service) getAllOpenStack(ctx context.Context, namespace string) (Resource, error) {
+func (s *Service) getAllCommonCapi(ctx context.Context, namespace string) (Resource, error) {
 	var clusterList capi.ClusterList
 	{
 		err := s.client.List(ctx, &clusterList, runtimeClient.InNamespace(namespace))
@@ -85,7 +85,7 @@ func (s *Service) getAllOpenStack(ctx context.Context, namespace string) (Resour
 	return &clusterCollection, nil
 }
 
-func (s *Service) getByNameOpenStack(ctx context.Context, name, namespace string) (Resource, error) {
+func (s *Service) getByNameCommonCapi(ctx context.Context, name, namespace string) (Resource, error) {
 	var cluster Cluster
 
 	{

--- a/pkg/data/domain/cluster/spec.go
+++ b/pkg/data/domain/cluster/spec.go
@@ -13,9 +13,10 @@ import (
 )
 
 type GetOptions struct {
-	Name      string
-	Provider  string
-	Namespace string
+	Name           string
+	Provider       string
+	Namespace      string
+	FallbackToCapi bool
 }
 
 type PatchOptions struct {

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -22,10 +22,11 @@ type Installation struct {
 	Provider          string
 	Codename          string
 	CACert            string
+	SourcePath        string
 }
 
-func New(ctx context.Context, fromUrl string, athenaUrl string) (*Installation, error) {
-	basePath, internalApiPath, err := GetBaseAndInternalPath(fromUrl)
+func New(ctx context.Context, fromUrl, customAthenaUrl string) (*Installation, error) {
+	_, internalApiPath, athenaUrl, err := GetBaseAndInternalPath(fromUrl)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -35,8 +36,8 @@ func New(ctx context.Context, fromUrl string, athenaUrl string) (*Installation, 
 		httpClient := http.DefaultClient
 		httpClient.Timeout = requestTimeout
 
-		if athenaUrl == "" {
-			athenaUrl = getAthenaUrl(basePath)
+		if customAthenaUrl != "" {
+			athenaUrl = customAthenaUrl
 		}
 		config := graphql.ClientImplConfig{
 			HttpClient: httpClient,
@@ -61,6 +62,7 @@ func New(ctx context.Context, fromUrl string, athenaUrl string) (*Installation, 
 		Provider:          info.Identity.Provider,
 		Codename:          info.Identity.Codename,
 		CACert:            info.Kubernetes.CaCert,
+		SourcePath:        fromUrl,
 	}
 
 	return i, nil

--- a/pkg/installation/url.go
+++ b/pkg/installation/url.go
@@ -27,7 +27,7 @@ const (
 
 var k8sApiURLRegexp = regexp.MustCompile(fmt.Sprintf("([^.]*)%s.*$", k8sApiUrlPrefix))
 var wcK8sApiUrlRegexp = regexp.MustCompile(fmt.Sprintf("^api\\.[0-9a-zA-Z]{5,10}\\.%s.*$", wcK8sApiUrlPrefix))
-var ipAddressRegexp = regexp.MustCompile("^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}(:[0-9]+)$")
+var ipAddressRegexp = regexp.MustCompile(`^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]+)$`)
 
 func GetUrlType(u string) int {
 	switch {

--- a/pkg/installation/url_test.go
+++ b/pkg/installation/url_test.go
@@ -12,6 +12,7 @@ func Test_GetBasePath(t *testing.T) {
 		url                    string
 		expectedResult         string
 		expectedInternalResult string
+		expectedAthenaResult   string
 		errorMatcher           func(error) bool
 	}{
 		{
@@ -19,24 +20,28 @@ func Test_GetBasePath(t *testing.T) {
 			url:                    "https://g8s.test.eu-west-1.aws.coolio.com",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
 			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
+			expectedAthenaResult:   "https://athena.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:                   "case 1: using k8s api url, without scheme",
 			url:                    "g8s.test.eu-west-1.aws.coolio.com",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
 			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
+			expectedAthenaResult:   "https://athena.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:                   "case 2: using k8s api url, with trailing slash",
 			url:                    "g8s.test.eu-west-1.aws.coolio.com/",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
 			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
+			expectedAthenaResult:   "https://athena.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:                   "case 3: using happa url",
 			url:                    "happa.g8s.test.eu-west-1.aws.coolio.com/",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
 			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
+			expectedAthenaResult:   "https://athena.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:         "case 4: using invalid url",
@@ -53,36 +58,41 @@ func Test_GetBasePath(t *testing.T) {
 			url:                    "https://api.g8s.test.eu-west-1.aws.coolio.com",
 			expectedResult:         "g8s.test.eu-west-1.aws.coolio.com",
 			expectedInternalResult: "internal-g8s.test.eu-west-1.aws.coolio.com",
+			expectedAthenaResult:   "https://athena.g8s.test.eu-west-1.aws.coolio.com",
 		},
 		{
 			name:                   "case 5: new style url",
 			url:                    "https://api.installation.customer.gigantic.io:6443",
 			expectedResult:         "installation.customer.gigantic.io",
 			expectedInternalResult: "internal-installation.customer.gigantic.io",
+			expectedAthenaResult:   "https://athena.installation.customer.gigantic.io",
 		},
 		{
 			name:                   "case 6: wc k8s api url",
 			url:                    "https://api.abc12.k8s.installation.customer.gigantic.io:6443",
 			expectedResult:         "abc12.k8s.installation.customer.gigantic.io",
 			expectedInternalResult: "internal-api.abc12.k8s.installation.customer.gigantic.io",
+			expectedAthenaResult:   "https://athena.abc12.k8s.installation.customer.gigantic.io",
 		},
 		{
 			name:                   "case 6: wc k8s api long url",
 			url:                    "https://api.abc12def34.k8s.installation.customer.gigantic.io:6443",
 			expectedResult:         "abc12def34.k8s.installation.customer.gigantic.io",
 			expectedInternalResult: "internal-api.abc12def34.k8s.installation.customer.gigantic.io",
+			expectedAthenaResult:   "https://athena.abc12def34.k8s.installation.customer.gigantic.io",
 		},
 		{
 			name:                   "case 7: mc k8s api custom domain",
 			url:                    "https://api.installation.xx-xxxx-x.aaa.bbb.ccc.tld",
 			expectedResult:         "installation.xx-xxxx-x.aaa.bbb.ccc.tld",
 			expectedInternalResult: "internal-installation.xx-xxxx-x.aaa.bbb.ccc.tld",
+			expectedAthenaResult:   "https://athena.installation.xx-xxxx-x.aaa.bbb.ccc.tld",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			basePath, internalPath, err := GetBaseAndInternalPath(tc.url)
+			basePath, internalPath, athenaUrl, err := GetBaseAndInternalPath(tc.url)
 			if tc.errorMatcher != nil {
 				if !tc.errorMatcher(err) {
 					t.Fatalf("error not matching expected matcher, got: %s", errors.Cause(err))
@@ -99,15 +109,9 @@ func Test_GetBasePath(t *testing.T) {
 			if internalPath != tc.expectedInternalResult {
 				t.Fatalf("internal path not expected, got: %s, want: %s", internalPath, tc.expectedInternalResult)
 			}
+			if athenaUrl != tc.expectedAthenaResult {
+				t.Fatalf("athena url not expected, got: %s, want: %s", athenaUrl, tc.expectedAthenaResult)
+			}
 		})
-	}
-}
-
-func Test_getAthenaUrl(t *testing.T) {
-	basePath := "g8s.test.eu-west-1.aws.coolio.com" // nolint:goconst
-	expectedResult := "https://athena.g8s.test.eu-west-1.aws.coolio.com"
-
-	if result := getAthenaUrl(basePath); result != expectedResult {
-		t.Fatalf("url not expected, got: %s", result)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
This PR attempts to solve 2 issues:

- it adds a new provider called `cloud-director` and prevents failures while handling unknown providers in some commands (e.g. `get clusters`),

- it also introduces an improved way of detecting installation providers. In previous versions the providers were derived from the source URL supplied to kubectl-gs. In this PR the provider is retrieved primarily from Athena, and in case it fails the old method is used as a fallback.

### What is the effect of this change to users?

It fixes several issues that the users faced in previous versions.

### What does it look like?

No changes in visible output.

### Any background context you can provide?

We have a new installation, which uses a provider called `cloud-director`. Kubectl-gs was not aware of this provider and as a result some commands were failing - e.g. `login --workload-cluster` or `get clusters`. This PR adds the new provider to kubectl-gs and also improves handling unknown providers, so that the commands do not fail just because the provider is unknown (they might still fail for other reasons when dealing with new providers).

Kubectl-gs needs to detect installation provider when running specific commands (e.g. `get` or `login`). The providers used to be derived from Kubernetes API URL of the installation's management cluster (or workload cluster in some cases). The detection was very simple: if the URL has a certain structure and contains "aws" in a specific, then the provider is AWS vintage. If it contains "azure" in a specific place, then the provider is Azure Vintage. Otherwise the provider is Open Stack. Now we have more than just these 3 providers, and Kubernetes API URLs are a more heterogenous than before, so the simple detection is no longer sufficient and deriving providers from the API URLs is no longer reliable. Therefore this PR introduces a new primary way of detecting providers - they are taken from installation details pulled from Athena. In case Athena is unreachable, the old simple detection is used as a fallback.

Fixes https://github.com/giantswarm/roadmap/issues/1763

### What is needed from the reviewers?

The changes can be tested by logging in to management and workload clusters in different installations and listing some resources.

### Do the docs need to be updated?

There are no visible changes, so the docs do not necessarily need to be updated.

### Should this change be mentioned in the release notes?

Debatable

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
