### PR TITLE
default generated name to 10 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+- Changed the length of random generated cluster names to `10`
+
 ## [2.48.0] - 2023-11-29
 
 ### Added

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -27,7 +27,8 @@ const (
 	// (does not contain 1 and l, to avoid confusion)
 	NameChars = "023456789abcdefghijkmnopqrstuvwxyz"
 	// NameLengthLong represents the number of characters used to create a resource name when --enable-long-names feature flag is used.
-	NameLengthLong = 20
+	NameLengthLong    = 20
+	NameLengthDefault = 10
 	// NameLengthShort represents the number of characters used to create a resource name.
 	NameLengthShort = 5
 
@@ -70,7 +71,7 @@ func GenerateName(enableLongNames bool) (string, error) {
 		letterRunes := []rune(NameChars)
 		length := NameLengthShort
 		if enableLongNames {
-			length = NameLengthLong
+			length = NameLengthDefault
 		}
 		characters := make([]rune, length)
 		r := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404


### PR DESCRIPTION
### What does this PR do?

Changes the amount of characters used on randomly generated cluster names to 10.

- [x] CHANGELOG.md has been updated

