### PR TITLE
Configurable timeout & improved error handling in kgs login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--login-timeout` flag to control the time period of OIDC login timeout
+
 ### Changed
 
 - Graceful failure of the `login` command in case workload cluster API is not known
+- Improved error message after login timeout
 
 ## [2.39.0] - 2023-06-22
 

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -71,7 +71,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster. Only Supported for Workload Cluster using clientcert auth mode")
 	cmd.Flags().IntVar(&f.ProxyPort, flagProxyPort, 9000, "Port for the socks proxy configuration for the cluster")
 
-	cmd.Flags().DurationVar(&f.LoginTimeout, flagLoginTimeout, 60*time.Second, "Duration for which kubectl gs will wait for the OIDC login to complete. Once the timeout is reached, OIDC login will fail. Default value is 60s.")
+	cmd.Flags().DurationVar(&f.LoginTimeout, flagLoginTimeout, 60*time.Second, "Duration for which kubectl gs will wait for the OIDC login to complete. Once the timeout is reached, OIDC login will fail.")
 
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -26,6 +26,8 @@ const (
 
 	flagProxy     = "proxy"
 	flagProxyPort = "proxy-port"
+
+	flagLoginTimeout = "login-timeout"
 )
 
 type flag struct {
@@ -46,6 +48,8 @@ type flag struct {
 
 	Proxy     bool
 	ProxyPort int
+
+	LoginTimeout time.Duration
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -67,6 +71,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster. Only Supported for Workload Cluster using clientcert auth mode")
 	cmd.Flags().IntVar(&f.ProxyPort, flagProxyPort, 9000, "Port for the socks proxy configuration for the cluster")
 
+	cmd.Flags().DurationVar(&f.LoginTimeout, flagLoginTimeout, 60*time.Second, "Duration for which kubectl gs will wait for the OIDC login to complete. Once the timeout is reached, OIDC login will fail. Default value is 60s.")
+
 	_ = cmd.Flags().MarkHidden(flagWCInsecureNamespace)
 	_ = cmd.Flags().MarkHidden("namespace")
 }
@@ -79,6 +85,10 @@ func (f *flag) Validate() error {
 	}
 	if ttlFlag <= 0 {
 		return microerror.Maskf(invalidFlagError, `--%s cannot be negative or zero.`, flagWCCertTTL)
+	}
+
+	if f.LoginTimeout <= 0 {
+		return microerror.Maskf(invalidFlagError, `--%s cannot be negative or zero`, flagLoginTimeout)
 	}
 
 	return nil

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -29,7 +29,6 @@ const (
 	customerConnectorType   = "customer"
 	giantswarmConnectorType = "giantswarm"
 
-	oidcResultTimeout     = 1 * time.Minute
 	oidcReadHeaderTimeout = 1 * time.Minute
 )
 
@@ -38,7 +37,7 @@ var (
 )
 
 // handleOIDC executes the OIDC authentication against an installation's authentication provider.
-func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *installation.Installation, connectorID string, clusterAdmin bool, port int) (authInfo, error) {
+func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *installation.Installation, connectorID string, clusterAdmin bool, port int, oidcResultTimeout time.Duration) (authInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, oidcResultTimeout)
 	defer cancel()
 


### PR DESCRIPTION
### What does this PR do?

- Added a new flag called `--login-timeout=DURATION` to configure a custom timeout period for the callback server when using `kgs login`.
- Improved error handling in case kgs login times out - added a hint to use the `--login-timeout` flag to increase the timeout period

### What is the effect of this change to users?

The users will be able to go through the full OIDC login process even in case it consists of multiple time consuming steps.

### What does it look like?

Description of the new flag:

```
$ kubectl gs login --help
...

Flags:
      ...
      --login-timeout duration      Duration for which kubectl gs will wait for the OIDC login to complete. Once the timeout is reached, OIDC login will fail. (default 1m0s)

```

Usage:
```
$ kubectl gs login installation --cluster-admin --login-timeout 120s
```

Error message when kgs login times out:
```
$ kubectl gs login installation --cluster-admin

Your browser should now be opening this URL:
https://installation...


Your authentication flow timed out after 1m0s. Please execute the same command again.
You can use the --login-timeout flag to configure a longer timeout interval, for example --login-timeout=120s.
Error: Auth response timed out: failed to get an authentication response on time
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2167

### What is needed from the reviewers?

Check that the flag works and the error messages make sense

### Do the docs need to be updated?

The `login-timeout` flag needs to be added to the docs

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
