### PR TITLE
Remove `controlPlane.replicas` value for CAPA since it is not supported anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `controlPlane.replicas` value for CAPA since it is not supported anymore
+
 ### Removed
 
 - Removed a support for DNS mode for proxy based CAPA clusters.

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -183,7 +183,6 @@ func BuildCapaClusterConfig(config ClusterConfig) capa.ClusterConfig {
 		},
 		ControlPlane: &capa.ControlPlane{
 			InstanceType: config.ControlPlaneInstanceType,
-			Replicas:     3,
 		},
 		NodePools: &map[string]capa.MachinePool{
 			config.AWS.MachinePool.Name: {

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -64,7 +64,6 @@ type Bastion struct {
 type ControlPlane struct {
 	APIMode                string   `json:"apiMode,omitempty"`
 	InstanceType           string   `json:"instanceType,omitempty"`
-	Replicas               int      `json:"replicas,omitempty"`
 	RootVolumeSizeGB       int      `json:"rootVolumeSizeGB,omitempty"`
 	EtcdVolumeSizeGB       int      `json:"etcdVolumeSizeGB,omitempty"`
 	ContainerdVolumeSizeGB int      `json:"containerdVolumeSizeGB,omitempty"`

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -10,7 +10,6 @@ data:
       topology: {}
     controlPlane:
       instanceType: control-plane-instance-type
-      replicas: 3
     metadata:
       description: just a test cluster
       name: test1

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
@@ -25,7 +25,6 @@ data:
     controlPlane:
       apiMode: private
       instanceType: control-plane-instance-type
-      replicas: 3
     metadata:
       description: just a test cluster
       name: test1

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -27,7 +27,6 @@ data:
     controlPlane:
       apiMode: public
       instanceType: control-plane-instance-type
-      replicas: 3
     metadata:
       description: just a test cluster
       name: test1


### PR DESCRIPTION
### What does this PR do?

Fix after https://github.com/giantswarm/cluster-aws/pull/312/files

### What is the effect of this change to users?

Values validate fine against latest `cluster-aws`, fixing the WC creation.

### What does it look like?

See golden files

### Do the docs need to be updated?

No, https://docs.giantswarm.io/getting-started/create-workload-cluster/ doesn't explicitly show this value.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No