### PR TITLE
Update CAPA subnet template types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Updated CAPA template output to support new subnet layout as of cluster-aws v0.21.0
+
 ## [2.31.0] - 2023-01-18
 
 ### Changed

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -107,9 +107,16 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 				return microerror.Mask(err)
 			}
 
+			flagValues.Network.Subnets = []capa.Subnet{
+				{
+					CidrBlocks: []capa.CIDRBlock{},
+				},
+			}
+
 			for i := 0; i < subnetCount; i++ {
-				flagValues.Network.Subnets = append(flagValues.Network.Subnets, capa.Subnet{
-					CidrBlock: subnets[i].CIDR().String(),
+				flagValues.Network.Subnets[0].CidrBlocks = append(flagValues.Network.Subnets[0].CidrBlocks, capa.CIDRBlock{
+					CIDR:             subnets[i].CIDR().String(),
+					AvailabilityZone: string(rune('a' + i)), // generate `a`, `b`, etc. based on which index we're at
 				})
 			}
 

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -34,7 +34,13 @@ type Network struct {
 }
 
 type Subnet struct {
-	CidrBlock string `json:"cidrBlock"`
+	CidrBlocks []CIDRBlock `json:"cidrBlocks"`
+	IsPublic   bool        `json:"isPublic"`
+}
+
+type CIDRBlock struct {
+	CIDR             string `json:"cidr"`
+	AvailabilityZone string `json:"availabilityZone"`
 }
 
 type Bastion struct {

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
@@ -26,8 +26,12 @@ data:
       apiMode: private
       dnsMode: private
       subnets:
-      - cidrBlock: 10.123.0.0/18
-      - cidrBlock: 10.123.64.0/18
+      - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.123.0.0/18
+        - availabilityZone: b
+          cidr: 10.123.64.0/18
+        isPublic: false
       topologyMode: GiantSwarmManaged
       vpcCIDR: 10.123.0.0/16
       vpcMode: private

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -26,8 +26,12 @@ data:
       apiMode: public
       dnsMode: private
       subnets:
-      - cidrBlock: 10.123.0.0/18
-      - cidrBlock: 10.123.64.0/18
+      - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.123.0.0/18
+        - availabilityZone: b
+          cidr: 10.123.64.0/18
+        isPublic: false
       topologyMode: UserManaged
       vpcCIDR: 10.123.0.0/16
       vpcMode: private


### PR DESCRIPTION
Blocked by https://github.com/giantswarm/cluster-aws/pull/205


### What does this PR do?

Changes the templated output of subnets for private CAPA clusters based on changes introduced in cluster-aws v0.21.0

### What is the effect of this change to users?

The correct output for cluster-values for clusters going forward.

### What does it look like?

N/a

### Any background context you can provide?

More complex config now supported in the template which caused it to change from a string array to an object array

### What is needed from the reviewers?

### Do the docs need to be updated?

No 

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
