### PR TITLE
Move CAPA userconfig values to global chart values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed 
 
-- **BREAKING** Move CAPA userconfig values to global chart values.
+- **BREAKING** All values of cluster userconfig for `CAPA` are moving under `global`.
 
 ## [2.48.1] - 2023-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed 
+
+- **BREAKING** Move CAPA userconfig values to global chart values.
+
 ## [2.48.0] - 2023-11-29
 
 ### Added

--- a/cmd/template/cluster/provider/templates/capa/functions.go
+++ b/cmd/template/cluster/provider/templates/capa/functions.go
@@ -10,14 +10,14 @@ import (
 )
 
 func GenerateClusterValues(flagInputs ClusterConfig) (string, error) {
-	if flagInputs.Connectivity.Topology.Mode != "" && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeGiantSwarmManaged && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeUserManaged && flagInputs.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeNone {
-		return "", fmt.Errorf("invalid topology mode value %q", flagInputs.Connectivity.Topology.Mode)
+	if flagInputs.Global.Connectivity.Topology.Mode != "" && flagInputs.Global.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeGiantSwarmManaged && flagInputs.Global.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeUserManaged && flagInputs.Global.Connectivity.Topology.Mode != gsannotation.NetworkTopologyModeNone {
+		return "", fmt.Errorf("invalid topology mode value %q", flagInputs.Global.Connectivity.Topology.Mode)
 	}
-	if flagInputs.Connectivity.Topology.PrefixListID != "" && !strings.HasPrefix(flagInputs.Connectivity.Topology.PrefixListID, "pl-") {
-		return "", fmt.Errorf("invalid AWS prefix list ID %q", flagInputs.Connectivity.Topology.PrefixListID)
+	if flagInputs.Global.Connectivity.Topology.PrefixListID != "" && !strings.HasPrefix(flagInputs.Global.Connectivity.Topology.PrefixListID, "pl-") {
+		return "", fmt.Errorf("invalid AWS prefix list ID %q", flagInputs.Global.Connectivity.Topology.PrefixListID)
 	}
-	if flagInputs.Connectivity.Topology.TransitGatewayID != "" && !strings.HasPrefix(flagInputs.Connectivity.Topology.TransitGatewayID, "tgw-") {
-		return "", fmt.Errorf("invalid AWS transit gateway ID %q", flagInputs.Connectivity.Topology.TransitGatewayID)
+	if flagInputs.Global.Connectivity.Topology.TransitGatewayID != "" && !strings.HasPrefix(flagInputs.Global.Connectivity.Topology.TransitGatewayID, "tgw-") {
+		return "", fmt.Errorf("invalid AWS transit gateway ID %q", flagInputs.Global.Connectivity.Topology.TransitGatewayID)
 	}
 
 	var flagConfigData map[string]interface{}

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -1,6 +1,6 @@
 package capa
 
-type ClusterConfig struct {
+type Global struct {
 	Connectivity     *Connectivity           `json:"connectivity,omitempty"`
 	ControlPlane     *ControlPlane           `json:"controlPlane,omitempty"`
 	Metadata         *Metadata               `json:"metadata,omitempty"`
@@ -8,9 +8,13 @@ type ClusterConfig struct {
 	ProviderSpecific *ProviderSpecific       `json:"providerSpecific,omitempty"`
 }
 
+type ClusterConfig struct {
+	Global *Global `json:"global,omitempty"`
+}
+
 type Metadata struct {
-	Name         string `json:"name,omitempty"`
 	Description  string `json:"description,omitempty"`
+	Name         string `json:"name,omitempty"`
 	Organization string `json:"organization,omitempty"`
 }
 

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -2,32 +2,33 @@
 apiVersion: v1
 data:
   values: |
-    connectivity:
-      bastion:
-        enabled: true
-      network:
-        vpcCidr: 10.123.0.0/16
-      topology: {}
-    controlPlane:
-      instanceType: control-plane-instance-type
-    metadata:
-      description: just a test cluster
-      name: test1
-      organization: test
-    nodePools:
-      worker1:
-        availabilityZones:
-        - eu-west-1a
-        - eu-west-1b
-        customNodeLabels:
-        - label=value
-        instanceType: big-one
-        maxSize: 5
-        minSize: 2
-        rootVolumeSizeGB: 200
-    providerSpecific:
-      awsClusterRoleIdentityName: default
-      region: the-region
+    global:
+      connectivity:
+        bastion:
+          enabled: true
+        network:
+          vpcCidr: 10.123.0.0/16
+        topology: {}
+      controlPlane:
+        instanceType: control-plane-instance-type
+      metadata:
+        description: just a test cluster
+        name: test1
+        organization: test
+      nodePools:
+        worker1:
+          availabilityZones:
+          - eu-west-1a
+          - eu-west-1b
+          customNodeLabels:
+          - label=value
+          instanceType: big-one
+          maxSize: 5
+          minSize: 2
+          rootVolumeSizeGB: 200
+      providerSpecific:
+        awsClusterRoleIdentityName: default
+        region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_2.golden
@@ -2,51 +2,52 @@
 apiVersion: v1
 data:
   values: |
-    connectivity:
-      bastion:
-        enabled: true
-      network:
-        vpcCidr: 10.123.0.0/16
-      proxy:
-        enabled: true
-        httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-        httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-        noProxy: test-domain.com
-      subnets:
-      - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.123.0.0/18
-        - availabilityZone: b
-          cidr: 10.123.64.0/18
-        isPublic: false
-      topology:
-        mode: GiantSwarmManaged
-      vpcMode: private
-    controlPlane:
-      apiMode: private
-      instanceType: control-plane-instance-type
-      loadBalancerIngressAllowCidrBlocks:
-      - 1.2.3.4/32
-      - 5.6.7.8/32
-      - 9.10.11.12/32
-    metadata:
-      description: just a test cluster
-      name: test1
-      organization: test
-    nodePools:
-      worker1:
-        availabilityZones:
-        - eu-west-1a
-        - eu-west-1b
-        customNodeLabels:
-        - label=value
-        instanceType: big-one
-        maxSize: 5
-        minSize: 2
-        rootVolumeSizeGB: 200
-    providerSpecific:
-      awsClusterRoleIdentityName: default
-      region: the-region
+    global:
+      connectivity:
+        bastion:
+          enabled: true
+        network:
+          vpcCidr: 10.123.0.0/16
+        proxy:
+          enabled: true
+          httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+          httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+          noProxy: test-domain.com
+        subnets:
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.0.0/18
+          - availabilityZone: b
+            cidr: 10.123.64.0/18
+          isPublic: false
+        topology:
+          mode: GiantSwarmManaged
+        vpcMode: private
+      controlPlane:
+        apiMode: private
+        instanceType: control-plane-instance-type
+        loadBalancerIngressAllowCidrBlocks:
+        - 1.2.3.4/32
+        - 5.6.7.8/32
+        - 9.10.11.12/32
+      metadata:
+        description: just a test cluster
+        name: test1
+        organization: test
+      nodePools:
+        worker1:
+          availabilityZones:
+          - eu-west-1a
+          - eu-west-1b
+          customNodeLabels:
+          - label=value
+          instanceType: big-one
+          maxSize: 5
+          minSize: 2
+          rootVolumeSizeGB: 200
+      providerSpecific:
+        awsClusterRoleIdentityName: default
+        region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -2,54 +2,55 @@
 apiVersion: v1
 data:
   values: |
-    connectivity:
-      bastion:
-        enabled: true
-      network:
-        vpcCidr: 10.123.0.0/16
-      proxy:
-        enabled: true
-        httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-        httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-        noProxy: test-domain.com
-      subnets:
-      - cidrBlocks:
-        - availabilityZone: a
-          cidr: 10.123.0.0/18
-        - availabilityZone: b
-          cidr: 10.123.64.0/18
-        isPublic: false
-      topology:
-        mode: UserManaged
-        prefixListId: pl-123456789abc
-        transitGatewayId: tgw-987987987987def
-      vpcMode: private
-    controlPlane:
-      apiMode: public
-      instanceType: control-plane-instance-type
-      loadBalancerIngressAllowCidrBlocks:
-      - 1.2.3.4/32
-      - 5.6.7.8/32
-      - 9.10.11.12/32
-      - 7.7.7.7/32
-    metadata:
-      description: just a test cluster
-      name: test1
-      organization: test
-    nodePools:
-      worker1:
-        availabilityZones:
-        - eu-west-1a
-        - eu-west-1b
-        customNodeLabels:
-        - label=value
-        instanceType: big-one
-        maxSize: 5
-        minSize: 2
-        rootVolumeSizeGB: 200
-    providerSpecific:
-      awsClusterRoleIdentityName: other-identity
-      region: the-region
+    global:
+      connectivity:
+        bastion:
+          enabled: true
+        network:
+          vpcCidr: 10.123.0.0/16
+        proxy:
+          enabled: true
+          httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+          httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
+          noProxy: test-domain.com
+        subnets:
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.0.0/18
+          - availabilityZone: b
+            cidr: 10.123.64.0/18
+          isPublic: false
+        topology:
+          mode: UserManaged
+          prefixListId: pl-123456789abc
+          transitGatewayId: tgw-987987987987def
+        vpcMode: private
+      controlPlane:
+        apiMode: public
+        instanceType: control-plane-instance-type
+        loadBalancerIngressAllowCidrBlocks:
+        - 1.2.3.4/32
+        - 5.6.7.8/32
+        - 9.10.11.12/32
+        - 7.7.7.7/32
+      metadata:
+        description: just a test cluster
+        name: test1
+        organization: test
+      nodePools:
+        worker1:
+          availabilityZones:
+          - eu-west-1a
+          - eu-west-1b
+          customNodeLabels:
+          - label=value
+          instanceType: big-one
+          maxSize: 5
+          minSize: 2
+          rootVolumeSizeGB: 200
+      providerSpecific:
+        awsClusterRoleIdentityName: other-identity
+        region: the-region
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**BREAKING CHANGE**

New contract for CAPA clusters, see https://github.com/giantswarm/cluster-aws/tree/master/helm/cluster-aws#values-schema-documentation

Issue: https://github.com/giantswarm/roadmap/issues/2954

### What does this PR do?

We moved helm values of `cluster-aws` into `global chart values` because we want to split Common Clusters CR's and Provider CR's in different repos.
Therefore we need to move all shared values into `global chart values` for making them visible between multiple helm charts, e.g. cluster-aws <-> cluster.

More information on `global chart values` [here](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values).

The userconfig changes from:

```yaml
apiVersion: v1
data:
  values: |
    connectivity:
      availabilityZoneUsageLimit: 3
      bastion:
        enabled: true
      network: {}
      topology: {}
    controlPlane: {}
    metadata:
      name: nick
      organization: giantswarm
    nodePools:
      nodepool0:
        instanceType: m5.xlarge
        maxSize: 10
        minSize: 3
        rootVolumeSizeGB: 300
    providerSpecific: {}
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: nick
  name: nick-userconfig
  namespace: org-giantswarm
```

to

```yaml
apiVersion: v1
data:
  values: |
    global:
      connectivity:
        availabilityZoneUsageLimit: 3
        bastion:
          enabled: true
        network: {}
        topology: {}
      controlPlane: {}
      metadata:
        name: nick
        organization: giantswarm
      nodePools:
        nodepool0:
          instanceType: m5.xlarge
          maxSize: 10
          minSize: 3
          rootVolumeSizeGB: 300
      providerSpecific: {}
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: nick
  name: nick-userconfig
  namespace: org-giantswarm
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated