### PR TITLE
Support deletion prevention for `kubectl gs template app` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Support deletion prevention for `kubectl gs template app` command
+
 ## [2.42.0] - 2023-10-06
 
 ### Fixed

--- a/cmd/login/runner_config_modify_test.go
+++ b/cmd/login/runner_config_modify_test.go
@@ -268,6 +268,7 @@ func TestKubeConfigModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			configDir, err := os.MkdirTemp("", "loginTest")
 			if err != nil {

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -307,6 +307,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			configDir, err := os.MkdirTemp("", "loginTest")
 			if err != nil {

--- a/cmd/template/app/command.go
+++ b/cmd/template/app/command.go
@@ -44,6 +44,7 @@ func New(config Config) (*cobra.Command, error) {
 		Use:   name,
 		Short: description,
 		Long:  description,
+		Args:  cobra.NoArgs,
 		RunE:  r.Run,
 	}
 

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
@@ -80,7 +81,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")
 	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigAnnotations, flagNamespaceConfigAnnotations, nil, "Namespace configuration annotations in form key=value.")
 	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigLabels, flagNamespaceConfigLabels, nil, "Namespace configuration labels in form key=value.")
-	cmd.Flags().BoolVar(&f.PreventDeletion, flagPreventDeletion, false, "Label the App and other templated resources with 'giantswarm.io/prevent-deletion' to prevent deletion (see https://docs.giantswarm.io/advanced/deletion-prevention/).")
+	cmd.Flags().BoolVar(&f.PreventDeletion, flagPreventDeletion, false, fmt.Sprintf("Label the App and other templated resources with '%s' to prevent deletion (see https://docs.giantswarm.io/advanced/deletion-prevention/).", label.PreventDeletion))
 
 	_ = cmd.Flags().MarkDeprecated(flagNamespace, fmt.Sprintf("use --%s instead", flagTargetNamespace))
 	_ = cmd.Flags().MarkDeprecated(flagCluster, fmt.Sprintf("use --%s instead", flagClusterName))

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -26,6 +26,7 @@ const (
 	flagNamespaceConfigAnnotations = "namespace-annotations"
 	flagNamespaceConfigLabels      = "namespace-labels"
 	flagOrganization               = "organization"
+	flagPreventDeletion            = "prevent-deletion"
 	flagRollbackTimeout            = "rollback-timeout"
 	flagUninstallTimeout           = "uninstall-timeout"
 	flagUpgradeTimeout             = "upgrade-timeout"
@@ -55,6 +56,7 @@ type flag struct {
 	UpgradeTimeout                 time.Duration
 	flagUserConfigMap              string
 	flagUserSecret                 string
+	PreventDeletion                bool
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -78,6 +80,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Version, flagVersion, "", "App version to be installed.")
 	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigAnnotations, flagNamespaceConfigAnnotations, nil, "Namespace configuration annotations in form key=value.")
 	cmd.Flags().StringSliceVar(&f.flagNamespaceConfigLabels, flagNamespaceConfigLabels, nil, "Namespace configuration labels in form key=value.")
+	cmd.Flags().BoolVar(&f.PreventDeletion, flagPreventDeletion, false, "Label the App and other templated resources with 'giantswarm.io/prevent-deletion' to prevent deletion (see https://docs.giantswarm.io/advanced/deletion-prevention/).")
 
 	_ = cmd.Flags().MarkDeprecated(flagNamespace, fmt.Sprintf("use --%s instead", flagTargetNamespace))
 	_ = cmd.Flags().MarkDeprecated(flagCluster, fmt.Sprintf("use --%s instead", flagClusterName))

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
@@ -115,7 +116,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			if userSecret.Labels == nil {
 				userSecret.Labels = map[string]string{}
 			}
-			userSecret.Labels["giantswarm.io/prevent-deletion"] = "true" //nolint:goconst
+			userSecret.Labels[label.PreventDeletion] = "true" //nolint:goconst
 		}
 
 		userConfigSecretYaml, err = yaml.Marshal(userSecret)
@@ -141,7 +142,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			if userConfigMap.Labels == nil {
 				userConfigMap.Labels = map[string]string{}
 			}
-			userConfigMap.Labels["giantswarm.io/prevent-deletion"] = "true"
+			userConfigMap.Labels[label.PreventDeletion] = "true"
 		}
 
 		userConfigConfigMapYaml, err = yaml.Marshal(userConfigMap)
@@ -163,7 +164,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	appConfig.NamespaceConfigLabels = namespaceLabels
 
 	if r.flag.PreventDeletion {
-		appConfig.ExtraLabels["giantswarm.io/prevent-deletion"] = "true"
+		appConfig.ExtraLabels[label.PreventDeletion] = "true"
 	}
 
 	r.setTimeouts(&appConfig)

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -115,7 +115,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			if userSecret.Labels == nil {
 				userSecret.Labels = map[string]string{}
 			}
