### PR TITLE
CAPA: Add hidden flags `--aws-prefix-list-id` and `--aws-transit-gateway-id` for private clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- CAPA: Add hidden flags `--aws-prefix-list-id` and `--aws-transit-gateway-id` for private clusters
+
 ### Changed
 
 - CAPA: Renamed hidden parameter `--role` to `--aws-cluster-role-identity-name` and adapted manifest output to the new name `awsClusterRoleIdentityName` (see [cluster-aws](https://github.com/giantswarm/cluster-aws/pull/192) change)

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -36,6 +36,8 @@ const (
 	flagAWSDNSMode                 = "dns-mode"
 	flagAWSVPCMode                 = "vpc-mode"
 	flagAWSTopologyMode            = "topology-mode"
+	flagAWSPrefixListID            = "aws-prefix-list-id"
+	flagAWSTransitGatewayID        = "aws-transit-gateway-id"
 
 	flagAWSMachinePoolMinSize          = "machine-pool-min-size"
 	flagAWSMachinePoolMaxSize          = "machine-pool-max-size"
@@ -157,6 +159,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AWS.VPCMode, flagAWSVPCMode, "", "VPC mode of the network (public,private)")
 	cmd.Flags().StringVar(&f.AWS.DNSMode, flagAWSDNSMode, "", "DNS  mode of the network (public,private)")
 	cmd.Flags().StringVar(&f.AWS.TopologyMode, flagAWSTopologyMode, "", "Topology mode of the network (UserManaged,GiantSwarmManaged,None)")
+	cmd.Flags().StringVar(&f.AWS.PrefixListID, flagAWSPrefixListID, "", "Prefix list ID to manage. Workload cluster will be able to reach the destinations in the prefix list via the transit gateway. If not specified, it will be looked up by name/namespace of the management cluster (ends with `-tgw-prefixlist`). Only applies to proxy-private clusters.")
+	cmd.Flags().StringVar(&f.AWS.TransitGatewayID, flagAWSTransitGatewayID, "", "ID of the transit gateway to attach the cluster VPC to. If not specified for workload clusters, the management cluster's transit gateway will be used. Only applies to proxy-private clusters.")
 	// aws control plane
 	cmd.Flags().StringVar(&f.AWS.ControlPlaneSubnet, flagAWSControlPlaneSubnet, "", "Subnet used for the Control Plane.")
 	// aws machine pool
@@ -257,6 +261,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkHidden(flagAWSVPCMode)
 	_ = cmd.Flags().MarkHidden(flagAWSDNSMode)
 	_ = cmd.Flags().MarkHidden(flagAWSTopologyMode)
+	_ = cmd.Flags().MarkHidden(flagAWSPrefixListID)
+	_ = cmd.Flags().MarkHidden(flagAWSTransitGatewayID)
 
 	_ = cmd.Flags().MarkHidden(flagGCPProject)
 	_ = cmd.Flags().MarkHidden(flagGCPFailureDomains)

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
+	gsannotation "github.com/giantswarm/k8smetadata/pkg/annotation"
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 
 	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/aws"
@@ -20,10 +21,9 @@ import (
 )
 
 const (
-	DefaultAppsRepoName  = "default-apps-aws"
-	ClusterAWSRepoName   = "cluster-aws"
-	ModePrivate          = "private"
-	TopoloyModeGSManaged = "GiantSwarmManaged"
+	DefaultAppsRepoName = "default-apps-aws"
+	ClusterAWSRepoName  = "cluster-aws"
+	ModePrivate         = "private"
 )
 
 func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
@@ -134,7 +134,9 @@ func templateClusterAWS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			flagValues.Network.APIMode = defaultTo(config.AWS.APIMode, ModePrivate)
 			flagValues.Network.VPCMode = defaultTo(config.AWS.VPCMode, ModePrivate)
 			flagValues.Network.DNSMode = defaultTo(config.AWS.DNSMode, ModePrivate)
-			flagValues.Network.TopologyMode = defaultTo(config.AWS.TopologyMode, TopoloyModeGSManaged)
+			flagValues.Network.TopologyMode = defaultTo(config.AWS.TopologyMode, gsannotation.NetworkTopologyModeGiantSwarmManaged)
+			flagValues.Network.PrefixListID = config.AWS.PrefixListID
+			flagValues.Network.TransitGatewayID = config.AWS.TransitGatewayID
 		}
 
 		configData, err := capa.GenerateClusterValues(flagValues)

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -45,6 +45,8 @@ type AWSConfig struct {
 	VPCMode                    string
 	DNSMode                    string
 	TopologyMode               string
+	PrefixListID               string
+	TransitGatewayID           string
 }
 
 type AWSMachinePoolConfig struct {

--- a/cmd/template/cluster/provider/templates/capa/functions.go
+++ b/cmd/template/cluster/provider/templates/capa/functions.go
@@ -1,11 +1,25 @@
 package capa
 
 import (
+	"fmt"
+	"strings"
+
+	gsannotation "github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 )
 
 func GenerateClusterValues(flagInputs ClusterConfig) (string, error) {
+	if flagInputs.Network.TopologyMode != "" && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeGiantSwarmManaged && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeUserManaged && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeNone {
+		return "", fmt.Errorf("invalid topology mode value %q", flagInputs.Network.TopologyMode)
+	}
+	if flagInputs.Network.PrefixListID != "" && !strings.HasPrefix(flagInputs.Network.PrefixListID, "pl-") {
+		return "", fmt.Errorf("invalid AWS prefix list ID %q", flagInputs.Network.PrefixListID)
+	}
+	if flagInputs.Network.TransitGatewayID != "" && !strings.HasPrefix(flagInputs.Network.TransitGatewayID, "tgw-") {
+		return "", fmt.Errorf("invalid AWS transit gateway ID %q", flagInputs.Network.TransitGatewayID)
+	}
+
 	var flagConfigData map[string]interface{}
 
 	{

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -27,6 +27,8 @@ type Network struct {
 	AvailabilityZoneUsageLimit int      `json:"availabilityZoneUsageLimit,omitempty"`
 	VPCCIDR                    string   `json:"vpcCIDR,omitempty"`
 	TopologyMode               string   `json:"topologyMode,omitempty"`
+	PrefixListID               string   `json:"prefixListID,omitempty"`
+	TransitGatewayID           string   `json:"transitGatewayID,omitempty"`
 	VPCMode                    string   `json:"vpcMode,omitempty"`
 	APIMode                    string   `json:"apiMode,omitempty"`
 	DNSMode                    string   `json:"dnsMode,omitempty"`

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -169,6 +169,8 @@ func Test_run(t *testing.T) {
 					NetworkVPCCIDR:             "10.123.0.0/16",
 					APIMode:                    "public",
 					TopologyMode:               "UserManaged",
+					PrefixListID:               "pl-123456789abc",
+					TransitGatewayID:           "tgw-987987987987def",
 					HttpsProxy:                 "https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000",
 					HttpProxy:                  "http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000",
 					NoProxy:                    "test-domain.com",

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -25,6 +25,7 @@ data:
     network:
       apiMode: public
       dnsMode: private
+      prefixListID: pl-123456789abc
       subnets:
       - cidrBlocks:
         - availabilityZone: a
@@ -33,6 +34,7 @@ data:
           cidr: 10.123.64.0/18
         isPublic: false
       topologyMode: UserManaged
+      transitGatewayID: tgw-987987987987def
       vpcCIDR: 10.123.0.0/16
       vpcMode: private
     organization: test


### PR DESCRIPTION
### What does this PR do?

Add necessary flags to create workload clusters on private CAPA MCs. Also, validate related inputs (topology mode, TGW/PL ID format).

### What is the effect of this change to users?

We omit the fields if not specified, so no changes.

### What does it look like?

```
apiVersion: v1
data:
  values: |
    # [...]
    network:
      apiMode: private
      availabilityZoneUsageLimit: 3
      dnsMode: private
      prefixListID: pl-abcdef123456
      # [...]
      topologyMode: UserManaged
      transitGatewayID: tgw-123456ghijkl
      vpcCIDR: 1.2.3.0/22
      vpcMode: private
    # [...]
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: andreas36
  name: andreas36-userconfig
  namespace: org-giantswarm
```

### Any background context you can provide?

Needed for testing https://github.com/giantswarm/roadmap/issues/1832 on private clusters.

### What is needed from the reviewers?

@giantswarm/team-hydra please check thoroughly if the flag help text matches what we actually do topology-wise. I've explained it as I understand the networking right now.

### Do the docs need to be updated?

Not yet. We will do that together with private cluster feature documentation.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No