### PR TITLE
Add CAPA cluster templating parameter `--control-plane-load-balancer-ingress-allow-cidr-block` which automatically adds NAT Gateway IPs of the MC to the allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add CAPA cluster templating parameter `--control-plane-load-balancer-ingress-allow-cidr-block` which automatically adds NAT Gateway IPs of the MC to the allowlist
+
 ## [2.45.4] - 2023-11-08
 
 ### Added

--- a/cmd/template/cluster/command.go
+++ b/cmd/template/cluster/command.go
@@ -57,6 +57,7 @@ func New(config Config) (*cobra.Command, error) {
 		Use:   name,
 		Short: description,
 		Long:  description,
+		Args:  cobra.NoArgs,
 		RunE:  r.Run,
 		PreRunE: middleware.Compose(
 			renewtoken.Middleware(*config.ConfigFlags),

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -26,19 +26,20 @@ type AWSConfig struct {
 	ControlPlaneSubnet string
 
 	// for CAPA
-	AWSClusterRoleIdentityName string
-	MachinePool                AWSMachinePoolConfig
-	NetworkAZUsageLimit        int
-	NetworkVPCCIDR             string
-	ClusterType                string
-	HttpProxy                  string
-	HttpsProxy                 string
-	NoProxy                    string
-	APIMode                    string
-	VPCMode                    string
-	TopologyMode               string
-	PrefixListID               string
-	TransitGatewayID           string
+	AWSClusterRoleIdentityName                     string
+	MachinePool                                    AWSMachinePoolConfig
+	NetworkAZUsageLimit                            int
+	NetworkVPCCIDR                                 string
+	ClusterType                                    string
+	HttpProxy                                      string
+	HttpsProxy                                     string
+	NoProxy                                        string
+	APIMode                                        string
+	VPCMode                                        string
+	TopologyMode                                   string
+	PrefixListID                                   string
+	TransitGatewayID                               string
+	ControlPlaneLoadBalancerIngressAllowCIDRBlocks []string
 }
 
 type AWSMachinePoolConfig struct {
@@ -138,6 +139,7 @@ type AppConfig struct {
 }
 
 type ClusterConfig struct {
+	ManagementCluster string
 	KubernetesVersion string
 	FileName          string
 	ControlPlaneAZ    []string

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -62,13 +62,14 @@ type Bastion struct {
 }
 
 type ControlPlane struct {
-	APIMode                string   `json:"apiMode,omitempty"`
-	InstanceType           string   `json:"instanceType,omitempty"`
-	RootVolumeSizeGB       int      `json:"rootVolumeSizeGB,omitempty"`
-	EtcdVolumeSizeGB       int      `json:"etcdVolumeSizeGB,omitempty"`
-	ContainerdVolumeSizeGB int      `json:"containerdVolumeSizeGB,omitempty"`
-	KubeletVolumeSizeGB    int      `json:"kubeletVolumeSizeGB,omitempty"`
-	AvailabilityZones      []string `json:"availabilityZones,omitempty"`
+	APIMode                            string   `json:"apiMode,omitempty"`
+	InstanceType                       string   `json:"instanceType,omitempty"`
+	RootVolumeSizeGB                   int      `json:"rootVolumeSizeGB,omitempty"`
+	EtcdVolumeSizeGB                   int      `json:"etcdVolumeSizeGB,omitempty"`
+	ContainerdVolumeSizeGB             int      `json:"containerdVolumeSizeGB,omitempty"`
+	KubeletVolumeSizeGB                int      `json:"kubeletVolumeSizeGB,omitempty"`
+	AvailabilityZones                  []string `json:"availabilityZones,omitempty"`
+	LoadBalancerIngressAllowCIDRBlocks []string `json:"loadBalancerIngressAllowCidrBlocks,omitempty"`
 }
 
 type MachinePool struct {

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -123,6 +123,7 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 		ControlPlaneInstanceType: r.flag.ControlPlaneInstanceType,
 		Description:              r.flag.Description,
 		KubernetesVersion:        r.flag.KubernetesVersion,
+		ManagementCluster:        r.flag.ManagementCluster,
 		Name:                     r.flag.Name,
 		Organization:             r.flag.Organization,
 		PodsCIDR:                 r.flag.PodsCIDR,

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
@@ -25,6 +25,10 @@ data:
     controlPlane:
       apiMode: private
       instanceType: control-plane-instance-type
+      loadBalancerIngressAllowCidrBlocks:
+      - 1.2.3.4/32
+      - 5.6.7.8/32
+      - 9.10.11.12/32
     metadata:
       description: just a test cluster
       name: test1

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -27,6 +27,11 @@ data:
     controlPlane:
       apiMode: public
       instanceType: control-plane-instance-type
+      loadBalancerIngressAllowCidrBlocks:
+      - 1.2.3.4/32
+      - 5.6.7.8/32
+      - 9.10.11.12/32
+      - 7.7.7.7/32
     metadata:
       description: just a test cluster
       name: test1

--- a/cmd/template/command.go
+++ b/cmd/template/command.go
@@ -149,6 +149,7 @@ func New(config Config) (*cobra.Command, error) {
 		Use:   name,
 		Short: description,
 		Long:  description,
+		Args:  cobra.NoArgs,
 		RunE:  r.Run,
 	}
 

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -11,6 +11,7 @@ import (
 	k8score "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	capainfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	eks "sigs.k8s.io/cluster-api-provider-aws/v2/controlplane/eks/api/v1beta2"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1beta1"
@@ -33,6 +34,7 @@ func NewSchemeBuilder() []func(*runtime.Scheme) error {
 		provider.AddToScheme,         // AWSConfig/AzureConfig
 		release.AddToScheme,          // Release
 		securityv1alpha1.AddToScheme, // Organizations
+		capainfrav1.AddToScheme,      // AWSCluster (CAPA)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Implements https://github.com/giantswarm/roadmap/issues/2883

### What is the effect of this change to users?

New parameters for CAPA cluster templating

### What does it look like?

```sh
$ kubectl-gs template cluster --provider capa --name kgstest --organization giantswarm --control-plane-load-balancer-ingress-allow-cidr-block "16.0.0.0/8" --management-cluster golem | grep -A6 controlPlane:
    controlPlane:
      loadBalancerIngressAllowCidrBlocks:
      - 3.11.43.118/32
      - 35.177.163.198/32
      - 35.177.19.14/32
      - 16.0.0.0/8
    metadata:
```

### Do the docs need to be updated?

I will adapt https://docs.giantswarm.io/advanced/cluster-management/private-clusters/#kubernetes-api-allowlist.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

no