### PR TITLE
Update project.go to fix dev version number

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,10 +1,10 @@
 # Consul - no fix yet
-CVE-2022-29153 until=2023-06-01
-CVE-2021-41803 until=2023-06-01
-sonatype-2022-6522  until=2023-06-01
-CVE-2023-27561 until=2023-06-01
+CVE-2022-29153 until=2023-07-01
+CVE-2021-41803 until=2023-07-01
+sonatype-2022-6522  until=2023-07-01
+CVE-2023-27561 until=2023-07-01
 
 # pkg:golang/k8s.io/apiserver@v0.25.0
 # # This is present in the current latest v0.26.0 as well
-CVE-2020-8561 until=2023-06-01
+CVE-2020-8561 until=2023-07-01
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "kubectl-gs"
 	source      = "https://github.com/giantswarm/kubectl-gs"
-	version     = "2.37.0-dev"
+	version     = "2.37.1-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
This was missing from https://github.com/giantswarm/kubectl-gs/pull/1068