### PR TITLE
support internal api in id token verification

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,5 +2,5 @@
 CVE-2024-24786 until=2024-03-31
 
 # pkg:golang/github.com/hashicorp/vault/api
-CVE-2024-2048 until=2024-04-31
-CVE-2024-2660 until=2024-04-31
+CVE-2024-2048 until=2024-04-30
+CVE-2024-2660 until=2024-04-30

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -3,3 +3,4 @@ CVE-2024-24786 until=2024-03-31
 
 # pkg:golang/github.com/hashicorp/vault/api
 CVE-2024-2048 until=2024-04-31
+CVE-2024-2660 until=2024-04-31

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,4 +2,4 @@
 CVE-2024-24786 until=2024-03-31
 
 # pkg:golang/github.com/hashicorp/vault/api
-CVE-2024-2048 until=2024-03-31
+CVE-2024-2048 until=2024-04-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Make error message actionable in case `kubectl gs template cluster` fails because the user did not log into, or point to, the management cluster
+- Support internal api URLs in `kubectl gs login` id token verification
+- Print a warning in case `kubectl gs login` id token verification fails but don't fail the command
 
 ## [2.52.2] - 2024-03-26
 

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -151,9 +151,9 @@ func (r *runner) loginWithInstallation(ctx context.Context, tokenOverride string
 		} else {
 			contextName := kubeconfig.GenerateKubeContextName(i.Codename)
 			if r.flag.DeviceAuth || r.isDeviceAuthContext(k8sConfigAccess, contextName) {
-				authResult, err = handleDeviceFlowOIDC(r.stdout, i)
+				authResult, err = handleDeviceFlowOIDC(r.stdout, r.stderr, i, r.flag.InternalAPI)
 			} else {
-				authResult, err = handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ConnectorID, r.flag.ClusterAdmin, r.flag.CallbackServerHost, r.flag.CallbackServerPort, r.flag.LoginTimeout)
+				authResult, err = handleOIDC(ctx, r.stdout, r.stderr, i, r.flag.ConnectorID, r.flag.ClusterAdmin, r.flag.InternalAPI, r.flag.CallbackServerHost, r.flag.CallbackServerPort, r.flag.LoginTimeout)
 				if err != nil && errors.Is(err, context.DeadlineExceeded) || IsAuthResponseTimedOut(err) {
 					fmt.Fprintf(r.stderr, "\nYour authentication flow timed out after %s. Please execute the same command again.\n", r.flag.LoginTimeout.String())
 					fmt.Fprintf(r.stderr, "You can use the --login-timeout flag to configure a longer timeout interval, for example --login-timeout=%.0fs.\n", 2*r.flag.LoginTimeout.Seconds())

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -37,7 +37,7 @@ var (
 )
 
 // handleOIDC executes the OIDC authentication against an installation's authentication provider.
-func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *installation.Installation, connectorID string, clusterAdmin bool, host string, port int, oidcResultTimeout time.Duration) (authInfo, error) {
+func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *installation.Installation, connectorID string, clusterAdmin bool, internalAPI bool, host string, port int, oidcResultTimeout time.Duration) (authInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, oidcResultTimeout)
 	defer cancel()
 
@@ -108,17 +108,25 @@ func handleOIDC(ctx context.Context, out io.Writer, errOut io.Writer, i *install
 		authResult.clientID = clientID
 	}
 
-	apiServerURL := i.K8sApiURL
+	var apiServerURL string
+	{
+		if internalAPI {
+			apiServerURL = i.K8sInternalApiURL
+		} else {
+			apiServerURL = i.K8sApiURL
+		}
+	}
+
 	caData := []byte(i.CACert)
 	err = VerifyIDTokenWithKubernetesAPI(authResult.token, apiServerURL, caData)
 	if err != nil {
-		return authInfo{}, microerror.Mask(err)
+		fmt.Fprintf(errOut, "%s\n\n", color.YellowString("OIDC flow succeeded but token verification returned error %s.", err.Error()))
 	}
 	return authResult, nil
 }
 
 // handleDeviceFlowOIDC executes the OIDC device authentication flow against an installation's authentication provider.
-func handleDeviceFlowOIDC(out io.Writer, i *installation.Installation) (authInfo, error) {
+func handleDeviceFlowOIDC(out io.Writer, errOut io.Writer, i *installation.Installation, internalAPI bool) (authInfo, error) {
 	auther := oidc.NewDeviceAuthenticator(clientID, i)
 
 	deviceCodeData, err := auther.LoadDeviceCode()
@@ -139,13 +147,20 @@ func handleDeviceFlowOIDC(out io.Writer, i *installation.Installation) (authInfo
 		refreshToken: deviceTokenData.RefreshToken,
 		clientID:     clientID,
 	}
+	var apiServerURL string
+	{
+		if internalAPI {
+			apiServerURL = i.K8sInternalApiURL
+		} else {
+			apiServerURL = i.K8sApiURL
+		}
+	}
 
-	apiServerURL := i.K8sApiURL
 	caData := []byte(i.CACert)
 
 	err = VerifyIDTokenWithKubernetesAPI(authResult.token, apiServerURL, caData)
 	if err != nil {
-		return authInfo{}, microerror.Mask(err)
+		fmt.Fprintf(errOut, "%s\n\n", color.YellowString("OIDC device flow succeeded but token verification returned error %s.", err.Error()))
 	}
 	return authResult, nil
 }


### PR DESCRIPTION
towards https://github.com/orgs/giantswarm/projects/273/views/50?sliceBy%5Bvalue%5D=BigMac+%F0%9F%8D%94&pane=issue&itemId=60522658

### What does this PR do?

The id token verification in the login command only used the standard api adress and not respect the `--internal-api` flag. Therefore it would fail for users with only access to the internal one. This fixes the problem.

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
