### PR TITLE
Add minimal support for templating CAPZ clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add minimal support for templating CAPZ clusters
+
 ### Changed
 
 - App: Rename `nginx-ingress-controller-app` to `ingress-nginx`. ([#1077](https://github.com/giantswarm/kubectl-gs/pull/1077))
@@ -35,7 +39,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Stop using old `v1alpha3` version when using CAPI CRDs. 
+- Stop using old `v1alpha3` version when using CAPI CRDs.
 
 ## [2.34.1] - 2023-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Added
+### Breaking changes
 
-- Add minimal support for templating CAPZ clusters
+- Add minimal support for templating CAPZ clusters by command line parameters. This removes `--cluster-config` and `--default-app-config` parameters which required handcrafted YAML input. It leaves one consistent templating option for CAPI products (`kubectl gs template cluster --provider ... --other-params`).
 
 ## [2.38.0] - 2023-06-14
 

--- a/cmd/gitops/add/base/flag.go
+++ b/cmd/gitops/add/base/flag.go
@@ -11,16 +11,21 @@ import (
 )
 
 const (
-	flagProvider = "provider"
+	flagAzureSubscriptionID = "azure-subscription-id"
+	flagProvider            = "provider"
+	flagRegion              = "region"
 )
 
 type flag struct {
-	Provider string
+	Provider            string
+	Region              string
+	AzureSubscriptionID string
 }
 
 func supportedProviders() []string {
 	return []string{
 		key.ProviderCAPA,
+		key.ProviderCAPZ,
 		key.ProviderGCP,
 		key.ProviderOpenStack,
 	}
@@ -28,6 +33,10 @@ func supportedProviders() []string {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", fmt.Sprintf("Installation infrastructure provider, supported values: %s", strings.Join(supportedProviders(), ", ")))
+	cmd.Flags().StringVar(&f.Region, flagRegion, "", "AWS/Azure/GCP region where cluster will be created")
+
+	// Azure only
+	cmd.Flags().StringVar(&f.AzureSubscriptionID, flagAzureSubscriptionID, "", "Azure subscription ID")
 }
 
 func (f *flag) Validate() error {

--- a/cmd/gitops/add/base/runner.go
+++ b/cmd/gitops/add/base/runner.go
@@ -9,6 +9,7 @@ import (
 
 	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
 
+	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capz"
 	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/openstack"
 	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
 	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/base"
@@ -53,7 +54,9 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 
 func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) error {
 	config := common.StructureConfig{
-		Provider: r.flag.Provider,
+		Provider:            r.flag.Provider,
+		Region:              r.flag.Region,
+		AzureSubscriptionID: r.flag.AzureSubscriptionID,
 	}
 
 	var err error
@@ -93,6 +96,8 @@ func generateClusterBaseTemplates(config common.StructureConfig) (common.Cluster
 	switch config.Provider {
 	case key.ProviderCAPA:
 		return generateCapAClusterBaseTemplates(config)
+	case key.ProviderCAPZ:
+		return generateCapZClusterBaseTemplates(config)
 	case key.ProviderGCP:
 		return generateCapGClusterBaseTemplates(config)
 	case key.ProviderOpenStack:
@@ -264,6 +269,52 @@ func generateCapOClusterBaseTemplates(structureConfig common.StructureConfig) (c
 	}
 
 	defaultAppsValues, err := openstack.GenerateDefaultAppsValues(openstack.DefaultAppsConfig{
+		ClusterName:  "${cluster_name}",
+		Organization: "${organization}",
+	})
+
+	if err != nil {
+		return clusterBaseTemplates, err
+	}
+
+	clusterBaseTemplates.ClusterAppCr = clusterAppCr
+	clusterBaseTemplates.ClusterValues = clusterValues
+	clusterBaseTemplates.DefaultAppsAppCr = defaultAppsAppCr
+	clusterBaseTemplates.DefaultAppsValues = defaultAppsValues
+
+	return clusterBaseTemplates, nil
+}
+
+func generateCapZClusterBaseTemplates(structureConfig common.StructureConfig) (common.ClusterBaseTemplates, error) {
+	clusterBaseTemplates := common.ClusterBaseTemplates{}
+
+	clusterAppCr, err := generateClusterAppCrTemplate("cluster-azure")
+
+	if err != nil {
+		return clusterBaseTemplates, err
+	}
+
+	clusterConfig := providers.BuildCapzClusterConfig(providers.ClusterConfig{
+		Name:         "${cluster_name}",
+		Organization: "${organization}",
+		Region:       structureConfig.Region,
+		Azure: providers.AzureConfig{
+			SubscriptionID: structureConfig.AzureSubscriptionID,
+		},
+	})
+	clusterValues, err := capz.GenerateClusterValues(clusterConfig)
+
+	if err != nil {
+		return clusterBaseTemplates, err
+	}
+
+	defaultAppsAppCr, err := generateDefaultAppsAppCrTemplate("default-apps-azure")
+
+	if err != nil {
+		return clusterBaseTemplates, err
+	}
+
+	defaultAppsValues, err := capz.GenerateDefaultAppsValues(capz.DefaultAppsConfig{
 		ClusterName:  "${cluster_name}",
 		Organization: "${organization}",
 	})

--- a/cmd/template/cluster/error.go
+++ b/cmd/template/cluster/error.go
@@ -25,8 +25,3 @@ func IsInvalidFlag(err error) bool {
 var templateFlagNotImplemented = &microerror.Error{
 	Kind: "templateFlagsNotImplementedError",
 }
-
-// IsTemplateFlagNotImplemented asserts templateFlagNotImplemented
-func IsTemplateFlagNotImplemented(err error) bool {
-	return microerror.Cause(err) == templateFlagNotImplemented
-}

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -47,6 +47,9 @@ const (
 	flagAWSMachinePoolRootVolumeSizeGB = "machine-pool-root-volume-size-gb"
 	flagAWSMachinePoolCustomNodeLabels = "machine-pool-custom-node-labels"
 
+	// Azure only
+	flagAzureSubscriptionID = "azure-subscription-id"
+
 	// GCP only.
 	flagGCPProject                               = "gcp-project"
 	flagGCPFailureDomains                        = "gcp-failure-domains"
@@ -141,6 +144,7 @@ type flag struct {
 
 	// Provider-specific
 	AWS       provider.AWSConfig
+	Azure     provider.AzureConfig
 	GCP       provider.GCPConfig
 	OpenStack provider.OpenStackConfig
 	App       provider.AppConfig
@@ -183,6 +187,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.AWS.MachinePool.RootVolumeSizeGB, flagAWSMachinePoolRootVolumeSizeGB, 300, "AWS Machine pool disk size")
 	cmd.Flags().StringSliceVar(&f.AWS.MachinePool.AZs, flagAWSMachinePoolAZs, []string{}, "AWS Machine pool availability zones")
 	cmd.Flags().StringSliceVar(&f.AWS.MachinePool.CustomNodeLabels, flagAWSMachinePoolCustomNodeLabels, []string{}, "AWS Machine pool custom node labels")
+
+	// Azure only
+	cmd.Flags().StringVar(&f.Azure.SubscriptionID, flagAzureSubscriptionID, "", "Azure subscription ID")
 
 	// GCP only.
 	cmd.Flags().StringVar(&f.GCP.Project, flagGCPProject, "", "Google Cloud Platform project name")
@@ -306,7 +313,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Release, flagRelease, "", "Workload cluster release.")
 	cmd.Flags().StringSliceVar(&f.Label, flagLabel, nil, "Workload cluster label.")
 	cmd.Flags().StringVar(&f.ServicePriority, flagServicePriority, label.ServicePriorityHighest, fmt.Sprintf("Service priority of the cluster. Must be one of %v", getServicePriorities()))
-	cmd.Flags().StringVar(&f.Region, flagRegion, "", "AWS region where cluster will be created")
+	cmd.Flags().StringVar(&f.Region, flagRegion, "", "AWS/Azure/GCP region where cluster will be created")
 	// bastion
 	cmd.Flags().StringVar(&f.BastionInstanceType, flagBastionInstanceType, "", "Instance type used for the bastion node.")
 	cmd.Flags().IntVar(&f.BastionReplicas, flagBastionReplicas, 1, "Replica count for the bastion node")

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -112,10 +112,6 @@ const (
 	flagRelease                  = "release"
 	flagLabel                    = "label"
 	flagServicePriority          = "service-priority"
-
-	// new YAML
-	flagClusterAppYaml = "cluster-config"
-	flagDefaultAppYaml = "default-app-config"
 )
 
 type flag struct {
@@ -138,10 +134,6 @@ type flag struct {
 	ControlPlaneInstanceType string
 	ServicePriority          string
 
-	// new YAML
-	ClusterAppConfigYAML string
-	DefaultAppConfigYAML string
-
 	// Provider-specific
 	AWS       provider.AWSConfig
 	Azure     provider.AzureConfig
@@ -156,10 +148,6 @@ type flag struct {
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.EnableLongNames, flagEnableLongNames, true, "Allow long names.")
 	cmd.Flags().StringVar(&f.Provider, flagProvider, "", "Installation infrastructure provider.")
-
-	// new YAML
-	cmd.Flags().StringVar(&f.ClusterAppConfigYAML, flagClusterAppYaml, "", "cluster yaml config.")
-	cmd.Flags().StringVar(&f.DefaultAppConfigYAML, flagDefaultAppYaml, "", "default app yaml config.")
 
 	// AWS only.
 	cmd.Flags().StringVar(&f.AWS.AWSClusterRoleIdentityName, flagAWSClusterRoleIdentityName, "", "Name of the AWSClusterRoleIdentity that will be used for cluster creation.")
@@ -370,128 +358,124 @@ func (f *flag) Validate() error {
 		}
 	}
 
-	if f.ClusterAppConfigYAML == "" {
+	if f.PodsCIDR != "" {
+		if !validateCIDR(f.PodsCIDR) {
+			return microerror.Maskf(invalidFlagError, "--%s must be a valid CIDR", flagPodsCIDR)
+		}
+	}
 
-		if f.PodsCIDR != "" {
-			if !validateCIDR(f.PodsCIDR) {
-				return microerror.Maskf(invalidFlagError, "--%s must be a valid CIDR", flagPodsCIDR)
+	if f.Organization == "" {
+		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagOrganization)
+	}
+
+	{
+		// Validate Master AZs.
+		switch f.Provider {
+		case key.ProviderAWS:
+			if len(f.ControlPlaneAZ) != 0 && len(f.ControlPlaneAZ) != 1 && len(f.ControlPlaneAZ) != 3 {
+				return microerror.Maskf(invalidFlagError, "--%s must be set to either one or three availability zone names", flagControlPlaneAZ)
 			}
-		}
-
-		if f.Organization == "" {
-			return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagOrganization)
-		}
-
-		{
-			// Validate Master AZs.
-			switch f.Provider {
-			case key.ProviderAWS:
-				if len(f.ControlPlaneAZ) != 0 && len(f.ControlPlaneAZ) != 1 && len(f.ControlPlaneAZ) != 3 {
-					return microerror.Maskf(invalidFlagError, "--%s must be set to either one or three availability zone names", flagControlPlaneAZ)
-				}
-				if f.AWS.ControlPlaneSubnet != "" {
-					matchedSubnet, err := regexp.MatchString("^20|21|22|23|24|25$", f.AWS.ControlPlaneSubnet)
-					if err == nil && !matchedSubnet {
-						return microerror.Maskf(invalidFlagError, "--%s must be a valid subnet size (20, 21, 22, 23, 24 or 25)", flagAWSControlPlaneSubnet)
-					}
-				}
-			case key.ProviderGCP:
-				if f.Region == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagRegion)
-				}
-				if f.GCP.Project == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagGCPProject)
-				}
-				if f.GCP.FailureDomains == nil {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagGCPFailureDomains)
-				}
-			case key.ProviderAzure:
-				if len(f.ControlPlaneAZ) > 1 {
-					return microerror.Maskf(invalidFlagError, "--%s supports one availability zone only", flagControlPlaneAZ)
-				}
-			case key.ProviderOpenStack:
-				if f.OpenStack.Cloud == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackCloud)
-				}
-				if f.OpenStack.CloudConfig == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackCloudConfig)
-				}
-				if f.OpenStack.ExternalNetworkID == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackExternalNetworkID)
-				}
-				if f.OpenStack.NodeCIDR != "" {
-					if f.OpenStack.NetworkName != "" || f.OpenStack.SubnetName != "" {
-						return microerror.Maskf(invalidFlagError, "--%s and --%s must be empty when --%s is used",
-							flagOpenStackNetworkName, flagOpenStackSubnetName, flagOpenStackNodeCIDR)
-					}
-					if !validateCIDR(f.OpenStack.NodeCIDR) {
-						return microerror.Maskf(invalidFlagError, "--%s must be a valid CIDR", flagOpenStackNodeCIDR)
-					}
-				} else {
-					if f.OpenStack.NetworkName == "" || f.OpenStack.SubnetName == "" {
-						return microerror.Maskf(invalidFlagError, "--%s and --%s must be set when --%s is empty",
-							flagOpenStackNetworkName, flagOpenStackSubnetName, flagOpenStackNodeCIDR)
-					}
-				}
-				// bastion
-				if f.OpenStack.Bastion.BootFromVolume && f.OpenStack.Bastion.DiskSize < 1 {
-					return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackBastionDiskSize, flagOpenStackBastionBootFromVolume)
-				}
-				if f.OpenStack.Bastion.Flavor == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackBastionMachineFlavor)
-				}
-				if f.OpenStack.Bastion.Image == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackBastionImage)
-				}
-				// control plane
-				if f.OpenStack.ControlPlane.BootFromVolume && f.OpenStack.ControlPlane.DiskSize < 1 {
-					return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackControlPlaneDiskSize, flagOpenStackControlPlaneBootFromVolume)
-				}
-				if f.OpenStack.ControlPlane.Flavor == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackControlPlaneMachineFlavor)
-				}
-				if f.OpenStack.ControlPlane.Image == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackControlPlaneImage)
-				}
-				// worker
-				if f.OpenStack.WorkerReplicas < 1 {
-					return microerror.Maskf(invalidFlagError, "--%s must be greater than 0", flagOpenStackWorkerReplicas)
-				}
-				if f.OpenStack.WorkerFailureDomain == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerFailureDomain)
-				}
-				if len(f.ControlPlaneAZ) != 0 {
-					if len(f.ControlPlaneAZ)%2 != 1 {
-						return microerror.Maskf(invalidFlagError, "--%s must be an odd number number of values (usually 1 or 3 for non-HA and HA respectively)", flagControlPlaneAZ)
-					}
-
-					var validFailureDomain bool
-					for _, az := range f.ControlPlaneAZ {
-						if f.OpenStack.WorkerFailureDomain == az {
-							validFailureDomain = true
-							break
-						}
-					}
-
-					if !validFailureDomain {
-						return microerror.Maskf(invalidFlagError, "--%s must be among the AZs specified with --%s", flagOpenStackWorkerFailureDomain, flagControlPlaneAZ)
-					}
-				}
-				if f.OpenStack.Worker.BootFromVolume && f.OpenStack.Worker.DiskSize < 1 {
-					return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackWorkerDiskSize, flagOpenStackWorkerBootFromVolume)
-				}
-				if f.OpenStack.Worker.Flavor == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerMachineFlavor)
-				}
-				if f.OpenStack.Worker.Image == "" {
-					return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerImage)
-				}
-			case key.ProviderCAPA:
-				if f.AWS.ClusterType == "proxy-private" && (f.AWS.HttpsProxy == "" || f.AWS.NetworkVPCCIDR == "") {
-					return microerror.Maskf(invalidFlagError, "--%s and --%s are required when proxy-private is selected", flagAWSHttpsProxy, flagNetworkVPCCidr)
+			if f.AWS.ControlPlaneSubnet != "" {
+				matchedSubnet, err := regexp.MatchString("^20|21|22|23|24|25$", f.AWS.ControlPlaneSubnet)
+				if err == nil && !matchedSubnet {
+					return microerror.Maskf(invalidFlagError, "--%s must be a valid subnet size (20, 21, 22, 23, 24 or 25)", flagAWSControlPlaneSubnet)
 				}
 			}
+		case key.ProviderGCP:
+			if f.Region == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagRegion)
+			}
+			if f.GCP.Project == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagGCPProject)
+			}
+			if f.GCP.FailureDomains == nil {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagGCPFailureDomains)
+			}
+		case key.ProviderAzure:
+			if len(f.ControlPlaneAZ) > 1 {
+				return microerror.Maskf(invalidFlagError, "--%s supports one availability zone only", flagControlPlaneAZ)
+			}
+		case key.ProviderOpenStack:
+			if f.OpenStack.Cloud == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackCloud)
+			}
+			if f.OpenStack.CloudConfig == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackCloudConfig)
+			}
+			if f.OpenStack.ExternalNetworkID == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackExternalNetworkID)
+			}
+			if f.OpenStack.NodeCIDR != "" {
+				if f.OpenStack.NetworkName != "" || f.OpenStack.SubnetName != "" {
+					return microerror.Maskf(invalidFlagError, "--%s and --%s must be empty when --%s is used",
+						flagOpenStackNetworkName, flagOpenStackSubnetName, flagOpenStackNodeCIDR)
+				}
+				if !validateCIDR(f.OpenStack.NodeCIDR) {
+					return microerror.Maskf(invalidFlagError, "--%s must be a valid CIDR", flagOpenStackNodeCIDR)
+				}
+			} else {
+				if f.OpenStack.NetworkName == "" || f.OpenStack.SubnetName == "" {
+					return microerror.Maskf(invalidFlagError, "--%s and --%s must be set when --%s is empty",
+						flagOpenStackNetworkName, flagOpenStackSubnetName, flagOpenStackNodeCIDR)
+				}
+			}
+			// bastion
+			if f.OpenStack.Bastion.BootFromVolume && f.OpenStack.Bastion.DiskSize < 1 {
+				return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackBastionDiskSize, flagOpenStackBastionBootFromVolume)
+			}
+			if f.OpenStack.Bastion.Flavor == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackBastionMachineFlavor)
+			}
+			if f.OpenStack.Bastion.Image == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackBastionImage)
+			}
+			// control plane
+			if f.OpenStack.ControlPlane.BootFromVolume && f.OpenStack.ControlPlane.DiskSize < 1 {
+				return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackControlPlaneDiskSize, flagOpenStackControlPlaneBootFromVolume)
+			}
+			if f.OpenStack.ControlPlane.Flavor == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackControlPlaneMachineFlavor)
+			}
+			if f.OpenStack.ControlPlane.Image == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackControlPlaneImage)
+			}
+			// worker
+			if f.OpenStack.WorkerReplicas < 1 {
+				return microerror.Maskf(invalidFlagError, "--%s must be greater than 0", flagOpenStackWorkerReplicas)
+			}
+			if f.OpenStack.WorkerFailureDomain == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerFailureDomain)
+			}
+			if len(f.ControlPlaneAZ) != 0 {
+				if len(f.ControlPlaneAZ)%2 != 1 {
+					return microerror.Maskf(invalidFlagError, "--%s must be an odd number number of values (usually 1 or 3 for non-HA and HA respectively)", flagControlPlaneAZ)
+				}
 
+				var validFailureDomain bool
+				for _, az := range f.ControlPlaneAZ {
+					if f.OpenStack.WorkerFailureDomain == az {
+						validFailureDomain = true
+						break
+					}
+				}
+
+				if !validFailureDomain {
+					return microerror.Maskf(invalidFlagError, "--%s must be among the AZs specified with --%s", flagOpenStackWorkerFailureDomain, flagControlPlaneAZ)
+				}
+			}
+			if f.OpenStack.Worker.BootFromVolume && f.OpenStack.Worker.DiskSize < 1 {
+				return microerror.Maskf(invalidFlagError, "--%s must be greater than 0 when --%s is specified", flagOpenStackWorkerDiskSize, flagOpenStackWorkerBootFromVolume)
+			}
+			if f.OpenStack.Worker.Flavor == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerMachineFlavor)
+			}
+			if f.OpenStack.Worker.Image == "" {
+				return microerror.Maskf(invalidFlagError, "--%s is required", flagOpenStackWorkerImage)
+			}
+		case key.ProviderCAPA:
+			if f.AWS.ClusterType == "proxy-private" && (f.AWS.HttpsProxy == "" || f.AWS.NetworkVPCCIDR == "") {
+				return microerror.Maskf(invalidFlagError, "--%s and --%s are required when proxy-private is selected", flagAWSHttpsProxy, flagNetworkVPCCidr)
+			}
 		}
 
 		if f.Release == "" {

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	DefaultAppsRepoName = "default-apps-aws"
-	ClusterAWSRepoName  = "cluster-aws"
-	ModePrivate         = "private"
+	DefaultAppsAWSRepoName = "default-apps-aws"
+	ClusterAWSRepoName     = "cluster-aws"
+	ModePrivate            = "private"
 )
 
 func WriteCAPATemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
