### PR TITLE
Fixed client certificate creation for CAPVCD WCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed creating client certificates for workload clusters in `capvcd` installations.
+
 ## [2.31.1] - 2023-01-19
 
 ### Changed

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -18,5 +18,6 @@ func PureCAPIProviders() []string {
 		ProviderGCP,
 		ProviderVSphere,
 		ProviderOpenStack,
+		ProviderCloudDirector,
 	}
 }


### PR DESCRIPTION
### What does this PR do?

It adds CAPVCD to the list of pure CAPI providers.

### What is the effect of this change to users?

Creation of client certificates for WCs in CAPVCD should work after this fix is applied. There are no impacts on any other providers.

### What does it look like?

No visible changes, just a bug fix/

### Any background context you can provide?

Creating client certificates for workload clusters in CAPVCD installations did not work because Kubectl-gs used an incorrect method to generate the certificates. Recognizing the provider as pure CAPI fixes the problem.

### What is needed from the reviewers?

It can be tested by creating a client certificate for a WC in Guppy and verifying that it works.

### Do the docs need to be updated?

No need to update the docs

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
