### PR TITLE
Add `kubectl gs get nodepool` for CAPZ,CAPV and CAPVCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Add `kubectl gs get nodepools` for CAPA.
+- Add `kubectl gs get nodepools` for CAPA,CAPZ,CAPV and CAPVCD.
 
 ### Changed
 

--- a/cmd/get/nodepools/printer.go
+++ b/cmd/get/nodepools/printer.go
@@ -32,9 +32,18 @@ func (r *runner) printOutput(npResource nodepool.Resource) error {
 		case key.ProviderCAPA:
 			capabilities := feature.New(feature.ProviderCAPA)
 			resource = provider.GetCAPATable(npResource, capabilities)
+		case key.ProviderCAPZ:
+			capabilities := feature.New(feature.ProviderCAPZ)
+			resource = provider.GetCAPITable(npResource, capabilities)
 		case key.ProviderAzure:
 			capabilities := feature.New(feature.ProviderAzure)
 			resource = provider.GetAzureTable(npResource, capabilities)
+		case key.ProviderCloudDirector:
+			capabilities := feature.New(feature.ProviderCloudDirector)
+			resource = provider.GetCAPITable(npResource, capabilities)
+		case key.ProviderVSphere:
+			capabilities := feature.New(feature.ProviderVSphere)
+			resource = provider.GetCAPITable(npResource, capabilities)
 		}
 
 		printOptions := printers.PrintOptions{

--- a/cmd/get/nodepools/provider/capi_md.go
+++ b/cmd/get/nodepools/provider/capi_md.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+)
+
+func GetCAPITable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string"},
+			{Name: "Cluster Name", Type: "string"},
+			{Name: "Age", Type: "string", Format: "date-time"},
+			{Name: "Condition", Type: "string"},
+			{Name: "Nodes Min/Max", Type: "string"},
+			{Name: "Nodes Desired", Type: "integer"},
+			{Name: "Nodes Ready", Type: "integer"},
+			{Name: "Description", Type: "string"},
+		},
+	}
+
+	switch n := npResource.(type) {
+	case *nodepool.Nodepool:
+		table.Rows = append(table.Rows, getCAPINodePoolRow(*n, capabilities))
+	case *nodepool.Collection:
+		// Sort ASC by Cluster name.
+		sort.Slice(n.Items, func(i, j int) bool {
+			var iClusterName, jClusterName string
+
+			if n.Items[i].MachineDeployment != nil && n.Items[i].MachineDeployment.Labels != nil {
+				iClusterName = key.ClusterID(n.Items[i].MachineDeployment)
+			}
+			if n.Items[j].MachineDeployment != nil && n.Items[j].MachineDeployment.Labels != nil {
+				jClusterName = key.ClusterID(n.Items[j].MachineDeployment)
+			}
+
+			return strings.Compare(iClusterName, jClusterName) > 0
+		})
+		for _, nodePool := range n.Items {
+			table.Rows = append(table.Rows, getCAPINodePoolRow(nodePool, capabilities))
+		}
+	}
+
+	return table
+}
+
+func getCAPINodePoolRow(
+	nodePool nodepool.Nodepool,
+	capabilities *feature.Service,
+) metav1.TableRow {
+	if nodePool.MachineDeployment == nil {
+		return metav1.TableRow{}
+	}
+
+	return metav1.TableRow{
+		Cells: []interface{}{
+			nodePool.MachineDeployment.GetName(),
+			key.ClusterID(nodePool.MachineDeployment),
+			output.TranslateTimestampSince(nodePool.MachineDeployment.CreationTimestamp),
+			getCAPILatestCondition(nodePool, capabilities),
+			nodePool.MachineDeployment.Status.Replicas,
+			nodePool.MachineDeployment.Status.Replicas,
+			nodePool.MachineDeployment.Status.ReadyReplicas,
+			getCAPIDescription(nodePool),
+		},
+		Object: runtime.RawExtension{
+			Object: nodePool.MachineDeployment,
+		},
+	}
+}
+
+func getCAPILatestCondition(nodePool nodepool.Nodepool, capabilities *feature.Service) string {
+	if len(nodePool.MachineDeployment.Status.Conditions) > 0 {
+		return formatCondition(string(nodePool.MachineDeployment.Status.Conditions[0].Type))
+	}
+
+	return naValue
+}
+
+func getCAPIDescription(nodePool nodepool.Nodepool) string {
+	description := key.MachineDeploymentName(nodePool.MachineDeployment)
+	if len(description) < 1 {
+		description = naValue
+	}
+
+	return description
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/appcatalog v0.10.1
 	github.com/giantswarm/backoff v1.0.0
 	github.com/giantswarm/k8sclient/v7 v7.2.0
-	github.com/giantswarm/k8smetadata v0.23.0
+	github.com/giantswarm/k8smetadata v0.24.0
 	github.com/giantswarm/microerror v0.4.1
 	github.com/giantswarm/micrologger v1.1.1
 	github.com/giantswarm/organization-operator v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,6 @@ github.com/giantswarm/backoff v1.0.0 h1:1oeTvyPsm1tJrHlSmfxbIWuoCNWPOkWJCb8kfLvE
 github.com/giantswarm/backoff v1.0.0/go.mod h1:l/WqbggvG5Ndxxws0LUgVEvP5E82Qj5/PF8SMip/1QM=
 github.com/giantswarm/k8sclient/v7 v7.2.0 h1:twh4egNcuTJEH7R/hYVhs8nwEXPlr0u/o9CB1Kv9H9A=
 github.com/giantswarm/k8sclient/v7 v7.2.0/go.mod h1:kZGRtOqe4vAKXtWm69tsj2Q9CpWlwzpa1uP1lfDtjlE=
-github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
-github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/k8smetadata v0.24.0 h1:mAIgH4W06qx8X5rV9QEtJhCJLn8DMXfTfNVZi5ROp4c=
 github.com/giantswarm/k8smetadata v0.24.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/microerror v0.4.1 h1:WMiD7HQASoUA9lZzPlPK+erCEOJ0uT4cyo18VfCXHD0=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/giantswarm/k8sclient/v7 v7.2.0 h1:twh4egNcuTJEH7R/hYVhs8nwEXPlr0u/o9C
 github.com/giantswarm/k8sclient/v7 v7.2.0/go.mod h1:kZGRtOqe4vAKXtWm69tsj2Q9CpWlwzpa1uP1lfDtjlE=
 github.com/giantswarm/k8smetadata v0.23.0 h1:iGwa1Nb45Sfcd5wqJEKBvxY1u5yXFg3Sq5Fw62nyRGA=
 github.com/giantswarm/k8smetadata v0.23.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
+github.com/giantswarm/k8smetadata v0.24.0 h1:mAIgH4W06qx8X5rV9QEtJhCJLn8DMXfTfNVZi5ROp4c=
+github.com/giantswarm/k8smetadata v0.24.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/microerror v0.4.1 h1:WMiD7HQASoUA9lZzPlPK+erCEOJ0uT4cyo18VfCXHD0=
 github.com/giantswarm/microerror v0.4.1/go.mod h1:URFj0gFCmZihjya6saQCXxslBrgctXb4NsXYHB5JdrI=
 github.com/giantswarm/micrologger v1.1.1 h1:gpu9uq1Vixey20Zo5pra5m/5EsmLrNlTwIgjBoc1jhE=

--- a/internal/feature/providers.go
+++ b/internal/feature/providers.go
@@ -1,9 +1,12 @@
 package feature
 
 const (
-	ProviderAWS       = "aws"
-	ProviderAzure     = "azure"
-	ProviderKVM       = "kvm"
-	ProviderOpenStack = "openstack"
-	ProviderCAPA      = "capa"
+	ProviderAWS           = "aws"
+	ProviderAzure         = "azure"
+	ProviderKVM           = "kvm"
+	ProviderOpenStack     = "openstack"
+	ProviderCAPA          = "capa"
+	ProviderCAPZ          = "capz"
+	ProviderCloudDirector = "cloud-director"
+	ProviderVSphere       = "vspshere"
 )

--- a/internal/key/common.go
+++ b/internal/key/common.go
@@ -15,6 +15,15 @@ func ClusterID(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Cluster]
 }
 
+func MachineDeploymentName(getter AnnotationsGetter) string {
+	annotations := getter.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+
+	return annotations[annotation.MachineDeploymentName]
+}
+
 func MachinePoolName(getter AnnotationsGetter) string {
 	annotations := getter.GetAnnotations()
 	if annotations == nil {

--- a/pkg/data/domain/nodepool/capi_md.go
+++ b/pkg/data/domain/nodepool/capi_md.go
@@ -1,0 +1,74 @@
+package nodepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (s *Service) getAllCAPI(ctx context.Context, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{}
+	if len(clusterID) > 0 {
+		labelSelector[capi.ClusterNameLabel] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	machineDeployments := &capi.MachineDeploymentList{}
+	{
+		err = s.client.List(ctx, machineDeployments, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else if len(machineDeployments.Items) == 0 {
+			return nil, microerror.Mask(noResourcesError)
+		}
+	}
+
+	npCollection := &Collection{}
+	{
+		for _, cr := range machineDeployments.Items {
+			o := cr
+
+			np := Nodepool{
+				MachineDeployment: &o,
+			}
+			npCollection.Items = append(npCollection.Items, np)
+		}
+	}
+
+	return npCollection, nil
+}
+
+func (s *Service) getByIdCAPI(ctx context.Context, id, namespace, clusterID string) (Resource, error) {
+	var err error
+
+	labelSelector := runtimeClient.MatchingLabels{
+		label.MachineDeployment: id,
+	}
+	if len(clusterID) > 0 {
+		labelSelector[capi.ClusterNameLabel] = clusterID
+	}
+	inNamespace := runtimeClient.InNamespace(namespace)
+
+	np := &Nodepool{}
+
+	{
+		crs := &capi.MachineDeploymentList{}
+		err = s.client.List(ctx, crs, labelSelector, inNamespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(crs.Items) < 1 {
+			return nil, microerror.Mask(notFoundError)
+		}
+		np.MachineDeployment = &crs.Items[0]
+
+	}
+
+	return np, nil
+}

--- a/pkg/data/domain/nodepool/common.go
+++ b/pkg/data/domain/nodepool/common.go
@@ -48,6 +48,21 @@ func (s *Service) getByName(ctx context.Context, provider, name, namespace, clus
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
+		case key.ProviderCAPZ:
+			np, err = s.getByIdCAPI(ctx, name, namespace, clusterName)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		case key.ProviderCloudDirector:
+			np, err = s.getByIdCAPI(ctx, name, namespace, clusterName)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		case key.ProviderVSphere:
+			np, err = s.getByIdCAPI(ctx, name, namespace, clusterName)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
 		default:
 			return nil, microerror.Mask(invalidProviderError)
 		}
@@ -77,6 +92,24 @@ func (s *Service) getAll(ctx context.Context, provider, namespace, clusterID str
 
 		case key.ProviderCAPA:
 			npCollection, err = s.getAllCAPA(ctx, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+		case key.ProviderCAPZ:
+			npCollection, err = s.getAllCAPI(ctx, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+		case key.ProviderCloudDirector:
+			npCollection, err = s.getAllCAPI(ctx, namespace, clusterID)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+		case key.ProviderVSphere:
+			npCollection, err = s.getAllCAPI(ctx, namespace, clusterID)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1519

Since CAPVCD, CAPV and CAPZ are using machine deployments for now, I combined them by only scraping machine deployments and using the same pattern.

Example for CAPVCD:

```
kubectl-gs get nodepool -n org-giantswarm -c test-cncf1                                                                                                                                                                 
NAME                CLUSTER NAME   AGE   CONDITION   NODES MIN/MAX   NODES DESIRED   NODES READY   DESCRIPTION
test-cncf1-worker   test-cncf1     23h   READY       3               3               3             n/a
```