### PR TITLE
Set DNS record to kubeconfig for non-vintage providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Change how `login` works on CAPVCD and CAPV to use our DNS record for the k8s API when using these providers, rather than the value found in the CAPI CRs.
+- Change how `login` works to use our DNS record for the k8s API when using non-vintage providers, rather than the value found in the CAPI CRs.
 
 ## [2.47.0] - 2023-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change how `login` works on CAPVCD and CAPV to use our DNS record for the k8s API when using these providers, rather than the value found in the CAPI CRs.
+
 ## [2.47.0] - 2023-11-13
 
 ### Changed

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -235,7 +235,7 @@ func (r *runner) createCertKubeconfig(ctx context.Context, c *cluster.Cluster, s
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 
 	// When on CAPI we need our custom DNS record for the k8s api, rather than the value found in the CAPI CRs so that our connection through the VPN works.
-	if provider != key.ProviderAWS && provider != key.ProviderAzure {
+	if provider != key.ProviderAWS && provider != key.ProviderAzure && provider != key.ProviderEKS {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 	}
 

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -235,7 +235,7 @@ func (r *runner) createCertKubeconfig(ctx context.Context, c *cluster.Cluster, s
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 
 	// When CAPA or CGP we need our custom DNS record for the k8s api, rather than the value found in the CAPI CRs so that our connection through the VPN works.
-	if provider == key.ProviderCAPA || provider == key.ProviderGCP || provider == key.ProviderCloudDirector || provider == key.ProviderVSphere {
+	if provider != key.ProviderAWS && provider != key.ProviderAzure {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 	}
 

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -234,7 +234,7 @@ func (r *runner) createCertKubeconfig(ctx context.Context, c *cluster.Cluster, s
 
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 
-	// When CAPA or CGP we need our custom DNS record for the k8s api, rather than the value found in the CAPI CRs so that our connection through the VPN works.
+	// When on CAPI we need our custom DNS record for the k8s api, rather than the value found in the CAPI CRs so that our connection through the VPN works.
 	if provider != key.ProviderAWS && provider != key.ProviderAzure {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 	}

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -235,7 +235,7 @@ func (r *runner) createCertKubeconfig(ctx context.Context, c *cluster.Cluster, s
 	clusterServer := fmt.Sprintf("https://%s:%d", c.Cluster.Spec.ControlPlaneEndpoint.Host, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 
 	// When CAPA or CGP we need our custom DNS record for the k8s api, rather than the value found in the CAPI CRs so that our connection through the VPN works.
-	if provider == key.ProviderCAPA || provider == key.ProviderGCP {
+	if provider == key.ProviderCAPA || provider == key.ProviderGCP || provider == key.ProviderCloudDirector || provider == key.ProviderVSphere {
 		clusterServer = fmt.Sprintf("https://api.%s.%s:%d", c.Cluster.Name, clusterBasePath, c.Cluster.Spec.ControlPlaneEndpoint.Port)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Change how `login` works to use our DNS record for the k8s API when using non-vintage providers, rather than the value found in the CAPI CRs.

@calvix do we need to exclude EKS as well?

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
