### PR TITLE
vSphere: Fix templating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - App: Rename `nginx-ingress-controller-app` to `ingress-nginx`. ([#1077](https://github.com/giantswarm/kubectl-gs/pull/1077))
+- vSphere: Fix templating. ([#1079](https://github.com/giantswarm/kubectl-gs/pull/1079))
 
 ## [2.37.0] - 2023-05-17
 

--- a/cmd/template/cluster/provider/capv.go
+++ b/cmd/template/cluster/provider/capv.go
@@ -20,6 +20,7 @@ func WriteVSphereTemplate(ctx context.Context, client k8sclient.Interface, out i
 		Organization      string
 		PodsCIDR          string
 		ReleaseVersion    string
+		SSHPublicKeys     []string
 	}{
 		Description:       config.Description,
 		KubernetesVersion: "v1.20.1",
@@ -28,6 +29,7 @@ func WriteVSphereTemplate(ctx context.Context, client k8sclient.Interface, out i
 		Organization:      config.Organization,
 		PodsCIDR:          config.PodsCIDR,
 		ReleaseVersion:    config.ReleaseVersion,
+		SSHPublicKeys:     []string{},
 	}
 
 	var templates []templateConfig

--- a/cmd/template/cluster/provider/templates/vsphere/kubeadm_config_template.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/vsphere/kubeadm_config_template.yaml.tmpl
@@ -26,6 +26,10 @@ spec:
       - echo "{{ `{{ ds.meta_data.hostname }}` }}" >/etc/hostname
       users:
       - name: capv
+        {{ with .SSHPublicKeys }}
         sshAuthorizedKeys:
-        - "{{ .SSHPublicKey }}"
+        {{ range . }}
+        - "{{ . }}"
+        {{ end }}
+        {{ end }}
         sudo: ALL=(ALL) NOPASSWD:ALL

--- a/cmd/template/cluster/provider/templates/vsphere/kubeadm_control_plane.yaml.tmpl
+++ b/cmd/template/cluster/provider/templates/vsphere/kubeadm_control_plane.yaml.tmpl
@@ -86,8 +86,12 @@ spec:
     useExperimentalRetryJoin: true
     users:
     - name: capv
+      {{ with .SSHPublicKeys }}
       sshAuthorizedKeys:
-      - "{{ .SSHPublicKey }}"
+      {{ range . }}
+      - "{{ . }}"
+      {{ end }}
+      {{ end }}
       sudo: ALL=(ALL) NOPASSWD:ALL
   machineTemplate:
     infrastructureRef:


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the templating of cluster manifests for vSphere. Before it failed because the `SSHPublicKey` field was missing in the data object.

### What is the effect of this change to users?

It makes templating vSphere cluster manifests actually possible.

### What does it look like?

Before I got this error:

```
Error: Template: kubeadm_control_plane.yaml.tmpl:90:12: executing "kubeadm_control_plane.yaml.tmpl" at <.SSHPublicKey>: can't evaluate field SSHPublicKey in type struct { Description string; KubernetesVersion string; Name string; Namespace string; Organization string; PodsCIDR string; ReleaseVersion string }
```

Now the cluster manifests are getting rendered properly. Due to the `with` statement, the affected sections look like this:

```
    users:
    - name: capv
      sudo: ALL=(ALL) NOPASSWD:ALL
```

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

Build `kubectl-gs`, test templating on a vSphere installation.

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Nope. 👎
