### PR TITLE
Make cluster name choice required for templating CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,23 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `kubectl gs template cluster`: Either `--name` or new `--generated-name` parameter is now required for CAPI cluster names. We kept the CLI backward-compatible for vintage, so if none of these parameters is specified, the old default of generating a random name still applies and no error is thrown.
+
 ## [2.49.1] - 2023-12-06
 
 ## [2.49.0] - 2023-12-05
 
-### Changed 
+### Changed
 
 - **BREAKING** All values of cluster userconfig for `CAPA` are moving under `global`.
 
 ## [2.48.1] - 2023-11-30
 
 ### Changed
-- Changed the length of random generated cluster names to `10`
+
+- Changed the length of randomly-generated cluster names to 10
 
 ## [2.48.0] - 2023-11-29
 

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -117,6 +117,7 @@ const (
 	flagControlPlaneInstanceType = "control-plane-instance-type"
 	flagControlPlaneAZ           = "control-plane-az"
 	flagDescription              = "description"
+	flagGenerateName             = "generate-name"
 	flagKubernetesVersion        = "kubernetes-version"
 	flagName                     = "name"
 	flagOIDCIssuerURL            = "oidc-issuer-url"
@@ -144,6 +145,7 @@ type flag struct {
 	// Common.
 	ControlPlaneAZ           []string
 	Description              string
+	GenerateName             bool
 	KubernetesVersion        string
 	Name                     string
 	Output                   string
@@ -332,7 +334,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ControlPlaneInstanceType, flagControlPlaneInstanceType, "", "Instance type used for Control plane nodes")
 	cmd.Flags().StringVar(&f.Description, flagDescription, "", "User-friendly description of the cluster's purpose (formerly called name).")
 	cmd.Flags().StringVar(&f.KubernetesVersion, flagKubernetesVersion, defaultKubernetesVersion, "Cluster Kubernetes version.")
-	cmd.Flags().StringVar(&f.Name, flagName, "", "Unique identifier of the cluster (formerly called ID).")
+	cmd.Flags().StringVar(&f.Name, flagName, "", fmt.Sprintf("Unique identifier of the cluster. You must specify either --%s or --%s (except for vintage where, for CLI compatibility, we kept the old default of randomly generating a name if you do not specify one of these flags).", flagName, flagGenerateName))
+	cmd.Flags().BoolVar(&f.GenerateName, flagGenerateName, false, fmt.Sprintf("Generate a random identifier of the cluster. We recommend to instead choose a name explicitly using --%s. You must specify either --%s or --%s (except for vintage where, for CLI compatibility, we kept the old default of randomly generating a name if you do not specify one of these flags).", flagName, flagName, flagGenerateName))
 	cmd.Flags().StringVar(&f.OIDC.IssuerURL, flagOIDCIssuerURL, "", "OIDC issuer URL.")
 	cmd.Flags().StringVar(&f.OIDC.CAFile, flagOIDCCAFile, "", "Path to CA file used to verify OIDC issuer (optional, OpenStack only).")
 	cmd.Flags().StringVar(&f.OIDC.ClientID, flagOIDCClientID, "", "OIDC client ID.")
@@ -384,7 +387,18 @@ func (f *flag) Validate(cmd *cobra.Command) error {
 		return microerror.Maskf(invalidFlagError, "--%s must be one of: %s", flagProvider, strings.Join(validProviders, ", "))
 	}
 
+	// For vintage, don't break CLI parameter compatibility. But for CAPI or newer implementations, we want to enforce
+	// an explicit choice for a specified name (`--name`) or randomly generated name (`--generate-name`).
+	requireEitherNameOrGenerateNameFlag := key.IsPureCAPIProvider(f.Provider)
+
 	if f.Name != "" {
+		if f.GenerateName {
+			return microerror.Maskf(
+				invalidFlagError,
+				"--%s and --%s are mutually exclusive. We recommend choosing a name explicitly using --%s.",
+				flagName, flagGenerateName, flagName)
+		}
+
 		valid, err := key.ValidateName(f.Name, true)
 		if err != nil {
 			return microerror.Mask(err)
@@ -396,6 +410,17 @@ func (f *flag) Validate(cmd *cobra.Command) error {
 			}
 			message += fmt.Sprintf(", and be no longer than %d characters in length", maxLength)
 			return microerror.Maskf(invalidFlagError, message)
+		}
+	} else if !f.GenerateName {
+		if requireEitherNameOrGenerateNameFlag {
+			return microerror.Maskf(
+				invalidFlagError,
+				"Either --%s or --%s must be specified. We recommend choosing a name explicitly using --%s.",
+				flagName, flagGenerateName, flagName)
+		} else {
+			// Keep supporting this old default for vintage (= no naming parameter given means to randomly
+			// generate a cluster name)
+			f.GenerateName = true
 		}
 	}
 

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"sort"
@@ -124,7 +125,6 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 		Description:              r.flag.Description,
 		KubernetesVersion:        r.flag.KubernetesVersion,
 		ManagementCluster:        r.flag.ManagementCluster,
-		Name:                     r.flag.Name,
 		Organization:             r.flag.Organization,
 		PodsCIDR:                 r.flag.PodsCIDR,
 		ReleaseVersion:           r.flag.Release,
@@ -141,13 +141,19 @@ func (r *runner) getClusterConfig() (provider.ClusterConfig, error) {
 		VSphere:   r.flag.VSphere,
 	}
 
-	if config.Name == "" {
+	if r.flag.GenerateName {
 		generatedName, err := key.GenerateName(true)
 		if err != nil {
 			return provider.ClusterConfig{}, microerror.Mask(err)
 		}
 
 		config.Name = generatedName
+	} else {
+		config.Name = r.flag.Name
+	}
+
+	if config.Name == "" {
+		return provider.ClusterConfig{}, errors.New("logic error in name assignment")
 	}
 
 	// Remove leading 'v' from release flag input.


### PR DESCRIPTION
### What does this PR do?

Implement https://github.com/giantswarm/roadmap/issues/2983

### What is the effect of this change to users?

| Provider | Flags | Result |
|-|-|-|
| Vintage | _none_ | Name randomly generated (old default is kept) |
| CAPI | _none_ | Error (parameter required from now on) |
| Vintage or CAPI | --name XYZ | Specified name is used, if valid |
| Vintage or CAPI | --generate-name | Name randomly generated |
| Vintage or CAPI | --name XYZ --generate-name | Error (parameters are mutually exclusive) |

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

Yes