### PR TITLE
Use newer CAPI CRD versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Stop using old `v1alpha3` version when using CAPI CRDs. 
+
 ## [2.34.1] - 2023-03-30
 
 ### Fixed

--- a/cmd/template/nodepool/provider/common.go
+++ b/cmd/template/nodepool/provider/common.go
@@ -1,14 +1,13 @@
 package provider
 
 import (
-	capiexp "github.com/giantswarm/apiextensions/v6/pkg/apis/capiexp/v1alpha3"
 	corev1alpha1 "github.com/giantswarm/apiextensions/v6/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
 type NodePoolCRsConfig struct {
@@ -64,11 +63,11 @@ func newcapiMachinePoolCR(config NodePoolCRsConfig, infrastructureRef *corev1.Ob
 			ClusterName:    config.ClusterName,
 			Replicas:       toInt32Ptr(int32(config.NodesMin)),
 			FailureDomains: config.AvailabilityZones,
-			Template: clusterv1.MachineTemplateSpec{
-				Spec: clusterv1.MachineSpec{
+			Template: capi.MachineTemplateSpec{
+				Spec: capi.MachineSpec{
 					ClusterName:       config.ClusterName,
 					InfrastructureRef: *infrastructureRef,
-					Bootstrap: clusterv1.Bootstrap{
+					Bootstrap: capi.Bootstrap{
 						ConfigRef: bootstrapConfigRef,
 					},
 				},


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2350

### What does this PR do?

Fetch `v1beta1` version of the CAPI CRDs instead of `v1alpha3` when requesting CRs to the k8s api.

### What is the effect of this change to users?

Should be transparent to users.

### What does it look like?

n/a

### Any background context you can provide?

It seems we already use `v1beta1` pretty much everywhere, but this slipped through the cracks.

### What is needed from the reviewers?

Check if this would work as it was before.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated

### Is this a breaking change?

No
