### PR TITLE
Sanitize input yaml files parsed for config map data

### DIFF
--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -152,7 +152,23 @@ func ReadConfigMapYamlFromFile(fs afero.Fs, path string) (string, error) {
 		return "", microerror.Maskf(unmashalToMapFailedError, err.Error())
 	}
 
-	return string(data), nil
+	return sanitize(string(data)), nil
+}
+
+// Sanitize input yaml files
+//
+// Trim spaces from end of lines, because sig.k8s.io/yaml@v1.3.0 outputs the whole file content
+// as a raw, single line string if there are empty spaces at end of lines.
+func sanitize(content string) string {
+	var sanitizedContent []string
+
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		sanitizedLine := strings.TrimRight(line, " ")
+		sanitizedContent = append(sanitizedContent, sanitizedLine)
+	}
+
+	return strings.Join(sanitizedContent, "\n")
 }
 
 // ReadSecretYamlFromFile reads a configmap from a YAML file.


### PR DESCRIPTION
### What does this PR do?

Trim spaces from end of lines, because sig.k8s.io/yaml@v1.3.0 outputs the whole file content as a raw, single line string if there are empty spaces at end of lines.

For example running the following command:

```shell
kubectl gs template app \
    --catalog "default" \
    --app-name "example" \
    --name "cluster-aws" \
    --version "0.33.0" \
    --target-namespace "org-example" \
    --in-cluster \
    --user-configmap "configmap.yaml"
```

Beyond the App CR it generates the config map too. Taking the following file as `configmap.yaml`:

```yaml
a: 123
b: cde
```

It will result in the following config map:

```yaml
apiVersion: v1
data:
  values: |
    a: 123
    b: cde
kind: ConfigMap
metadata:
  name: example-userconfig
  namespace: org-example
```

However when you have extra spaces let's say after `a: 123` at the end of the line:

```yaml
a: 123  
b: cde
```

It will result in:

```yaml
apiVersion: v1
data:
  values: "a: 123  \nb: cde\n"
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: snail-userconfig
  namespace: org-giantswarm

```

Which is valid, but not a good user experience.

### What is the effect of this change to users?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Doubt so.
