### PR TITLE
Update flag.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make the `--organization` flag visible when templating App CR.
+
 ## [2.43.0] - 2023-10-11
 
 ### Added

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -85,8 +85,6 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	_ = cmd.Flags().MarkDeprecated(flagNamespace, fmt.Sprintf("use --%s instead", flagTargetNamespace))
 	_ = cmd.Flags().MarkDeprecated(flagCluster, fmt.Sprintf("use --%s instead", flagClusterName))
-
-	_ = cmd.Flags().MarkHidden(flagOrganization)
 }
 
 func (f *flag) Validate() error {


### PR DESCRIPTION
### What does this PR do?

It makes the organization flag visible.

### What is the effect of this change to users?

He should see the flag being available.

### What does it look like?

N/A

### Any background context you can provide?

The flag was previously configured to be hidden, for it was introduced at the time when we were somewhere at the beginning of manging-apps-in-org-namespace journey, and most flags at the time were hidden.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
