### PR TITLE
vsphere: k8s version defaulting was not ok

### DIFF
--- a/cmd/template/cluster/provider/capv.go
+++ b/cmd/template/cluster/provider/capv.go
@@ -184,7 +184,7 @@ func getMachineTemplate(machineTemplate *VSphereMachineTemplate, clusterConfig *
 		NumCPUs:      machineTemplate.NumCPUs,
 		MemoryMiB:    machineTemplate.MemoryMiB,
 		ResourcePool: config.ResourcePool,
-		Template:     fmt.Sprintf(config.ImageTemplate, clusterConfig.KubernetesVersion),
+		Template:     config.ImageTemplate,
 	}
 }
 

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -220,7 +220,7 @@ func Test_run(t *testing.T) {
 					ResourcePool:            "foopool",
 					NetworkName:             "foonet",
 					CredentialsSecretName:   "foosecret",
-					ImageTemplate:           "foo-%-os",
+					ImageTemplate:           "foobar",
 					ControlPlane: provider.VSphereControlPlane{
 						VSphereMachineTemplate: provider.VSphereMachineTemplate{
 							DiskGiB:   42,

--- a/cmd/template/cluster/testdata/run_template_cluster_capv.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capv.golden
@@ -29,7 +29,7 @@ data:
             networkName: foonet
         numCPUs: 6
         resourcePool: foopool
-        template: foo-%!o(string=v1.2.3)s
+        template: foobar
       replicas: 5
     helmReleases:
       cilium:
@@ -49,7 +49,7 @@ data:
             networkName: foonet
         numCPUs: 7
         resourcePool: foopool
-        template: foo-%!o(string=v1.2.3)s
+        template: foobar
     nodePools:
       worker:
         class: default


### PR DESCRIPTION
if the custom `--vsphere-image-template` didn't have the placeholder set, it was messed up