### PR TITLE
add CAPZ wc login support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
+- Add workload cluster login support for `CAPZ` based clusters
 - CAPA: Add hidden flags `--aws-prefix-list-id` and `--aws-transit-gateway-id` for private clusters
 
 ### Changed

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -4,6 +4,7 @@ const (
 	ProviderAWS           = "aws"
 	ProviderAzure         = "azure"
 	ProviderCAPA          = "capa"
+	ProviderCAPZ          = "capz"
 	ProviderGCP           = "gcp"
 	ProviderKVM           = "kvm"
 	ProviderOpenStack     = "openstack"
@@ -15,6 +16,7 @@ const (
 func PureCAPIProviders() []string {
 	return []string{
 		ProviderCAPA,
+		ProviderCAPZ,
 		ProviderGCP,
 		ProviderVSphere,
 		ProviderOpenStack,


### PR DESCRIPTION
### What does this PR do?

Add `CAPZ` as pure `CAPI` provider to make workload cluster login work via 
```
k gs login glippy --workload-cluster <myWorkloadCluster> --cluster-admin --certificate-group system:masters --certificate-ttl 3h
```

This also makes login through `opsctl` work

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
