### PR TITLE
Login error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Graceful failure of the `login` command in case workload cluster API is not known
+
 ## [2.39.0] - 2023-06-22
 
 ### Breaking changes

--- a/cmd/login/error.go
+++ b/cmd/login/error.go
@@ -226,3 +226,21 @@ var insufficientPermissionsError = &microerror.Error{
 func IsInsufficientPermissions(err error) bool {
 	return microerror.Cause(err) == insufficientPermissionsError
 }
+
+var clusterAPINotReadyError = &microerror.Error{
+	Kind: "clusterAPINotReadyError",
+}
+
+// IsClusterAPINotReady asserts clusterAPINotReadyError.
+func IsClusterAPINotReady(err error) bool {
+	return microerror.Cause(err) == clusterAPINotReadyError
+}
+
+var clusterAPINotKnownError = &microerror.Error{
+	Kind: "clusterAPINotKnownError",
+}
+
+// IsClusterAPINotKnown asserts clusterAPINotKnownError.
+func IsClusterAPINotKnown(err error) bool {
+	return microerror.Cause(err) == clusterAPINotKnownError
+}

--- a/cmd/login/runner_config_modify_test.go
+++ b/cmd/login/runner_config_modify_test.go
@@ -593,8 +593,13 @@ func createCluster(name string, namespace string) v1beta1.Cluster {
 	return v1beta1.Cluster{
 		TypeMeta:   v1.TypeMeta{Kind: "Cluster", APIVersion: "cluster.x-k8s.io/v1beta1"},
 		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec:       v1beta1.ClusterSpec{},
-		Status:     v1beta1.ClusterStatus{},
+		Spec: v1beta1.ClusterSpec{
+			ControlPlaneEndpoint: v1beta1.APIEndpoint{
+				Host: "localhost",
+				Port: 6443,
+			},
+		},
+		Status: v1beta1.ClusterStatus{},
 	}
 }
 

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -3,12 +3,13 @@ package login
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
 	"net"
 	"regexp"
 	"strings"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/clientcert"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
-	"github.com/giantswarm/microerror"
 )
 
 const (

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -3,22 +3,26 @@ package login
 import (
 	"context"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"net"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
-	"github.com/giantswarm/microerror"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/clientcert"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/microerror"
+)
+
+const (
+	newClusterMaxAge = 30 * time.Minute
 )
 
 func (r *runner) getServiceSet(client k8sclient.Interface) (serviceSet, error) {
@@ -129,6 +133,13 @@ func (r *runner) handleWCClientCert(ctx context.Context) error {
 	// At the moment, the only available login option for WC is client cert
 	contextName, contextExists, err := r.createClusterClientCert(ctx, client, provider)
 	if err != nil {
+		if IsClusterAPINotReady(err) {
+			fmt.Fprintf(r.stdout, "\nCould not create a context for workload cluster %s, as the cluster's API server endpoint is not known yet.\n", r.flag.WCName)
+			fmt.Fprintf(r.stdout, "If the cluster has been created recently, please wait for a few minutes and try again.\n")
+		} else if IsClusterAPINotKnown(err) {
+			fmt.Fprintf(r.stdout, "\nCould not create a context for workload cluster %s, as the cluster's API server endpoint is not known.\n", r.flag.WCName)
+			fmt.Fprintf(r.stdout, "Since the cluster has been created a while ago, this appears to be a problem with cluster creation. Please contact Giant Swarm's support.\n")
+		}
 		return microerror.Mask(err)
 	}
 
@@ -191,6 +202,13 @@ func (r *runner) createClusterClientCert(ctx context.Context, client k8sclient.I
 	clientCertResource, secret, err := r.getCredentials(ctx, services.clientCertService, certConfig)
 	if err != nil {
 		return "", false, microerror.Mask(err)
+	}
+
+	if c.Cluster.Spec.ControlPlaneEndpoint.Host == "" || c.Cluster.Spec.ControlPlaneEndpoint.Port == 0 {
+		if c.Cluster.ObjectMeta.CreationTimestamp.Time.Before(time.Now().Add(-newClusterMaxAge)) {
+			return "", false, microerror.Maskf(clusterAPINotKnownError, "API for cluster '%s' is not known", r.flag.WCName)
+		}
+		return "", false, microerror.Maskf(clusterAPINotReadyError, "API for cluster '%s' is not ready yet", r.flag.WCName)
 	}
 
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)

--- a/cmd/login/wc_test.go
+++ b/cmd/login/wc_test.go
@@ -562,7 +562,7 @@ func getCluster(name, namespace, controlPlaneEndpoint string, creationTimestamp 
 	}
 
 	if controlPlaneURL != nil {
-		port, err := strconv.Atoi(controlPlaneURL.Port())
+		port, err := strconv.ParseInt(controlPlaneURL.Port(), 10, 32)
 		if err == nil {
 			cluster.Spec.ControlPlaneEndpoint = capi.APIEndpoint{
 				Host: controlPlaneURL.Host,


### PR DESCRIPTION
### What does this PR do?

Graceful failure of the `login` command in case workload cluster API is not known

### What is the effect of this change to users?

When the user attempts to log it to a workload cluster, whose API is not ready, the `login` command will fail and present a meaningful error message to the user.

### What does it look like?

In case the cluster is was created less than 30 minutes ago:

```
$ kubectl gs login mc123 --workload-cluster wc123 --cluster-admin --certificate-group system:masters --certificate-ttl 15m
Context 'gs-mc123' is already selected.
You are logged in to the cluster 'mc123'.

Could not create a context for workload cluster wc123, as the cluster's API server endpoint is not known yet.
If the cluster has been created recently, please wait for a few minutes and try again.
Error: Cluster api not ready: API for cluster 'wc123' is not ready yet
```

Otherwise:

```
$ kubectl gs login mc123 --workload-cluster wc123 --cluster-admin --certificate-group system:masters --certificate-ttl 8h
Context 'gs-mc123' is already selected.
You are logged in to the cluster 'mc123'.

Could not create a context for workload cluster wc123, as the cluster's API server endpoint is not known.
Since the cluster has been created a while ago, this appears to be a problem with cluster creation. Please contact Giant Swarm's support.
Error: Cluster api not known: API for cluster 'wc123' is not known
```

### Any background context you can provide?

Fixes https://github.com/giantswarm/roadmap/issues/1413

### What is needed from the reviewers?

Check that the conditions for the error are correct and the error messages make sense

### Do the docs need to be updated?

Probably not

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Debatable. The `login` command fails where it used to succeed while producing an invalid entry in kubeconfig.
