### PR TITLE
Adapt to match latest schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- `kubectl gs template cluster` for Cluster API provider AWS has been adapted to work with the latest values schema of cluster-aws.
+
 ## [2.33.0] - 2023-03-08
 
 ### Added

--- a/cmd/template/cluster/provider/templates/capa/functions.go
+++ b/cmd/template/cluster/provider/templates/capa/functions.go
@@ -10,14 +10,14 @@ import (
 )
 
 func GenerateClusterValues(flagInputs ClusterConfig) (string, error) {
-	if flagInputs.Network.TopologyMode != "" && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeGiantSwarmManaged && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeUserManaged && flagInputs.Network.TopologyMode != gsannotation.NetworkTopologyModeNone {
-		return "", fmt.Errorf("invalid topology mode value %q", flagInputs.Network.TopologyMode)
+	if flagInputs.Connectivity.Topology.Mode != "" && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeGiantSwarmManaged && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeUserManaged && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeNone {
+		return "", fmt.Errorf("invalid topology mode value %q", flagInputs.Connectivity.Topology.Mode)
 	}
-	if flagInputs.Network.PrefixListID != "" && !strings.HasPrefix(flagInputs.Network.PrefixListID, "pl-") {
-		return "", fmt.Errorf("invalid AWS prefix list ID %q", flagInputs.Network.PrefixListID)
+	if flagInputs.Connectivity.Topology.PrefixListID != "" && !strings.HasPrefix(flagInputs.Connectivity.Topology.PrefixListID, "pl-") {
+		return "", fmt.Errorf("invalid AWS prefix list ID %q", flagInputs.Connectivity.Topology.PrefixListID)
 	}
-	if flagInputs.Network.TransitGatewayID != "" && !strings.HasPrefix(flagInputs.Network.TransitGatewayID, "tgw-") {
-		return "", fmt.Errorf("invalid AWS transit gateway ID %q", flagInputs.Network.TransitGatewayID)
+	if flagInputs.Connectivity.Topology.TransitGatewayID != "" && !strings.HasPrefix(flagInputs.Connectivity.Topology.TransitGatewayID, "tgw-") {
+		return "", fmt.Errorf("invalid AWS transit gateway ID %q", flagInputs.Connectivity.Topology.TransitGatewayID)
 	}
 
 	var flagConfigData map[string]interface{}

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -1,16 +1,18 @@
 package capa
 
 type ClusterConfig struct {
-	ClusterDescription string                  `json:"clusterDescription,omitempty"`
-	ClusterName        string                  `json:"clusterName,omitempty"`
-	Organization       string                  `json:"organization,omitempty"`
-	AWS                *AWS                    `json:"aws,omitempty"`
-	Network            *Network                `json:"network,omitempty"`
-	Bastion            *Bastion                `json:"bastion,omitempty"`
-	ControlPlane       *ControlPlane           `json:"controlPlane,omitempty"`
-	MachinePools       *map[string]MachinePool `json:"machinePools,omitempty"`
-	FlatcarAWSAccount  string                  `json:"flatcarAWSAccount,omitempty"`
-	Proxy              *Proxy                  `json:"proxy,omitempty"`
+	Connectivity     *Connectivity           `json:"connectivity,omitempty"`
+	ControlPlane     *ControlPlane           `json:"controlPlane,omitempty"`
+	Metadata         *Metadata               `json:"metadata,omitempty"`
+	NodePools        *map[string]MachinePool `json:"nodePools,omitempty"`
+	ProviderSpecific *ProviderSpecific       `json:"providerSpecific,omitempty"`
+	Internal         *Internal               `json:"internal,omitempty"`
+}
+
+type Metadata struct {
+	Name         string
+	Description  string
+	Organization string
 }
 
 type DefaultAppsConfig struct {
@@ -18,21 +20,36 @@ type DefaultAppsConfig struct {
 	Organization string `json:"organization,omitempty"`
 }
 
-type AWS struct {
-	Region                     string `json:"region,omitempty"`
+type ProviderSpecific struct {
+	AMI                        string `json:"ami,omitempty"`
 	AWSClusterRoleIdentityName string `json:"awsClusterRoleIdentityName,omitempty"`
+	FlatcarAWSAccount          string `json:"flatcarAwsAccount,omitempty"`
+	Region                     string `json:"region,omitempty"`
+}
+
+type Connectivity struct {
+	AvailabilityZoneUsageLimit int       `json:"availabilityZoneUsageLimit,omitempty"`
+	Bastion                    *Bastion  `json:"bastion,omitempty"`
+	DNS                        *DNS      `json:"dns,omitempty"`
+	Network                    *Network  `json:"network,omitempty"`
+	Proxy                      *Proxy    `json:"proxy,omitempty"`
+	Subnets                    []Subnet  `json:"subnets,omitempty"`
+	Topology                   *Topology `json:"topology,omitempty"`
+	VPCMode                    string    `json:"vpcMode,omitempty"`
 }
 
 type Network struct {
-	AvailabilityZoneUsageLimit int      `json:"availabilityZoneUsageLimit,omitempty"`
-	VPCCIDR                    string   `json:"vpcCIDR,omitempty"`
-	TopologyMode               string   `json:"topologyMode,omitempty"`
-	PrefixListID               string   `json:"prefixListID,omitempty"`
-	TransitGatewayID           string   `json:"transitGatewayID,omitempty"`
-	VPCMode                    string   `json:"vpcMode,omitempty"`
-	APIMode                    string   `json:"apiMode,omitempty"`
-	DNSMode                    string   `json:"dnsMode,omitempty"`
-	Subnets                    []Subnet `json:"subnets,omitempty"`
+	VPCCIDR string `json:"vpcCidr,omitempty"`
+}
+
+type Topology struct {
+	Mode             string `json:"mode,omitempty"`
+	PrefixListID     string `json:"prefixListId,omitempty"`
+	TransitGatewayID string `json:"transitGatewayId,omitempty"`
+}
+
+type DNS struct {
+	Mode string `json:"mode,omitempty"`
 }
 
 type Subnet struct {
@@ -46,11 +63,13 @@ type CIDRBlock struct {
 }
 
 type Bastion struct {
+	Enabled      bool   `json:"enabled,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 	Replicas     int    `json:"replicas,omitempty"`
 }
 
 type ControlPlane struct {
+	APIMode                string   `json:"apiMode,omitempty"`
 	InstanceType           string   `json:"instanceType,omitempty"`
 	Replicas               int      `json:"replicas,omitempty"`
 	RootVolumeSizeGB       int      `json:"rootVolumeSizeGB,omitempty"`
@@ -72,7 +91,10 @@ type MachinePool struct {
 
 type Proxy struct {
 	Enabled    bool   `json:"enabled,omitempty"`
-	HttpsProxy string `json:"https_proxy,omitempty"`
-	HttpProxy  string `json:"http_proxy,omitempty"`
-	NoProxy    string `json:"no_proxy,omitempty"`
+	HttpsProxy string `json:"httpsProxy,omitempty"`
+	HttpProxy  string `json:"httpProxy,omitempty"`
+	NoProxy    string `json:"noProxy,omitempty"`
+}
+
+type Internal struct {
 }

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -2,16 +2,21 @@
 apiVersion: v1
 data:
   values: |
-    aws:
-      awsClusterRoleIdentityName: default
-      region: the-region
-    bastion: {}
-    clusterDescription: just a test cluster
-    clusterName: test1
+    connectivity:
+      bastion:
+        enabled: true
+      dns: {}
+      network:
+        vpcCidr: 10.123.0.0/16
+      topology: {}
     controlPlane:
       instanceType: control-plane-instance-type
       replicas: 3
-    machinePools:
+    metadata:
+      Description: just a test cluster
+      Name: test1
+      Organization: test
+    nodePools:
       worker1:
         availabilityZones:
         - eu-west-1a
@@ -22,9 +27,9 @@ data:
         maxSize: 5
         minSize: 2
         rootVolumeSizeGB: 200
-    network:
-      vpcCIDR: 10.123.0.0/16
-    organization: test
+    providerSpecific:
+      awsClusterRoleIdentityName: default
+      region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
@@ -2,16 +2,37 @@
 apiVersion: v1
 data:
   values: |
-    aws:
-      awsClusterRoleIdentityName: default
-      region: the-region
-    bastion: {}
-    clusterDescription: just a test cluster
-    clusterName: test1
+    connectivity:
+      bastion:
+        enabled: true
+      dns:
+        mode: private
+      network:
+        vpcCidr: 10.123.0.0/16
+      proxy:
+        enabled: true
+        httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+        httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+        noProxy: test-domain.com
+      subnets:
+      - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.123.0.0/18
+        - availabilityZone: b
+          cidr: 10.123.64.0/18
+        isPublic: false
+      topology:
+        mode: GiantSwarmManaged
+      vpcMode: private
     controlPlane:
+      apiMode: private
       instanceType: control-plane-instance-type
       replicas: 3
-    machinePools:
+    metadata:
+      Description: just a test cluster
+      Name: test1
+      Organization: test
+    nodePools:
       worker1:
         availabilityZones:
         - eu-west-1a
@@ -22,25 +43,9 @@ data:
         maxSize: 5
         minSize: 2
         rootVolumeSizeGB: 200
-    network:
-      apiMode: private
-      dnsMode: private
-      subnets:
-      - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.123.0.0/18
-        - availabilityZone: b
-          cidr: 10.123.64.0/18
-        isPublic: false
-      topologyMode: GiantSwarmManaged
-      vpcCIDR: 10.123.0.0/16
-      vpcMode: private
-    organization: test
-    proxy:
-      enabled: true
-      http_proxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-      https_proxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-      no_proxy: test-domain.com
+    providerSpecific:
+      awsClusterRoleIdentityName: default
+      region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -2,16 +2,39 @@
 apiVersion: v1
 data:
   values: |
-    aws:
-      awsClusterRoleIdentityName: other-identity
-      region: the-region
-    bastion: {}
-    clusterDescription: just a test cluster
-    clusterName: test1
+    connectivity:
+      bastion:
+        enabled: true
+      dns:
+        mode: private
+      network:
+        vpcCidr: 10.123.0.0/16
+      proxy:
+        enabled: true
+        httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+        httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+        noProxy: test-domain.com
+      subnets:
+      - cidrBlocks:
+        - availabilityZone: a
+          cidr: 10.123.0.0/18
+        - availabilityZone: b
+          cidr: 10.123.64.0/18
+        isPublic: false
+      topology:
+        mode: UserManaged
+        prefixListId: pl-123456789abc
+        transitGatewayId: tgw-987987987987def
+      vpcMode: private
     controlPlane:
+      apiMode: public
       instanceType: control-plane-instance-type
       replicas: 3
-    machinePools:
+    metadata:
+      Description: just a test cluster
+      Name: test1
+      Organization: test
+    nodePools:
       worker1:
         availabilityZones:
         - eu-west-1a
@@ -22,27 +45,9 @@ data:
         maxSize: 5
         minSize: 2
         rootVolumeSizeGB: 200
-    network:
-      apiMode: public
-      dnsMode: private
-      prefixListID: pl-123456789abc
-      subnets:
-      - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.123.0.0/18
-        - availabilityZone: b
-          cidr: 10.123.64.0/18
-        isPublic: false
-      topologyMode: UserManaged
-      transitGatewayID: tgw-987987987987def
-      vpcCIDR: 10.123.0.0/16
-      vpcMode: private
-    organization: test
-    proxy:
-      enabled: true
-      http_proxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-      https_proxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-      no_proxy: test-domain.com
+    providerSpecific:
+      awsClusterRoleIdentityName: other-identity
+      region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
### What does this PR do?

After the schema changes in https://github.com/giantswarm/roadmap/issues/2142 this PR adapts the `kubectl gs template cluster` command for provider `capa` to work with the latest schema.

### What is the effect of this change to users?

`k gs template cluster` will work with the next cluster-aws release, but no longer with the ones before.

### Any background context you can provide?

See above issue

### What is needed from the reviewers?

We want to issue an e2e test using this branch.

### Do the docs need to be updated?

Maybe, the values example output.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Yes, as it makes the command incompatible with earlier cluster-aws releases.
