### PR TITLE
Add flag to enable Socks proxy configuration in the cluster section of the kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for `--proxy` and `--proxy-port` flags to `login cmd` to enable `proxy-url: socks5://localhost:9000` in the cluster section of the configuration added to kubeconfig
+
 ## [2.35.0] - 2023-04-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Add support for `--proxy` and `--proxy-port` flags to `login cmd` to enable `proxy-url: socks5://localhost:9000` in the cluster section of the configuration added to kubeconfig
+  - This is only supported for `clientcert` Workload Clusters
 
 ## [2.35.0] - 2023-04-17
 

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -71,6 +71,8 @@ type credentialConfig struct {
 	clusterServer string
 	loginOptions  LoginOptions
 	filePath      string
+	proxy         bool
+	proxyPort     int
 }
 
 func generateClientCertUID() string {
@@ -306,6 +308,10 @@ func storeWCClientCertCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afe
 		cluster.Server = c.clusterServer
 		cluster.CertificateAuthority = ""
 		cluster.CertificateAuthorityData = c.certCA
+
+		if c.proxy {
+			cluster.ProxyURL = fmt.Sprintf("socks5://localhost:%d", c.proxyPort)
+		}
 
 		// Add cluster configuration to config.
 		config.Clusters[clusterName] = cluster

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -23,6 +23,9 @@ const (
 	flagWCInsecureNamespace = "insecure-namespace"
 
 	flagConnectorID = "connector-id"
+
+	flagProxy     = "proxy"
+	flagProxyPort = "proxy-port"
 )
 
 type flag struct {
@@ -40,6 +43,9 @@ type flag struct {
 	WCInsecureNamespace bool
 
 	ConnectorID string
+
+	Proxy     bool
+	ProxyPort int
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -57,6 +63,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.WCInsecureNamespace, flagWCInsecureNamespace, false, fmt.Sprintf(`For client certificate creation. Allow using an insecure namespace for creating the client certificate. Requires --%s.`, flagWCName))
 
 	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Dex connector to use for authentication. This allows to skip the selection page.")
+
+	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster")
+	cmd.Flags().IntVar(&f.ProxyPort, flagProxyPort, 9000, "Port for the socks proxy configuration for the cluster")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -64,7 +64,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&f.ConnectorID, flagConnectorID, "", "Dex connector to use for authentication. This allows to skip the selection page.")
 
-	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster")
+	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster. Only Supported for Workload Cluster using clientcert auth mode")
 	cmd.Flags().IntVar(&f.ProxyPort, flagProxyPort, 9000, "Port for the socks proxy configuration for the cluster")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -209,6 +209,8 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 		clusterServer: clusterServer,
 		filePath:      r.flag.SelfContained,
 		loginOptions:  r.loginOptions,
+		proxy:         r.flag.Proxy,
+		proxyPort:     r.flag.ProxyPort,
 	}
 
 	contextName, contextExists, err = r.storeWCClientCertCredentials(credentialConfig)


### PR DESCRIPTION
### What does this PR do?

Add support for `socks proxy` configuration in the cluster section of a kubeconfig created by the login command

### What is the effect of this change to users?
When the flag `--proxy` is specified a config like like 

`proxy-url: socks5://localhost:9000` 

will be added to the to the `cluster` configuration for the cluster that is being logged in 


### What does it look like?
```
clusters:
- cluster:
    certificate-authority-data: DATA+OMITTED
    proxy-url: socks5://localhost:9000
    server: https://apiserver.cluster1.example.com:6443
  name: cluster1
```

### Any background context you can provide?

In some cases we need to access apiserver through an ssh bastion host, using an SSHD socks proxy is a quick and convenient way to do this 

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
