### PR TITLE
NameLengthLong update to 20

### DIFF
--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -27,7 +27,7 @@ const (
 	// (does not contain 1 and l, to avoid confusion)
 	NameChars = "023456789abcdefghijkmnopqrstuvwxyz"
 	// NameLengthLong represents the number of characters used to create a resource name when --enable-long-names feature flag is used.
-	NameLengthLong = 10
+	NameLengthLong = 20
 	// NameLengthShort represents the number of characters used to create a resource name.
 	NameLengthShort = 5
 


### PR DESCRIPTION
### What does this PR do?

Following the update on maximum length on cluster names and the relevant resources. [Issue](https://github.com/giantswarm/roadmap/issues/2958) and [Fix](https://github.com/giantswarm/kyverno-policies-ux/pull/73) 
### Changes
- This PR updates the maximum character on cluster names to 20.

- [ ] CHANGELOG.md has been updated

