### PR TITLE
using flatcar as default image for vsphere cluster template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Increase the cluster name length to 20 characters.
 - Change how `login` works to use our DNS record for the k8s API when using non-vintage providers, rather than the value found in the CAPI CRs.
+- Defaults for `cluster template --provider vsphere` since it was migrated to flatcar os.
 
 ## [2.47.0] - 2023-11-13
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -133,7 +133,7 @@ const (
 
 	// defaults
 	defaultKubernetesVersion        = "v1.20.9"
-	defaultVSphereKubernetesVersion = "v1.24.11"
+	defaultVSphereKubernetesVersion = "v1.24.12"
 )
 
 type flag struct {
@@ -259,7 +259,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.VSphere.Worker.NumCPUs, flagVSphereWorkerNumCPUs, 6, "Number of CPUs for individual worker plane nodes")
 	cmd.Flags().IntVar(&f.VSphere.Worker.Replicas, flagVSphereWorkerReplicas, 3, "Number of worker plane replicas")
 	cmd.Flags().StringVar(&f.VSphere.ResourcePool, flagVSphereResourcePool, "*/Resources", "What resource pool in vsphere should be used")
-	cmd.Flags().StringVar(&f.VSphere.ImageTemplate, flagVSphereImageTemplate, "ubuntu-2004-kube-%s", "OS images with Kubernetes that should be used for VMs. The '%s' will be replaced with correct Kubernetes version.")
+	cmd.Flags().StringVar(&f.VSphere.ImageTemplate, flagVSphereImageTemplate, "flatcar-stable-3602.2.1-kube-%s-gs", "OS images with Kubernetes that should be used for VMs. These template should be available in vCenter. The '%s' will be replaced with correct Kubernetes version. Example: 'ubuntu-2004-kube-%%s'")
 	cmd.Flags().StringVar(&f.VSphere.CredentialsSecretName, flagVSphereCredentialsSecretName, "vsphere-credentials", "Name of the secret in K8s that should be associated to cluster app. It should exist in the organization's namesapce and should contain the credentials for vsphere.")
 
 	// App-based clusters only.


### PR DESCRIPTION
### What does this PR do?

`ssia` :D

basically aligning the defaults with https://github.com/giantswarm/cluster-vsphere/pull/98/files

- [x] CHANGELOG.md has been updated

### Is this a breaking change?
no
