### PR TITLE
Don't fail on versioncheck error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Errors during update checks no longer interrupt the command execution.
+
 ## [2.52.1] - 2024-02-01
 
 No significant changes compared to v2.52.0. This release was made to ensure the proper distribution to all channels, which failed with the last release.

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -71,8 +71,7 @@ func (r *runner) persistentPostRun(ctx context.Context, cmd *cobra.Command, args
 	}
 
 	if r.flag.disableVersionCheck {
-		// User wants to risk their life and use an older version.
-		// Not my problem anymore.
+		// User disabled the update check.
 		return nil
 	}
 

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -106,7 +106,8 @@ func (r *runner) persistentPostRun(ctx context.Context, cmd *cobra.Command, args
 
 		return nil
 	} else if err != nil {
-		return microerror.Mask(err)
+		// Print, but do no quit. We don't want to get into the way of the user.
+		fmt.Fprintf(r.stderr, "Error while checking for a new version of %s: %s\n\n", project.Name(), microerror.Mask(err))
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

When checking for an update fails, e. g. because of an error accessing GitHub, the original command will be executed anyway. Previously the CLI would have quit with an error code.

Context: https://github.com/giantswarm/giantswarm/issues/29618

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No