### PR TITLE
Fix authentication failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Errors during update checks no longer interrupt the command execution.
+- Fix authentication failure in case the browser sends multiple requests to the callback server during the `login` command execution
 
 ## [2.52.1] - 2024-02-01
 

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -154,6 +154,13 @@ func handleDeviceFlowOIDC(out io.Writer, i *installation.Installation) (authInfo
 // received from the authentication provider.
 func handleOIDCCallback(ctx context.Context, a *oidc.Authenticator) func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	return func(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+		// Handle any additional requests the browser makes (e.g. OPTIONS), otherwise the authentication process will fail
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			return callbackserver.FallthroughResult{Method: r.Method}, nil
+		}
+
+		// Handle GET request with the token
 		res, err := a.HandleIssuerResponse(ctx, r.URL.Query().Get("state"), r.URL.Query().Get("code"))
 		if err != nil {
 			failureTemplate, tErr := template.GetFailedHTMLTemplateReader()

--- a/pkg/callbackserver/callbackserver.go
+++ b/pkg/callbackserver/callbackserver.go
@@ -27,6 +27,11 @@ type CallbackServer struct {
 	readHeaderTimeout time.Duration
 }
 
+// FallthroughResult is an intermediate result returned by the callback function that should be skipped
+type FallthroughResult struct {
+	Method string
+}
+
 func New(config Config) (*CallbackServer, error) {
 	var err error
 
@@ -68,6 +73,10 @@ func (cs *CallbackServer) Run(ctx context.Context, callback CallbackFunc) (inter
 			result, err := callback(w, r)
 			if err != nil {
 				errorCh <- err
+				return
+			}
+
+			if _, ok := result.(FallthroughResult); ok {
 				return
 			}
 


### PR DESCRIPTION
### What does this PR do?

Fix authentication failure in case the browser sends multiple requests to the callback server during the `login` command execution

### What is the effect of this change to users?

The user experiencing problems with the `login` command resulting in the "SSO authentication failed" page being displayed in the browser will not experience the problem anymore

### What does it look like?

No visible changes apart

### Any background context you can provide?

Some users experienced problems when logging in to clusters using `kubectl gs login` standard flow. The command did not finish successfully. Instead the users saw a mysterious "SSO authentication failed" page loaded in their browser.

The problem was observed in specific environments - either certain Linux distributions or certain DEV/Canary versions of the browser (e.g. MS Edge Canary).

The root cause is that kubectl-gs expects the browser to make one GET request to the local callback server started during the login command, but browsers in some cases/environments send multiple requests (e.g. an OPTIONS request in addition to the expected GET request), and the callback server was not built to handle the additional requests.

### What is needed from the reviewers?

The best way to test the changes us to pull the latest changes from the PR, build kubectl-gs locally, use it to run the `login` command and check whether it works.

A Dev browser like MS Edge Canary can be used to test it in conditions, where it was failing.

### Do the docs need to be updated?

No need to update the docs.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
