### PR TITLE
Align files in order to fix release action

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.15.1
+#    devctl@6.16.0
 #
 name: Create Release
 on:
@@ -93,7 +93,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.1.0
         with:
           binary: "architect"
-          version: "6.11.0"
+          version: "6.13.0"
       - name: Install semver
         uses: giantswarm/install-binary-action@v1.1.0
         with:
@@ -266,7 +266,7 @@ jobs:
           - windows-amd64
     env:
       GITHUB_TOKEN: "${{ secrets.TAYLORBOT_GITHUB_ACTION }}"
-      GO_VERSION: 1.19.6
+      GO_VERSION: 1.21.3
       ARTIFACT_DIR: bin-dist
       TAG: v${{ needs.gather_facts.outputs.version }}
       CODE_SIGNING_CERT_BUNDLE_BASE64: ${{ secrets.CODE_SIGNING_CERT_BUNDLE_BASE64 }}
@@ -279,7 +279,7 @@ jobs:
         uses: giantswarm/install-binary-action@v1.1.0
         with:
           binary: "architect"
-          version: "6.11.0"
+          version: "6.13.0"
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v3.3.0
         with:

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.15.1
+#    devctl@6.16.0
 #
 name: Create Release PR
 on:

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.15.1
+#    devctl@6.16.0
 #
 name: gitleaks
 


### PR DESCRIPTION
### What does this PR do?

This should fix release errors like

```
cmd/template/cluster/provider/capa.go:7:2: package slices is not in GOROOT (/opt/hostedtoolcache/go/1.19.6/x64/src/slices)
```

### What is the effect of this change to users?

Releases work again, so users can download the latest binaries e.g. using self-update.

### Any background context you can provide?

Recent bump to Go 1.21 and use of only-1.21 features in this repo (`slices` module in standard library).

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated => not needed, we will release again after this

### Is this a breaking change?

no