-			userSecret.Labels["giantswarm.io/prevent-deletion"] = "true"
+			userSecret.Labels["giantswarm.io/prevent-deletion"] = "true" //nolint:goconst
 		}
 
 		userConfigSecretYaml, err = yaml.Marshal(userSecret)

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -73,7 +73,7 @@ const (
 	flagOpenStackDNSNameservers             = "dns-nameservers"
 	flagOpenStackExternalNetworkID          = "external-network-id"
 	flagOpenStackNodeCIDR                   = "node-cidr"
-	flagOpenStackBastionBootFromVolume      = "bastion-boot-from-volume"
+	flagOpenStackBastionBootFromVolume      = "bastion-boot-from-volume" //nolint:gosec
 	flagOpenStackNetworkName                = "network-name"
 	flagOpenStackSubnetName                 = "subnet-name"
 	flagOpenStackBastionDiskSize            = "bastion-disk-size"

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -27,7 +27,7 @@ const (
 	// Azure only.
 	flagAzureVMSize          = "azure-vm-size"
 	flagAzureUseSpotVMs      = "azure-spot-vms"
-	flagAzureSpotVMsMaxPrice = "azure-spot-vms-max-price"
+	flagAzureSpotVMsMaxPrice = "azure-spot-vms-max-price" //nolint:gosec
 
 	// Common.
 	flagAvailabilityZones = "availability-zones"

--- a/cmd/update/app/runner_test.go
+++ b/cmd/update/app/runner_test.go
@@ -98,6 +98,7 @@ func Test_run(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			var err error
 

--- a/cmd/update/cluster/runner_test.go
+++ b/cmd/update/cluster/runner_test.go
@@ -42,6 +42,7 @@ func Test_run(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		tc := tc
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			var err error
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/giantswarm/appcatalog v0.10.1
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8smetadata v0.22.0
+	github.com/giantswarm/k8smetadata v0.23.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v1.0.0
 	github.com/giantswarm/organization-operator v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/giantswarm/backoff v1.0.0 h1:1oeTvyPsm1tJrHlSmfxbIWuoCNWPOkWJCb8kfLvE
 github.com/giantswarm/backoff v1.0.0/go.mod h1:l/WqbggvG5Ndxxws0LUgVEvP5E82Qj5/PF8SMip/1QM=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8smetadata v0.22.0 h1:hTDM61G/vbyCPTo16bz3tTb+/Jg77kkEcUWKj6qZP4o=
-github.com/giantswarm/k8smetadata v0.22.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
+github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
+github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/microerror v0.4.0 h1:QeU+UZL0rRlVXKqYOHMxS0L7g8UD+dn84NT7myWVh4U=
 github.com/giantswarm/microerror v0.4.0/go.mod h1:Ju1YdC6TX/8witv7fIlkgiRr5FQUNyq3f4TX2QYnO7c=
 github.com/giantswarm/micrologger v1.0.0 h1:5W4h3K414CXhoXQ3rkGbrMl8yUGdbCLKMdg/EezccM4=

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -144,6 +144,23 @@ func Test_NewAppCR(t *testing.T) {
 			},
 			expectedGoldenFile: "app_config_cluster_values_yaml_output.golden",
 		},
+		{
+			name: "case 9: user values + extra labels",
+			config: Config{
+				AppName:           "ingress-nginx",
+				Catalog:           "giantswarm",
+				Cluster:           "eggs2",
+				DefaultingEnabled: true,
+				ExtraLabels: map[string]string{
+					"giantswarm.io/prevent-deletion": "true",
+				},
+				Name:                    "ingress-nginx",
+				Namespace:               "kube-system",
+				UserConfigConfigMapName: "ingress-nginx-user-values",
+				Version:                 "3.0.0",
+			},
+			expectedGoldenFile: "app_user_values_and_extra_labels_yaml_output.golden",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/template/app/testdata/app_user_values_and_extra_labels_yaml_output.golden
+++ b/pkg/template/app/testdata/app_user_values_and_extra_labels_yaml_output.golden
@@ -1,0 +1,18 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    giantswarm.io/prevent-deletion: "true"
+  name: ingress-nginx
+  namespace: eggs2
+spec:
+  catalog: giantswarm
+  kubeConfig:
+    inCluster: false
+  name: ingress-nginx
+  namespace: kube-system
+  userConfig:
+    configMap:
+      name: ingress-nginx-user-values
+      namespace: eggs2
+  version: 3.0.0


### PR DESCRIPTION
### What does this PR do?

https://github.com/giantswarm/giantswarm/issues/28310

Support [deletion prevention](https://docs.giantswarm.io/advanced/deletion-prevention/) through a new flag.

This is both helpful for customers and our own use (e.g. in MC bootstrapping where we typically don't want an MC to be deletable).

### What does it look like?

```
$ kubectl-gs template app --catalog=giantswarm --cluster-name="anditest" --name=nginx-ingress-controller-app --target-namespace=kube-system --version=2.30.0  --user-configmap <(echo "controller: { service: { public: false } }" | yq -y) --prevent-deletion
---
apiVersion: v1
data:
  values: |
    controller:
      service:
        public: false
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/prevent-deletion: "true"
  name: nginx-ingress-controller-app-userconfig-anditest
  namespace: anditest
---
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    giantswarm.io/prevent-deletion: "true"
  name: nginx-ingress-controller-app
  namespace: anditest
spec:
  catalog: giantswarm
  kubeConfig:
    inCluster: false
  name: nginx-ingress-controller-app
  namespace: kube-system
  userConfig:
    configMap:
      name: nginx-ingress-controller-app-userconfig-anditest
      namespace: anditest
  version: 2.30.0
```

### Do the docs need to be updated?

Yes, the article linked above.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No. The flag defaults to false.