### PR TITLE
Change default volume Docker size to 10Gb on AWS vintage NodePools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change default volume Docker size to 10Gb on AWS vintage NodePools.
+
 ## [2.46.0] - 2023-11-08
 
 ### Added

--- a/cmd/template/nodepool/provider/templates/aws/nodepool.go
+++ b/cmd/template/nodepool/provider/templates/aws/nodepool.go
@@ -100,7 +100,7 @@ func newAWSMachineDeploymentCR(c NodePoolCRsConfig) *v1alpha3.AWSMachineDeployme
 			NodePool: v1alpha3.AWSMachineDeploymentSpecNodePool{
 				Description: c.Description,
 				Machine: v1alpha3.AWSMachineDeploymentSpecNodePoolMachine{
-					DockerVolumeSizeGB:  100,
+					DockerVolumeSizeGB:  10,
 					KubeletVolumeSizeGB: 100,
 				},
 				Scaling: v1alpha3.AWSMachineDeploymentSpecNodePoolScaling{


### PR DESCRIPTION
### What does this PR do?

Before this PR:

```
$ kubectl gs template nodepool --provider aws --release v19.2.0 --cluster-name qv8c5 --description test --organization giantswarm --availability-zones eu-central-1a|grep dockerVolumeSize
      dockerVolumeSizeGB: 100
```

After this PR

```
$ kubectl gs template nodepool --provider aws --release v19.2.0 --cluster-name qv8c5 --description test --organization giantswarm --availability-zones eu-central-1a|grep dockerVolumeSize
      dockerVolumeSizeGB: 10
```

### What is the effect of this change to users?

they will save money as the docker volume is hardly used in recent clusters

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
