### PR TITLE
Fix login for CAPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change how `login` works on CAPA and `gcp` to use our DNS record for the k8s API when using these providers, rather than the value found in the CAPI CRs.
+
 ## [2.41.0] - 2023-08-16
 
 ### Added

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -3,18 +3,16 @@ package login
 import (
 	"context"
 	"fmt"
-	"net"
 	"regexp"
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
-
 	"github.com/fatih/color"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/giantswarm/kubectl-gs/v2/internal/key"
 	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/clientcert"
@@ -238,7 +236,7 @@ func (r *runner) createCertKubeconfig(ctx context.Context, c *cluster.Cluster, s
 
 	// If the control plane host is an IP address then it is a CAPI cluster and
 	// we need to manually set the cluster server to the correct domain
-	if net.ParseIP(c.Cluster.Spec.ControlPlaneEndpoint.Host) != nil {
+	if provider == key.ProviderCAPA || provider == key.ProviderGCP {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 	}
 


### PR DESCRIPTION
### What does this PR do?
Towards https://github.com/giantswarm/roadmap/issues/2351
Fix `kubectl-gs login` command to work on CAPA.

### What is the effect of this change to users?

It will use our custom DNS record for the k8s api, rather than the ELB DNS record that's stored in the CAPI CRs. This will make our GiantSwarm VPN configuration to work.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated
