### PR TITLE
Update module version to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Removed
 
-- Remove deprecated `--enable-long-name` flag (affected commands: kubectl gs template cluster/nodepool/networkpool/catalog)
+- **BREAKING** Remove deprecated `--enable-long-name` flag (affected commands: kubectl gs template cluster/nodepool/networkpool/catalog)
 
 ### Changed
 
-- **BREAKING** CAPA only change for new releases: render release version in config instead of cluster-aws version in App resource.
+- **BREAKING** When templating cluster manifests for CAPA clusters with `kubectl gs template cluster` command, now we set the workload cluster release version via the `--release` flag (like for vintage AWS), instead setting cluster-aws version via `--cluster-version`. 
 - Update module version to v3.
 
 ## [2.57.0] - 2024-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- CAPA only change for new releases: render release version in config instead of cluster-aws version in App resource.
+- **BREAKING** CAPA only change for new releases: render release version in config instead of cluster-aws version in App resource.
+- Update module version to v3.
 
 ## [2.57.0] - 2024-06-21
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 const (

--- a/cmd/get/apps/command.go
+++ b/cmd/get/apps/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/apps/printer.go
+++ b/cmd/get/apps/printer.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func (r *runner) printOutput(appResource app.Resource) error {

--- a/cmd/get/apps/runner.go
+++ b/cmd/get/apps/runner.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/capi/command.go
+++ b/cmd/get/capi/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/get/capi/runner.go
+++ b/cmd/get/capi/runner.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/get/catalogs/command.go
+++ b/cmd/get/catalogs/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/catalogs/printer.go
+++ b/cmd/get/catalogs/printer.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	catalogdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/catalog"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	catalogdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func (r *runner) printOutput(catalogResource catalogdata.Resource, maxColWidth uint) error {

--- a/cmd/get/catalogs/runner.go
+++ b/cmd/get/catalogs/runner.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	catalogdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/catalog"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	catalogdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/clusters/command.go
+++ b/cmd/get/clusters/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/clusters/printer.go
+++ b/cmd/get/clusters/printer.go
@@ -7,10 +7,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/clusters/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/clusters/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func (r *runner) printOutput(clusterResource cluster.Resource) error {

--- a/cmd/get/clusters/printer_test.go
+++ b/cmd/get/clusters/printer_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/giantswarm/k8smetadata/pkg/label"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = goflag.Bool("update", false, "update .golden reference test files")

--- a/cmd/get/clusters/provider/aws.go
+++ b/cmd/get/clusters/provider/aws.go
@@ -5,9 +5,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetAWSTable(clusterResource cluster.Resource) *metav1.Table {

--- a/cmd/get/clusters/provider/azure.go
+++ b/cmd/get/clusters/provider/azure.go
@@ -4,9 +4,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetAzureTable(clusterResource cluster.Resource) *metav1.Table {

--- a/cmd/get/clusters/provider/common.go
+++ b/cmd/get/clusters/provider/common.go
@@ -6,14 +6,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
 
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
 )
 
 const (

--- a/cmd/get/clusters/provider/openstack.go
+++ b/cmd/get/clusters/provider/openstack.go
@@ -4,8 +4,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetOpenStackTable(clusterResource cluster.Resource) *metav1.Table {

--- a/cmd/get/clusters/runner.go
+++ b/cmd/get/clusters/runner.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/clusters/runner_test.go
+++ b/cmd/get/clusters/runner_test.go
@@ -15,13 +15,13 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 // Test_run uses golden files.

--- a/cmd/get/command.go
+++ b/cmd/get/command.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/apps"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/capi"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/catalogs"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/clusters"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/nodepools"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/orgs"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/releases"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/apps"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/capi"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/catalogs"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/clusters"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/nodepools"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/orgs"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/releases"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/get/nodepools/command.go
+++ b/cmd/get/nodepools/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/nodepools/printer.go
+++ b/cmd/get/nodepools/printer.go
@@ -7,11 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get/nodepools/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get/nodepools/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type PrintOptions struct {

--- a/cmd/get/nodepools/printer_test.go
+++ b/cmd/get/nodepools/printer_test.go
@@ -19,10 +19,10 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = goflag.Bool("update", false, "update .golden reference test files")

--- a/cmd/get/nodepools/provider/aws.go
+++ b/cmd/get/nodepools/provider/aws.go
@@ -8,10 +8,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetAWSTable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {

--- a/cmd/get/nodepools/provider/azure.go
+++ b/cmd/get/nodepools/provider/azure.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetAzureTable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {

--- a/cmd/get/nodepools/provider/capa.go
+++ b/cmd/get/nodepools/provider/capa.go
@@ -8,10 +8,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetCAPATable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {

--- a/cmd/get/nodepools/provider/capi_md.go
+++ b/cmd/get/nodepools/provider/capi_md.go
@@ -7,10 +7,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/feature"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/internal/feature"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func GetCAPITable(npResource nodepool.Resource, capabilities *feature.Service) *metav1.Table {

--- a/cmd/get/nodepools/runner.go
+++ b/cmd/get/nodepools/runner.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/nodepools/runner_test.go
+++ b/cmd/get/nodepools/runner_test.go
@@ -14,13 +14,13 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 // Test_run uses golden files.

--- a/cmd/get/orgs/command.go
+++ b/cmd/get/orgs/command.go
@@ -7,15 +7,15 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/orgs/printer.go
+++ b/cmd/get/orgs/printer.go
@@ -7,13 +7,13 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
 )
 
 type PrintOptions struct {

--- a/cmd/get/orgs/printer_test.go
+++ b/cmd/get/orgs/printer_test.go
@@ -11,9 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 func Test_printOutput(t *testing.T) {

--- a/cmd/get/orgs/runner.go
+++ b/cmd/get/orgs/runner.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/orgs/runner_test.go
+++ b/cmd/get/orgs/runner_test.go
@@ -12,12 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeclient"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeclient"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 func Test_run(t *testing.T) {

--- a/cmd/get/releases/command.go
+++ b/cmd/get/releases/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/get/releases/printer.go
+++ b/cmd/get/releases/printer.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/release"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 const (

--- a/cmd/get/releases/runner.go
+++ b/cmd/get/releases/runner.go
@@ -12,9 +12,9 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/release"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 type runner struct {

--- a/cmd/get/runner.go
+++ b/cmd/get/runner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 type runner struct {

--- a/cmd/gitops/add/app/runner.go
+++ b/cmd/gitops/add/app/runner.go
@@ -12,10 +12,10 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/app"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	commonkey "github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/app"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	commonkey "github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 type runner struct {

--- a/cmd/gitops/add/automatic-updates/runner.go
+++ b/cmd/gitops/add/automatic-updates/runner.go
@@ -10,9 +10,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/updates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/updates"
 )
 
 type runner struct {

--- a/cmd/gitops/add/base/command.go
+++ b/cmd/gitops/add/base/command.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/gitops/add/base/flag.go
+++ b/cmd/gitops/add/base/flag.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 const (

--- a/cmd/gitops/add/base/runner.go
+++ b/cmd/gitops/add/base/runner.go
@@ -7,25 +7,25 @@ import (
 
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capv"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capz"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/openstack"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/base"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capv"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capz"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/openstack"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/base"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 
-	providers "github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capa"
-	capg "github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/gcp"
+	providers "github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capa"
+	capg "github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/gcp"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 type runner struct {

--- a/cmd/gitops/add/command.go
+++ b/cmd/gitops/add/command.go
@@ -11,13 +11,13 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	app "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/app"
-	autoup "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/automatic-updates"
-	base "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/base"
-	enc "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/encryption"
-	mc "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/management-cluster"
-	org "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/organization"
-	wc "github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add/workload-cluster"
+	app "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/app"
+	autoup "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/automatic-updates"
+	base "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/base"
+	enc "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/encryption"
+	mc "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/management-cluster"
+	org "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/organization"
+	wc "github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add/workload-cluster"
 )
 
 const (

--- a/cmd/gitops/add/encryption/runner.go
+++ b/cmd/gitops/add/encryption/runner.go
@@ -10,11 +10,11 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/encryption"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/encryption"
 )
 
 type runner struct {

--- a/cmd/gitops/add/management-cluster/runner.go
+++ b/cmd/gitops/add/management-cluster/runner.go
@@ -10,10 +10,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/encryption"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/management-cluster"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/management-cluster"
 )
 
 const (

--- a/cmd/gitops/add/organization/runner.go
+++ b/cmd/gitops/add/organization/runner.go
@@ -9,9 +9,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/organization"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/organization"
 )
 
 type runner struct {

--- a/cmd/gitops/add/workload-cluster/runner.go
+++ b/cmd/gitops/add/workload-cluster/runner.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/workload-cluster"
-	commonkey "github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/workload-cluster"
+	commonkey "github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 type runner struct {

--- a/cmd/gitops/command.go
+++ b/cmd/gitops/command.go
@@ -11,8 +11,8 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/gitops/add"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/gitops/initialize"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/gitops/add"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/gitops/initialize"
 )
 
 const (

--- a/cmd/gitops/initialize/runner.go
+++ b/cmd/gitops/initialize/runner.go
@@ -9,8 +9,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	structure "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/root"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	structure "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/root"
 )
 
 type runner struct {

--- a/cmd/login/auth.go
+++ b/cmd/login/auth.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/oidc"
 )
 
 type authInfo struct {

--- a/cmd/login/aws.go
+++ b/cmd/login/aws.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
 )
 
 type eksClusterConfig struct {

--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -26,13 +26,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	kgslabel "github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/clientcert"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	kgslabel "github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/clientcert"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/release"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
 )
 
 const (

--- a/cmd/login/clientcert_test.go
+++ b/cmd/login/clientcert_test.go
@@ -12,7 +12,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 func Test_ClientCert_SelfContainedFiles(t *testing.T) {

--- a/cmd/login/command.go
+++ b/cmd/login/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -10,8 +10,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
 )
 
 func (r *runner) findContext(ctx context.Context, installationIdentifier string) (bool, error) {

--- a/cmd/login/oidc.go
+++ b/cmd/login/oidc.go
@@ -14,10 +14,10 @@ import (
 	"github.com/skratchdot/open-golang/open"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/login/template"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/callbackserver"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/login/template"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/callbackserver"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/oidc"
 )
 
 const (

--- a/cmd/login/runner.go
+++ b/cmd/login/runner.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
 )
 
 type runner struct {

--- a/cmd/login/runner_config_modify_test.go
+++ b/cmd/login/runner_config_modify_test.go
@@ -33,8 +33,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	testoidc "github.com/giantswarm/kubectl-gs/v2/test/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	testoidc "github.com/giantswarm/kubectl-gs/v3/test/oidc"
 )
 
 func TestKubeConfigModification(t *testing.T) {

--- a/cmd/login/runner_test.go
+++ b/cmd/login/runner_test.go
@@ -19,10 +19,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
-	testoidc "github.com/giantswarm/kubectl-gs/v2/test/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
+	testoidc "github.com/giantswarm/kubectl-gs/v3/test/oidc"
 )
 
 func TestLogin(t *testing.T) {

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/clientcert"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/release"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/clientcert"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/release"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
 )
 
 const (

--- a/cmd/login/wc_test.go
+++ b/cmd/login/wc_test.go
@@ -34,11 +34,11 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	//nolint:staticcheck
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeclient"
-	testoidc "github.com/giantswarm/kubectl-gs/v2/test/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeclient"
+	testoidc "github.com/giantswarm/kubectl-gs/v3/test/oidc"
 )
 
 func TestWCClientCert(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,14 +10,14 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/get"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/gitops"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/login"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/selfupdate"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/update"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/validate"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/project"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/get"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/gitops"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/login"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/selfupdate"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/update"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/validate"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/project"
 )
 
 const (

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -10,9 +10,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/project"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/selfupdate"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/project"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/selfupdate"
 )
 
 type runner struct {

--- a/cmd/selfupdate/runner.go
+++ b/cmd/selfupdate/runner.go
@@ -10,9 +10,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/selfupdate"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/selfupdate"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/project"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/project"
 )
 
 type runner struct {

--- a/cmd/template/app/flag.go
+++ b/cmd/template/app/flag.go
@@ -8,8 +8,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/annotations"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/labels"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/annotations"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/labels"
 )
 
 const (

--- a/cmd/template/app/runner.go
+++ b/cmd/template/app/runner.go
@@ -15,10 +15,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/annotations"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/labels"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/annotations"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/labels"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 type runner struct {

--- a/cmd/template/catalog/runner.go
+++ b/cmd/template/catalog/runner.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templatecatalog "github.com/giantswarm/kubectl-gs/v2/pkg/template/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templatecatalog "github.com/giantswarm/kubectl-gs/v3/pkg/template/catalog"
 )
 
 type runner struct {

--- a/cmd/template/cluster/command.go
+++ b/cmd/template/cluster/command.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/template/cluster/flag.go
+++ b/cmd/template/cluster/flag.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/labels"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/labels"
 )
 
 const (

--- a/cmd/template/cluster/provider/aws.go
+++ b/cmd/template/cluster/provider/aws.go
@@ -10,8 +10,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/aws"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/aws"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config ClusterConfig) error {

--- a/cmd/template/cluster/provider/azure.go
+++ b/cmd/template/cluster/provider/azure.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
 )
 
 const (

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -20,9 +20,9 @@ import (
 	gsannotation "github.com/giantswarm/k8smetadata/pkg/annotation"
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capa"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capa"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 const (

--- a/cmd/template/cluster/provider/capg.go
+++ b/cmd/template/cluster/provider/capg.go
@@ -11,9 +11,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
-	capg "github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/gcp"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	capg "github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/gcp"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 const (

--- a/cmd/template/cluster/provider/capo.go
+++ b/cmd/template/cluster/provider/capo.go
@@ -11,9 +11,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/openstack"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/openstack"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 func WriteOpenStackTemplate(ctx context.Context, k8sClient k8sclient.Interface, output io.Writer, config ClusterConfig) error {

--- a/cmd/template/cluster/provider/capv.go
+++ b/cmd/template/cluster/provider/capv.go
@@ -14,9 +14,9 @@ import (
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capv"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capv"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 const (

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -13,9 +13,9 @@ import (
 
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capz"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capz"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 const (

--- a/cmd/template/cluster/provider/common.go
+++ b/cmd/template/cluster/provider/common.go
@@ -17,7 +17,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/app"
 )
 
 type AWSConfig struct {

--- a/cmd/template/cluster/provider/eks.go
+++ b/cmd/template/cluster/provider/eks.go
@@ -12,10 +12,10 @@ import (
 
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/capa"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider/templates/eks"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/capa"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider/templates/eks"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	templateapp "github.com/giantswarm/kubectl-gs/v3/pkg/template/app"
 )
 
 const (

--- a/cmd/template/cluster/provider/templates/aws/cluster.go
+++ b/cmd/template/cluster/provider/templates/aws/cluster.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 const (

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -14,10 +14,10 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/labels"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/labels"
 )
 
 type runner struct {

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -14,10 +14,10 @@ import (
 	capainfrav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 
 	//nolint:staticcheck
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/provider"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeclient"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/provider"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeclient"
 )
 
 var update = goflag.Bool("update", false, "update .golden reference test files")

--- a/cmd/template/command.go
+++ b/cmd/template/command.go
@@ -9,13 +9,13 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/app"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/catalog"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/networkpool"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/nodepool"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/organization"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/networkpool"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/nodepool"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/organization"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/template/networkpool/provider/common.go
+++ b/cmd/template/networkpool/provider/common.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/cluster/util"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/cluster/util"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 type NetworkPoolCRsConfig struct {

--- a/cmd/template/networkpool/runner.go
+++ b/cmd/template/networkpool/runner.go
@@ -9,8 +9,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/networkpool/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/networkpool/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 const (

--- a/cmd/template/nodepool/command.go
+++ b/cmd/template/nodepool/command.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/template/nodepool/flag.go
+++ b/cmd/template/nodepool/flag.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 const (

--- a/cmd/template/nodepool/provider/aws.go
+++ b/cmd/template/nodepool/provider/aws.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/nodepool/provider/templates/aws"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/nodepool/provider/templates/aws"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 func WriteAWSTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {

--- a/cmd/template/nodepool/provider/azure.go
+++ b/cmd/template/nodepool/provider/azure.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
 )
 
 func WriteAzureTemplate(ctx context.Context, client k8sclient.Interface, out io.Writer, config NodePoolCRsConfig) error {

--- a/cmd/template/nodepool/provider/templates/aws/nodepool.go
+++ b/cmd/template/nodepool/provider/templates/aws/nodepool.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 const (

--- a/cmd/template/nodepool/runner.go
+++ b/cmd/template/nodepool/runner.go
@@ -10,9 +10,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/template/nodepool/provider"
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/template/nodepool/provider"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/template/nodepool/runner_test.go
+++ b/cmd/template/nodepool/runner_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
 )
 
 func Test_run(t *testing.T) {

--- a/cmd/template/organization/runner.go
+++ b/cmd/template/organization/runner.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	template "github.com/giantswarm/kubectl-gs/v2/pkg/template/organization"
+	template "github.com/giantswarm/kubectl-gs/v3/pkg/template/organization"
 )
 
 type runner struct {

--- a/cmd/template/organization/runner_test.go
+++ b/cmd/template/organization/runner_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = goflag.Bool("update", false, "update .golden reference test files")

--- a/cmd/template/runner.go
+++ b/cmd/template/runner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 type runner struct {

--- a/cmd/update/app/command.go
+++ b/cmd/update/app/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/update/app/runner.go
+++ b/cmd/update/app/runner.go
@@ -10,8 +10,8 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
 )
 
 type runner struct {

--- a/cmd/update/app/runner_test.go
+++ b/cmd/update/app/runner_test.go
@@ -20,11 +20,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 const (

--- a/cmd/update/cluster/command.go
+++ b/cmd/update/cluster/command.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 const (

--- a/cmd/update/cluster/runner.go
+++ b/cmd/update/cluster/runner.go
@@ -12,9 +12,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
 )
 
 type runner struct {

--- a/cmd/update/cluster/runner_test.go
+++ b/cmd/update/cluster/runner_test.go
@@ -15,12 +15,12 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 func Test_run(t *testing.T) {

--- a/cmd/update/command.go
+++ b/cmd/update/command.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/update/app"
-	"github.com/giantswarm/kubectl-gs/v2/cmd/update/cluster"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/update/app"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/update/cluster"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/update/runner.go
+++ b/cmd/update/runner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 type runner struct {

--- a/cmd/validate/apps/command.go
+++ b/cmd/validate/apps/command.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware/renewtoken"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware/renewtoken"
 )
 
 var (

--- a/cmd/validate/apps/printer.go
+++ b/cmd/validate/apps/printer.go
@@ -7,9 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/output"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/pluralize"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/output"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/pluralize"
 )
 
 func (r *runner) printOutput(results app.ValidationResults) error {

--- a/cmd/validate/apps/report_printer.go
+++ b/cmd/validate/apps/report_printer.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/pluralize"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/pluralize"
 )
 
 // PrintReport prints app validation

--- a/cmd/validate/apps/runner.go
+++ b/cmd/validate/apps/runner.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/app"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/app"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/validate/command.go
+++ b/cmd/validate/command.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd/validate/apps"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/cmd/validate/apps"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 const (

--- a/cmd/validate/runner.go
+++ b/cmd/validate/runner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/commonconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/commonconfig"
 )
 
 type runner struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/kubectl-gs/v2
+module github.com/giantswarm/kubectl-gs/v3
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -238,6 +238,7 @@ require (
 replace (
 	github.com/docker/docker => github.com/moby/moby v27.0.1+incompatible
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+	github.com/hashicorp/go-retryablehttp => github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/vault/api => github.com/hashicorp/vault/api v1.14.0
 	github.com/opencontainers/runc v1.1.2 => github.com/opencontainers/runc v1.1.5
 	go.mozilla.org/sops/v3 => github.com/getsops/sops/v3 v3.8.1

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/go-retryablehttp v0.7.6 h1:TwRYfx2z2C4cLbXmT8I5PgP/xmuqASDyiVuGYfs9GZM=
-github.com/hashicorp/go-retryablehttp v0.7.6/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
+github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 h1:UpiO20jno/eV1eVZcxqWnUohyKRe1g8FPV/xH1s/2qs=

--- a/internal/gitops/filesystem/creator/types.go
+++ b/internal/gitops/filesystem/creator/types.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/afero"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
 )
 
 const (

--- a/internal/gitops/filesystem/modifier/flux-kustomization/kustomization.go
+++ b/internal/gitops/filesystem/modifier/flux-kustomization/kustomization.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/helper"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/helper"
 )
 
 type KustomizationModifier struct {

--- a/internal/gitops/filesystem/modifier/secret/secret.go
+++ b/internal/gitops/filesystem/modifier/secret/secret.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/helper"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/helper"
 )
 
 type SecretModifier struct {

--- a/internal/gitops/filesystem/modifier/sigs-kustomization/kustomization.go
+++ b/internal/gitops/filesystem/modifier/sigs-kustomization/kustomization.go
@@ -3,7 +3,7 @@ package sigskus
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/helper"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/helper"
 )
 
 type empty struct{}

--- a/internal/gitops/filesystem/modifier/sops/sops.go
+++ b/internal/gitops/filesystem/modifier/sops/sops.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/helper"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/helper"
 )
 
 const (

--- a/internal/gitops/structure/app/app.go
+++ b/internal/gitops/structure/app/app.go
@@ -6,12 +6,12 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
-	sigskusmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/sigs-kustomization"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	apptmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/app/templates"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
+	sigskusmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/sigs-kustomization"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	apptmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/app/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 const (

--- a/internal/gitops/structure/app/app_test.go
+++ b/internal/gitops/structure/app/app_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/app/templates/template.go
+++ b/internal/gitops/structure/app/templates/template.go
@@ -3,7 +3,7 @@ package app
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed appcr.yaml.tmpl

--- a/internal/gitops/structure/base/base.go
+++ b/internal/gitops/structure/base/base.go
@@ -3,10 +3,10 @@ package base
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	base "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/base/templates"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	base "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/base/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 func NewClusterBase(config common.StructureConfig) (*creator.CreatorConfig, error) {

--- a/internal/gitops/structure/base/base_test.go
+++ b/internal/gitops/structure/base/base_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/base/templates/template.go
+++ b/internal/gitops/structure/base/templates/template.go
@@ -3,7 +3,7 @@ package base
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed kustomization.yaml.tmpl

--- a/internal/gitops/structure/common/common.go
+++ b/internal/gitops/structure/common/common.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
 )
 
 // AppendFromTemplate add files from the given template to the

--- a/internal/gitops/structure/common/types.go
+++ b/internal/gitops/structure/common/types.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/encryption"
 )
 
 type StructureConfig struct {

--- a/internal/gitops/structure/encryption/encryption.go
+++ b/internal/gitops/structure/encryption/encryption.go
@@ -1,13 +1,13 @@
 package encryption
 
 import (
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
-	fluxkusmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/flux-kustomization"
-	secmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/secret"
-	sopsmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/sops"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
+	fluxkusmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/flux-kustomization"
+	secmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/secret"
+	sopsmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/sops"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 const (

--- a/internal/gitops/structure/management-cluster/cluster.go
+++ b/internal/gitops/structure/management-cluster/cluster.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/encryption"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
-	sopsmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/sops"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	mctmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/management-cluster/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
+	sopsmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/sops"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	mctmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/management-cluster/templates"
 )
 
 // NewManagementCluster creates a new Management Cluster directory

--- a/internal/gitops/structure/management-cluster/cluster_test.go
+++ b/internal/gitops/structure/management-cluster/cluster_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/encryption"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/encryption"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/management-cluster/templates/template.go
+++ b/internal/gitops/structure/management-cluster/templates/template.go
@@ -3,7 +3,7 @@ package mgmtcluster
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed management-cluster.yaml.tmpl

--- a/internal/gitops/structure/organization/organization.go
+++ b/internal/gitops/structure/organization/organization.go
@@ -3,10 +3,10 @@ package organization
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	orgtmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/organization/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	orgtmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/organization/templates"
 )
 
 // NewOrganization creates a new Organization directory

--- a/internal/gitops/structure/organization/organization_test.go
+++ b/internal/gitops/structure/organization/organization_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/organization/templates/template.go
+++ b/internal/gitops/structure/organization/templates/template.go
@@ -3,7 +3,7 @@ package organization
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed organization.yaml.tmpl

--- a/internal/gitops/structure/root/root.go
+++ b/internal/gitops/structure/root/root.go
@@ -3,10 +3,10 @@ package root
 import (
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	roottmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/root/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	roottmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/root/templates"
 )
 
 const (

--- a/internal/gitops/structure/root/templates/template.go
+++ b/internal/gitops/structure/root/templates/template.go
@@ -3,7 +3,7 @@ package root
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed pre-commit.tmpl

--- a/internal/gitops/structure/updates/templates/template.go
+++ b/internal/gitops/structure/updates/templates/template.go
@@ -3,7 +3,7 @@ package autoupdate
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed imagepolicy.yaml.tmpl

--- a/internal/gitops/structure/updates/updates.go
+++ b/internal/gitops/structure/updates/updates.go
@@ -6,13 +6,13 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
-	appmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/app"
-	sigskusmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/sigs-kustomization"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	updatetmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/updates/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
+	appmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/app"
+	sigskusmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/sigs-kustomization"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	updatetmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/updates/templates"
 )
 
 const (

--- a/internal/gitops/structure/updates/updates_test.go
+++ b/internal/gitops/structure/updates/updates_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/workload-cluster/cluster.go
+++ b/internal/gitops/structure/workload-cluster/cluster.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/creator"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier"
-	fluxkusmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/flux-kustomization"
-	sigskusmod "github.com/giantswarm/kubectl-gs/v2/internal/gitops/filesystem/modifier/sigs-kustomization"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/key"
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
-	wctmpl "github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/workload-cluster/templates"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/creator"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier"
+	fluxkusmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/flux-kustomization"
+	sigskusmod "github.com/giantswarm/kubectl-gs/v3/internal/gitops/filesystem/modifier/sigs-kustomization"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
+	wctmpl "github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/workload-cluster/templates"
 )
 
 // NewWorkloadCluster creates a new Workload Cluster directory

--- a/internal/gitops/structure/workload-cluster/cluster_test.go
+++ b/internal/gitops/structure/workload-cluster/cluster_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 type FsObjectExpected struct {

--- a/internal/gitops/structure/workload-cluster/templates/template.go
+++ b/internal/gitops/structure/workload-cluster/templates/template.go
@@ -3,7 +3,7 @@ package workcluster
 import (
 	_ "embed"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/gitops/structure/common"
+	"github.com/giantswarm/kubectl-gs/v3/internal/gitops/structure/common"
 )
 
 //go:embed apps_kustomization.yaml.tmpl

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -19,7 +19,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/normalize"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/normalize"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/kubectl-gs/v2/cmd"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/errorprinter"
+	"github.com/giantswarm/kubectl-gs/v3/cmd"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/errorprinter"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )

--- a/pkg/app/service.go
+++ b/pkg/app/service.go
@@ -7,9 +7,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	catalogdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/catalog"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/helmbinary"
+	appdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	catalogdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/helmbinary"
 )
 
 var _ Interface = &Service{}

--- a/pkg/app/validate.go
+++ b/pkg/app/validate.go
@@ -13,10 +13,10 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	appdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/app"
-	catalogdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/catalog"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/helmbinary"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	appdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/app"
+	catalogdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/catalog"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/helmbinary"
 )
 
 const (

--- a/pkg/commonconfig/commonconfig.go
+++ b/pkg/commonconfig/commonconfig.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
 )
 
 const (

--- a/pkg/commonconfig/commonconfig_test.go
+++ b/pkg/commonconfig/commonconfig_test.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 func TestCommonConfig_GetProviderFromInstallation(t *testing.T) {

--- a/pkg/data/domain/app/service.go
+++ b/pkg/data/domain/app/service.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	catalogdata "github.com/giantswarm/kubectl-gs/v2/pkg/data/domain/catalog"
+	catalogdata "github.com/giantswarm/kubectl-gs/v3/pkg/data/domain/catalog"
 )
 
 var _ Interface = &Service{}

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {

--- a/pkg/data/domain/nodepool/common.go
+++ b/pkg/data/domain/nodepool/common.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 func (s *Service) Get(ctx context.Context, options GetOptions) (Resource, error) {

--- a/pkg/errorprinter/errorprinter_test.go
+++ b/pkg/errorprinter/errorprinter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = goflag.Bool("update", false, "update .golden reference test files")

--- a/pkg/graphql/client_test.go
+++ b/pkg/graphql/client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = flag.Bool("update", false, "update .golden reference test files")

--- a/pkg/installation/info.go
+++ b/pkg/installation/info.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/graphql"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/graphql"
 )
 
 const infoQuery = `

--- a/pkg/installation/info_test.go
+++ b/pkg/installation/info_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/graphql"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/graphql"
 )
 
 func Test_getInstallationInfo(t *testing.T) {

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/graphql"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/graphql"
 )
 
 const (

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/label"
+	"github.com/giantswarm/kubectl-gs/v3/internal/label"
 )
 
 // Logic partially lifted from https://github.com/kubernetes/kubectl/blob/445ad13/pkg/cmd/label/label.go#L400-L425

--- a/pkg/middleware/renewtoken/renewtoken.go
+++ b/pkg/middleware/renewtoken/renewtoken.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/kubeconfig"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/pkg/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/oidc"
 )
 
 const (

--- a/pkg/middleware/renewtoken/renewtoken_test.go
+++ b/pkg/middleware/renewtoken/renewtoken_test.go
@@ -23,8 +23,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/middleware"
-	"github.com/giantswarm/kubectl-gs/v2/test/kubeconfig"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/middleware"
+	"github.com/giantswarm/kubectl-gs/v3/test/kubeconfig"
 )
 
 const (

--- a/pkg/oidc/device_auth.go
+++ b/pkg/oidc/device_auth.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/installation"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/installation"
 )
 
 const (

--- a/pkg/output/nameprinter_test.go
+++ b/pkg/output/nameprinter_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 var update = flag.Bool("update", false, "update .golden reference test files")

--- a/pkg/template/app/app.go
+++ b/pkg/template/app/app.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/kubectl-gs/v2/internal/key"
+	"github.com/giantswarm/kubectl-gs/v3/internal/key"
 )
 
 type Config struct {

--- a/pkg/template/app/app_test.go
+++ b/pkg/template/app/app_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kubectl-gs/v2/test/goldenfile"
+	"github.com/giantswarm/kubectl-gs/v3/test/goldenfile"
 )
 
 func Test_NewAppCR(t *testing.T) {

--- a/test/kubeclient/kubeclient.go
+++ b/test/kubeclient/kubeclient.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/scheme"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/scheme"
 )
 
 type fakeK8sClient struct {

--- a/test/oidc/mock-oidc-server.go
+++ b/test/oidc/mock-oidc-server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"gopkg.in/square/go-jose.v2"
 
-	"github.com/giantswarm/kubectl-gs/v2/pkg/oidc"
+	"github.com/giantswarm/kubectl-gs/v3/pkg/oidc"
 )
 
 type MockOidcServerConfig struct {


### PR DESCRIPTION
### What does this PR do?

This PR bumps go module version to v3, due to a breaking change that has been added here https://github.com/giantswarm/kubectl-gs/pull/1352.

### What is the effect of this change to users?

See https://github.com/giantswarm/kubectl-gs/pull/1352.

### What does it look like?

See https://github.com/giantswarm/kubectl-gs/pull/1352.

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3466

### Do the docs need to be updated?

Will check.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commnds/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)

Yes.