### PR TITLE
fix default-apps app template generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Setting `spec.config.configMap` in `app/<cluster-name>-default-apps` for `CAPZ` clusters.
+
 ## [2.36.0] - 2023-05-04
 
 ### Changed

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
+	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	corev1 "k8s.io/api/core/v1"
@@ -457,6 +458,7 @@ func TemplateClusterApp(ctx context.Context, output io.Writer, provider, cluster
 func TemplateDefaultApp(ctx context.Context, output io.Writer, provider, clusterName, clusterOrganization string, clusterApp applicationv1alpha1.App, clusterAppConfigValues map[string]interface{}) error {
 
 	appCR, err := templateapp.NewAppCR(templateapp.Config{
+		Cluster:                 clusterName,
 		AppName:                 fmt.Sprintf("%s-default-apps", clusterName),
 		Catalog:                 clusterApp.Spec.Catalog,
 		InCluster:               true,
@@ -464,6 +466,10 @@ func TemplateDefaultApp(ctx context.Context, output io.Writer, provider, cluster
 		Namespace:               organizationNamespace(clusterOrganization),
 		Version:                 clusterApp.Spec.Version,
 		UserConfigConfigMapName: fmt.Sprintf("%s-default-apps-user-values", clusterName),
+		UseClusterValuesConfig:  true,
+		ExtraLabels: map[string]string{
+			k8smetadata.ManagedBy: "cluster",
+		},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

### What is the effect of this change to users?

```diff
--- .vscode/generated-manifest-current.yaml	2023-05-15 15:54:05.392431214 +0200
+++ .vscode/generated-manifest-new.yaml	2023-05-15 15:59:43.863036035 +0200
@@ -62,14 +62,15 @@
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: jrp45
   name: jrp45-default-apps
   namespace: org-multi-project
 spec:
   catalog: cluster
   config:
     configMap:
-      name: ""
-      namespace: ""
+      name: jrp45-cluster-values
+      namespace: org-multi-project
     secret:
       name: ""
       namespace: ""

```

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Towards the `kube-proxy` replacement powered by Cilium

### What is needed from the reviewers?

Without the auto-generated `-cluster-values` configmap, the mandatory `baseDomain` value doesn't get propagated to the cilium config which is required to run in `kube-proxy`-less mode.

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