@@ -279,7 +279,7 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 		appVersion := config.App.DefaultAppsVersion
 		if appVersion == "" {
 			var err error
-			appVersion, err = getLatestVersion(ctx, k8sClient.CtrlClient(), DefaultAppsRepoName, config.App.DefaultAppsCatalog)
+			appVersion, err = getLatestVersion(ctx, k8sClient.CtrlClient(), DefaultAppsAWSRepoName, config.App.DefaultAppsCatalog)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -292,7 +292,7 @@ func templateDefaultAppsAWS(ctx context.Context, k8sClient k8sclient.Interface, 
 			Catalog:                 config.App.DefaultAppsCatalog,
 			DefaultingEnabled:       false,
 			InCluster:               true,
-			Name:                    DefaultAppsRepoName,
+			Name:                    DefaultAppsAWSRepoName,
 			Namespace:               organizationNamespace(config.Organization),
 			Version:                 appVersion,
 			UserConfigConfigMapName: configMapName,

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -1,0 +1,200 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/template"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/yaml"
+
+	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
+
+	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capz"
+	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+)
+
+const (
+	DefaultAppsAzureRepoName = "default-apps-azure"
+	ClusterAzureRepoName     = "cluster-azure"
+)
+
+func WriteCAPZTemplate(ctx context.Context, client k8sclient.Interface, output io.Writer, config ClusterConfig) error {
+	err := templateClusterCAPZ(ctx, client, output, config)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = templateDefaultAppsAzure(ctx, client, output, config)
+	return microerror.Mask(err)
+}
+
+func templateClusterCAPZ(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
+	appName := config.Name
+	configMapName := userConfigMapName(appName)
+
+	var configMapYAML []byte
+	{
+		flagValues := BuildCapzClusterConfig(config)
+
+		configData, err := capz.GenerateClusterValues(flagValues)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		userConfigMap, err := templateapp.NewConfigMap(templateapp.UserConfig{
+			Name:      configMapName,
+			Namespace: organizationNamespace(config.Organization),
+			Data:      configData,
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
+
+		configMapYAML, err = yaml.Marshal(userConfigMap)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var appYAML []byte
+	{
+		appVersion := config.App.ClusterVersion
+		if appVersion == "" {
+			var err error
+			appVersion, err = getLatestVersion(ctx, k8sClient.CtrlClient(), ClusterAzureRepoName, config.App.ClusterCatalog)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		clusterAppConfig := templateapp.Config{
+			AppName:                 config.Name,
+			Catalog:                 config.App.ClusterCatalog,
+			InCluster:               true,
+			Name:                    ClusterAzureRepoName,
+			Namespace:               organizationNamespace(config.Organization),
+			Version:                 appVersion,
+			UserConfigConfigMapName: configMapName,
+		}
+
+		var err error
+		appYAML, err = templateapp.NewAppCR(clusterAppConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	t := template.Must(template.New("appCR").Parse(key.AppCRTemplate))
+
+	err := t.Execute(output, templateapp.AppCROutput{
+		AppCR:               string(appYAML),
+		UserConfigConfigMap: string(configMapYAML),
+	})
+	return microerror.Mask(err)
+}
+
+func BuildCapzClusterConfig(config ClusterConfig) capz.ClusterConfig {
+	return capz.ClusterConfig{
+		Metadata: &capz.Metadata{
+			Name:         config.Name,
+			Description:  config.Description,
+			Organization: config.Organization,
+		},
+		ProviderSpecific: &capz.ProviderSpecific{
+			Location:       config.Region,
+			SubscriptionID: config.Azure.SubscriptionID,
+		},
+		Connectivity: &capz.Connectivity{
+			Bastion: &capz.Bastion{
+				Enabled:      true,
+				InstanceType: config.BastionInstanceType,
+			},
+		},
+		ControlPlane: &capz.ControlPlane{
+			InstanceType: config.ControlPlaneInstanceType,
+			Replicas:     3,
+		},
+	}
+}
+
+func templateDefaultAppsAzure(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {
+	appName := fmt.Sprintf("%s-default-apps", config.Name)
+	configMapName := userConfigMapName(appName)
+
+	var configMapYAML []byte
+	{
+		flagValues := capz.DefaultAppsConfig{
+			ClusterName:  config.Name,
+			Organization: config.Organization,
+		}
+
+		configData, err := capz.GenerateDefaultAppsValues(flagValues)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		userConfigMap, err := templateapp.NewConfigMap(templateapp.UserConfig{
+			Name:      configMapName,
+			Namespace: organizationNamespace(config.Organization),
+			Data:      configData,
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		userConfigMap.Labels = map[string]string{}
+		userConfigMap.Labels[k8smetadata.Cluster] = config.Name
+
+		configMapYAML, err = yaml.Marshal(userConfigMap)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var appYAML []byte
+	{
+		appVersion := config.App.DefaultAppsVersion
+		if appVersion == "" {
+			var err error
+			appVersion, err = getLatestVersion(ctx, k8sClient.CtrlClient(), DefaultAppsAzureRepoName, config.App.DefaultAppsCatalog)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		var err error
+		appYAML, err = templateapp.NewAppCR(templateapp.Config{
+			AppName:                 appName,
+			Cluster:                 config.Name,
+			Catalog:                 config.App.DefaultAppsCatalog,
+			DefaultingEnabled:       false,
+			InCluster:               true,
+			Name:                    DefaultAppsAzureRepoName,
+			Namespace:               organizationNamespace(config.Organization),
+			Version:                 appVersion,
+			UserConfigConfigMapName: configMapName,
+			UseClusterValuesConfig:  true,
+			ExtraLabels: map[string]string{
+				k8smetadata.ManagedBy: "cluster",
+			},
+		})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	t := template.Must(template.New("appCR").Parse(key.AppCRTemplate))
+
+	err := t.Execute(output, templateapp.AppCROutput{
+		UserConfigConfigMap: string(configMapYAML),
+		AppCR:               string(appYAML),
+	})
+	return microerror.Mask(err)
+}

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -66,6 +66,10 @@ type AWSMachinePoolConfig struct {
 	CustomNodeLabels []string
 }
 
+type AzureConfig struct {
+	SubscriptionID string
+}
+
 type GCPConfig struct {
 	Project           string
 	FailureDomains    []string
@@ -146,6 +150,7 @@ type ClusterConfig struct {
 
 	App       AppConfig
 	AWS       AWSConfig
+	Azure     AzureConfig
 	GCP       GCPConfig
 	OpenStack OpenStackConfig
 }

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
-	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	corev1 "k8s.io/api/core/v1"
@@ -29,9 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/app"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
 )
 
 type AWSConfig struct {
@@ -360,155 +357,6 @@ func ValidateYAML(ctx context.Context, logger micrologger.Logger, client k8sclie
 		}
 		// return all validation errors
 		return microerror.Mask(fmt.Errorf(strings.Join(validationErrors, "; ")))
-	}
-
-	return nil
-}
-
-func GetClusterApp(ctx context.Context, client k8sclient.Interface, capiProvider, clusterAppCatalog, clusterAppVersion string) (applicationv1alpha1.App, error) {
-
-	clusterApp := applicationv1alpha1.App{}
-
-	clusterApp.Spec.Catalog = clusterAppCatalog
-
-	clusterApp.Spec.Name = key.CAPIClusterApps(capiProvider)
-
-	if clusterAppVersion == "" {
-		latestAppVersion, err := getLatestVersion(ctx, client.CtrlClient(), clusterApp.Spec.Name, clusterApp.Spec.Catalog)
-		if err != nil {
-			return clusterApp, microerror.Mask(err)
-		}
-		clusterApp.Spec.Version = latestAppVersion
-	} else {
-		clusterApp.Spec.Version = clusterAppVersion
-	}
-
-	return clusterApp, nil
-
-}
-
-func GetDefaultApp(ctx context.Context, client k8sclient.Interface, capiProvider, clusterAppCatalog, clusterAppVersion string) (applicationv1alpha1.App, error) {
-
-	clusterApp := applicationv1alpha1.App{}
-
-	clusterApp.Spec.Catalog = clusterAppCatalog
-
-	clusterApp.Spec.Name = key.CAPIDefaultApps(capiProvider)
-
-	if clusterAppVersion == "" {
-		latestAppVersion, err := getLatestVersion(ctx, client.CtrlClient(), clusterApp.Spec.Name, clusterApp.Spec.Catalog)
-		if err != nil {
-			return clusterApp, microerror.Mask(err)
-		}
-		clusterApp.Spec.Version = latestAppVersion
-	} else {
-		clusterApp.Spec.Version = clusterAppVersion
-	}
-
-	return clusterApp, nil
-
-}
-
-// templateClusterApp templates the Cluster app
-func TemplateClusterApp(ctx context.Context, output io.Writer, provider, clusterName, clusterOrganization string, clusterApp applicationv1alpha1.App, clusterAppConfigValues map[string]interface{}) error {
-
-	appCR, err := templateapp.NewAppCR(templateapp.Config{
-		AppName:                 clusterName, // should be probably the name from the flag aka the name of my cluster
-		Catalog:                 clusterApp.Spec.Catalog,
-		InCluster:               true,
-		Name:                    clusterApp.Spec.Name,                       // should be hardcoeded
-		Namespace:               organizationNamespace(clusterOrganization), // should be the name of the org given by the flag
-		Version:                 clusterApp.Spec.Version,
-		UserConfigConfigMapName: fmt.Sprintf("%s-user-values", clusterName),
-	})
-	if err != nil {
-		return err
-	}
-
-	// marshal the given raw
-	clusterAppConfigYAML, err := yaml.Marshal(clusterAppConfigValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	clusterAppConfigMap, err := templateapp.NewConfigMap(templateapp.UserConfig{
-		Name:      fmt.Sprintf("%s-user-values", clusterName),
-		Namespace: organizationNamespace(clusterOrganization),
-		Data:      string(clusterAppConfigYAML),
-	})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	// marshal the generated cluster specific config map for later templating
-	clusterAppConfigMapRaw, err := yaml.Marshal(clusterAppConfigMap)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	t := template.Must(template.New("appCR").Parse(key.AppCRTemplate))
-
-	err = t.Execute(output, templateapp.AppCROutput{
-		AppCR:               string(appCR),
-		UserConfigConfigMap: string(clusterAppConfigMapRaw),
-	})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	return nil
-}
-
-// templateClusterApp templates the Cluster app
-func TemplateDefaultApp(ctx context.Context, output io.Writer, provider, clusterName, clusterOrganization string, clusterApp applicationv1alpha1.App, clusterAppConfigValues map[string]interface{}) error {
-
-	appCR, err := templateapp.NewAppCR(templateapp.Config{
-		Cluster:                 clusterName,
-		AppName:                 fmt.Sprintf("%s-default-apps", clusterName),
-		Catalog:                 clusterApp.Spec.Catalog,
-		InCluster:               true,
-		Name:                    clusterApp.Spec.Name,
-		Namespace:               organizationNamespace(clusterOrganization),
-		Version:                 clusterApp.Spec.Version,
-		UserConfigConfigMapName: fmt.Sprintf("%s-default-apps-user-values", clusterName),
-		UseClusterValuesConfig:  true,
-		ExtraLabels: map[string]string{
-			k8smetadata.ManagedBy: "cluster",
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	// marshal the given raw
-	clusterAppConfigYAML, err := yaml.Marshal(clusterAppConfigValues)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	clusterAppConfigMap, err := templateapp.NewConfigMap(templateapp.UserConfig{
-		Name:      fmt.Sprintf("%s-default-apps-user-values", clusterName),
-		Namespace: organizationNamespace(clusterOrganization),
-		Data:      string(clusterAppConfigYAML),
-	})
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	// marshal the generated cluster specific config map for later templating
-	clusterAppConfigMapRaw, err := yaml.Marshal(clusterAppConfigMap)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	t := template.Must(template.New("appCR").Parse(key.AppCRTemplate))
-
-	err = t.Execute(output, templateapp.AppCROutput{
-		AppCR:               string(appCR),
-		UserConfigConfigMap: string(clusterAppConfigMapRaw),
-	})
-	if err != nil {
-		return microerror.Mask(err)
 	}
 
 	return nil

--- a/cmd/template/cluster/provider/templates/capz/functions.go
+++ b/cmd/template/cluster/provider/templates/capz/functions.go
@@ -1,0 +1,61 @@
+package capz
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/yaml"
+)
+
+func GenerateClusterValues(flagInputs ClusterConfig) (string, error) {
+	var flagConfigData map[string]interface{}
+
+	if flagInputs.ProviderSpecific.Location == "" {
+		return "", fmt.Errorf("region is required (--region)")
+	}
+	if flagInputs.ProviderSpecific.SubscriptionID == "" {
+		return "", fmt.Errorf("subscription ID is required for Azure (--azure-subscription-id)")
+	}
+
+	{
+		flagConfigYAML, err := yaml.Marshal(flagInputs)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = yaml.Unmarshal(flagConfigYAML, &flagConfigData)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	finalConfigString, err := yaml.Marshal(flagInputs)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(finalConfigString), nil
+}
+
+func GenerateDefaultAppsValues(flagConfig DefaultAppsConfig) (string, error) {
+	var flagConfigData map[string]interface{}
+
+	{
+		flagConfigYAML, err := yaml.Marshal(flagConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = yaml.Unmarshal(flagConfigYAML, &flagConfigData)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	finalConfigString, err := yaml.Marshal(flagConfigData)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return string(finalConfigString), nil
+}

--- a/cmd/template/cluster/provider/templates/capz/types.go
+++ b/cmd/template/cluster/provider/templates/capz/types.go
@@ -1,0 +1,38 @@
+package capz
+
+type ClusterConfig struct {
+	Connectivity     *Connectivity     `json:"connectivity,omitempty"`
+	ControlPlane     *ControlPlane     `json:"controlPlane,omitempty"`
+	Metadata         *Metadata         `json:"metadata,omitempty"`
+	ProviderSpecific *ProviderSpecific `json:"providerSpecific,omitempty"`
+}
+
+type Metadata struct {
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Organization string `json:"organization,omitempty"`
+}
+
+type DefaultAppsConfig struct {
+	ClusterName  string `json:"clusterName,omitempty"`
+	Organization string `json:"organization,omitempty"`
+}
+
+type ProviderSpecific struct {
+	Location       string `json:"location,omitempty"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+}
+
+type Connectivity struct {
+	Bastion *Bastion `json:"bastion,omitempty"`
+}
+
+type Bastion struct {
+	Enabled      bool   `json:"enabled,omitempty"`
+	InstanceType string `json:"instanceType,omitempty"`
+}
+
+type ControlPlane struct {
+	InstanceType string `json:"instanceType,omitempty"`
+	Replicas     int    `json:"replicas,omitempty"`
+}

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -91,6 +91,11 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 			if err != nil {
 				return microerror.Mask(err)
 			}
+		case key.ProviderCAPZ:
+			err = provider.WriteCAPZTemplate(ctx, client, output, config)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 		case key.ProviderGCP:
 			err = provider.WriteGCPTemplate(ctx, client, output, config)
 			if err != nil {
@@ -176,6 +181,7 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 
 		App:       r.flag.App,
 		AWS:       r.flag.AWS,
+		Azure:     r.flag.Azure,
 		GCP:       r.flag.GCP,
 		OIDC:      r.flag.OIDC,
 		OpenStack: r.flag.OpenStack,

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -13,7 +12,6 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider"
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
@@ -27,9 +25,6 @@ type runner struct {
 	logger       micrologger.Logger
 	stdout       io.Writer
 	stderr       io.Writer
-
-	clusterName         string
-	clusterOrganization string
 }
 
 func (r *runner) Run(cmd *cobra.Command, args []string) error {
@@ -69,97 +64,49 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 		output = outFile
 	}
 
-	if r.flag.ClusterAppConfigYAML == "" && r.flag.DefaultAppConfigYAML == "" {
-		config, err := r.getClusterConfig()
+	config, err := r.getClusterConfig()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	switch r.flag.Provider {
+	case key.ProviderAWS:
+		err = provider.WriteAWSTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		switch r.flag.Provider {
-		case key.ProviderAWS:
-			err = provider.WriteAWSTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderAzure:
-			err = provider.WriteAzureTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderCAPA:
-			err = provider.WriteCAPATemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderCAPZ:
-			err = provider.WriteCAPZTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderGCP:
-			err = provider.WriteGCPTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderOpenStack:
-			err = provider.WriteOpenStackTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		case key.ProviderVSphere:
-			err = provider.WriteVSphereTemplate(ctx, client, output, config)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-		default:
-			return microerror.Mask(templateFlagNotImplemented)
-		}
-	} else {
-		// read given cluster yaml
-		clusterAppConfig, err := r.getClusterYAML()
+	case key.ProviderAzure:
+		err = provider.WriteAzureTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		clusterApp, err := provider.GetClusterApp(ctx, client, r.flag.Provider, r.flag.App.ClusterCatalog, r.flag.App.ClusterVersion)
+	case key.ProviderCAPA:
+		err = provider.WriteCAPATemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		// validate given yaml against cluster-azure app values schema
-		err = provider.ValidateYAML(ctx, r.logger, client, clusterApp, clusterAppConfig)
+	case key.ProviderCAPZ:
+		err = provider.WriteCAPZTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		// template cluster app
-		err = provider.TemplateClusterApp(ctx, output, r.flag.Provider, r.clusterName, r.clusterOrganization, clusterApp, clusterAppConfig)
+	case key.ProviderGCP:
+		err = provider.WriteGCPTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		// read given cluster yaml
-		defaultAppConfig, err := r.getDefaultAppYAML()
+	case key.ProviderOpenStack:
+		err = provider.WriteOpenStackTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		clusterDefaultApp, err := provider.GetDefaultApp(ctx, client, r.flag.Provider, r.flag.App.DefaultAppsCatalog, r.flag.App.DefaultAppsVersion)
+	case key.ProviderVSphere:
+		err = provider.WriteVSphereTemplate(ctx, client, output, config)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		// validate given yaml against cluster-azure app values schema
-		err = provider.ValidateYAML(ctx, r.logger, client, clusterDefaultApp, defaultAppConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		err = provider.TemplateDefaultApp(ctx, output, r.flag.Provider, r.clusterName, r.clusterOrganization, clusterDefaultApp, defaultAppConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
+	default:
+		return microerror.Mask(templateFlagNotImplemented)
 	}
 
 	return nil
@@ -210,58 +157,4 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 	}
 
 	return config, nil
-}
-
-// getClusterYAML reads the given cluster yaml file
-// and overwrite some metadata fields if --name and/or --organization is set
-func (r *runner) getClusterYAML() (map[string]interface{}, error) {
-	yamlFile, err := os.ReadFile(r.flag.ClusterAppConfigYAML)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	var yamlConfig map[string]interface{}
-
-	err = yaml.Unmarshal(yamlFile, &yamlConfig)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	// overwrite metadata information from flags if given
-	if r.flag.Name != "" {
-		yamlConfig["metadata"].(map[string]interface{})["name"] = r.flag.Name
-		yamlConfig["metadata"].(map[string]interface{})["description"] = r.flag.Name + " cluster"
-		r.clusterName = fmt.Sprintf("%v", yamlConfig["metadata"].(map[string]interface{})["name"])
-	} else {
-		r.clusterName = fmt.Sprintf("%v", yamlConfig["metadata"].(map[string]interface{})["name"])
-	}
-	if r.flag.Organization != "" {
-		yamlConfig["metadata"].(map[string]interface{})["organization"] = r.flag.Organization
-		r.clusterOrganization = fmt.Sprintf("%v", yamlConfig["metadata"].(map[string]interface{})["organization"])
-	} else {
-		r.clusterOrganization = fmt.Sprintf("%v", yamlConfig["metadata"].(map[string]interface{})["organization"])
-	}
-
-	return yamlConfig, nil
-}
-
-// getDefaultAppYAML reads the given cluster yaml file
-// and overwrite some metadata fields if --name and/or --organization is set
-func (r *runner) getDefaultAppYAML() (map[string]interface{}, error) {
-	yamlFile, err := os.ReadFile(r.flag.DefaultAppConfigYAML)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	var yamlConfig map[string]interface{}
-
-	err = yaml.Unmarshal(yamlFile, &yamlConfig)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	yamlConfig["clusterName"] = r.clusterName
-	yamlConfig["organization"] = r.clusterOrganization
-
-	return yamlConfig, nil
 }

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -179,6 +179,28 @@ func Test_run(t *testing.T) {
 			args:               nil,
 			expectedGoldenFile: "run_template_cluster_capa_3.golden",
 		},
+		{
+			name: "case 4: template cluster capz",
+			flags: &flag{
+				Name:                     "test1",
+				Provider:                 "capz",
+				Description:              "just a test cluster",
+				Region:                   "northeurope",
+				Organization:             "test",
+				ControlPlaneInstanceType: "B2s",
+				App: provider.AppConfig{
+					ClusterVersion:     "1.0.0",
+					ClusterCatalog:     "the-catalog",
+					DefaultAppsCatalog: "the-default-catalog",
+					DefaultAppsVersion: "2.0.0",
+				},
+				Azure: provider.AzureConfig{
+					SubscriptionID: "12345678-ebb8-4b1f-8f96-d950d9e7aaaa",
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_capz.golden",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/template/cluster/testdata/run_template_cluster_capz.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capz.golden
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+data:
+  values: |
+    connectivity:
+      bastion:
+        enabled: true
+    controlPlane:
+      instanceType: B2s
+      replicas: 3
+    metadata:
+      description: just a test cluster
+      name: test1
+      organization: test
+    providerSpecific:
+      location: northeurope
+      subscriptionId: 12345678-ebb8-4b1f-8f96-d950d9e7aaaa
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    giantswarm.io/cluster: test1
+  name: test1-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: test1
+  namespace: org-test
+spec:
+  catalog: the-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: cluster-azure
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test1-userconfig
+      namespace: org-test
+  version: 1.0.0
+---
+apiVersion: v1
+data:
+  values: |
+    clusterName: test1
+    organization: test
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    giantswarm.io/cluster: test1
+  name: test1-default-apps-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: test1
+    giantswarm.io/managed-by: cluster
+  name: test1-default-apps
+  namespace: org-test
+spec:
+  catalog: the-default-catalog
+  config:
+    configMap:
+      name: test1-cluster-values
+      namespace: org-test
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: default-apps-azure
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test1-default-apps-userconfig
+      namespace: org-test
+  version: 2.0.0

--- a/internal/gitops/structure/common/types.go
+++ b/internal/gitops/structure/common/types.go
@@ -40,6 +40,11 @@ type StructureConfig struct {
 	RepositoryName    string
 	SkipMAPI          bool
 	WorkloadCluster   string
+
+	Region string
+
+	// Azure only
+	AzureSubscriptionID string
 }
 
 type ClusterBaseTemplates struct {

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -1,7 +1,5 @@
 package key
 
-import "fmt"
-
 const (
 	ProviderAWS           = "aws"
 	ProviderAzure         = "azure"
@@ -40,26 +38,4 @@ func PureCAPIProviders() []string {
 		ProviderOpenStack,
 		ProviderCloudDirector,
 	}
-}
-
-// CAPIProviderApps return the provider specific apps
-func CAPIClusterApps(CAPIProvider string) string {
-
-	switch CAPIProvider {
-	case ProviderCAPZ:
-		return fmt.Sprintf("%s-%s", ProviderClusterAppPrefix, ProviderCAPZAppSuffix)
-	}
-
-	return ""
-}
-
-// CAPIProviderApps return the provider specific apps
-func CAPIDefaultApps(CAPIProvider string) string {
-
-	switch CAPIProvider {
-	case ProviderCAPZ:
-		return fmt.Sprintf("%s-%s", ProviderDefaultAppPrefix, ProviderCAPZAppSuffix)
-	}
-
-	return ""
 }


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/525

### What is the effect of this change to users?

None, since cluster templating for CAPZ wasn't a supported feature before

### What does it look like?

This minimal command now works:

```
kubectl gs template cluster --provider capz --organization testing --name bam --region westeurope --azure-subscription-id 00000000-0000-0000-0000-000000000000
```

### Any background context you can provide?

Mainly to make our "Create a workload cluster" documentation consistent, since I'm currently working on that (https://github.com/giantswarm/roadmap/issues/2393)

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No