### PR TITLE
Network CIDRs command generation

### DIFF
--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -38,6 +38,8 @@ const (
 	flagAWSPrefixListID                                  = "aws-prefix-list-id"
 	flagAWSTransitGatewayID                              = "aws-transit-gateway-id"
 	flagAWSControlPlaneLoadBalancerIngressAllowCIDRBlock = "control-plane-load-balancer-ingress-allow-cidr-block"
+	flagAWSPublicSubnetSize                              = "public-subnet-size"
+	flagAWSPrivateSubnetSize                             = "private-subnet-size"
 
 	flagAWSMachinePoolMinSize          = "machine-pool-min-size"
 	flagAWSMachinePoolMaxSize          = "machine-pool-max-size"
@@ -188,6 +190,9 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.AWS.TopologyMode, flagAWSTopologyMode, "", "Topology mode of the network (UserManaged,GiantSwarmManaged,None)")
 	cmd.Flags().StringVar(&f.AWS.PrefixListID, flagAWSPrefixListID, "", "Prefix list ID to manage. Workload cluster will be able to reach the destinations in the prefix list via the transit gateway. If not specified, it will be looked up by name/namespace of the management cluster (ends with `-tgw-prefixlist`). Only applies to proxy-private clusters.")
 	cmd.Flags().StringVar(&f.AWS.TransitGatewayID, flagAWSTransitGatewayID, "", "ID of the transit gateway to attach the cluster VPC to. If not specified for workload clusters, the management cluster's transit gateway will be used. Only applies to proxy-private clusters.")
+	cmd.Flags().IntVar(&f.AWS.PublicSubnetSize, flagAWSPublicSubnetSize, 20, "Size of the public subnets. Minimum size is 25.")
+	cmd.Flags().IntVar(&f.AWS.PrivateSubnetSize, flagAWSPrivateSubnetSize, 18, "Size of the private subnets. Minimum size is 25.")
+
 	// aws control plane
 	cmd.Flags().StringVar(&f.AWS.ControlPlaneSubnet, flagAWSControlPlaneSubnet, "", "Subnet used for the Control Plane.")
 	cmd.Flags().StringArrayVar(&f.AWS.ControlPlaneLoadBalancerIngressAllowCIDRBlocks, flagAWSControlPlaneLoadBalancerIngressAllowCIDRBlock, nil, fmt.Sprintf("IPv4 address ranges that are allowed to connect to the control plane load balancer, in CIDR notation. When setting this flag, kubectl-gs automatically adds the NAT Gateway IPs of the management cluster so that the workload cluster can still be managed. If only the management cluster's IP ranges should be allowed, specify one empty value instead of an IP range ('--%s \"\"'). Supported for CAPA. You also need to specify --%s.", flagAWSControlPlaneLoadBalancerIngressAllowCIDRBlock, flagManagementCluster))

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -40,6 +40,8 @@ type AWSConfig struct {
 	PrefixListID                                   string
 	TransitGatewayID                               string
 	ControlPlaneLoadBalancerIngressAllowCIDRBlocks []string
+	PublicSubnetSize                               int
+	PrivateSubnetSize                              int
 }
 
 type AWSMachinePoolConfig struct {


### PR DESCRIPTION
### What does this PR do?

Allows customization of network CIDRs

### What is the effect of this change to users?

Allows customers to change the CIDRs of the cluster.

### What does it look like?

```
kubectl gs template cluster --provider capa --organization giantswarm-production --descriptio
n "Giant Swarm Operations Cluster" --vpc-cidr 10.10.0.0/16 --az-usage-limit 2 --public-subnet-size 23 --private-su
bnet-size 21
```

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
