### PR TITLE
Fix gitops pre-commit template shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Changed
+
+- Use more portable, Bash specific shebang for GitOps pre-commit script template
+
 ## [3.1.0] - 2024-07-23
 
 ### Added

--- a/internal/gitops/structure/root/templates/pre-commit.tmpl
+++ b/internal/gitops/structure/root/templates/pre-commit.tmpl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # The script looks for the *.enc.yaml files that suppose to be encrypted,
 # and verifies the encryption has happened.


### PR DESCRIPTION
### Summary

This PR makes the GitOps `pre-commit` script template's [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) specific to Bash, in a way that maximizes portability across different operating systems.

The script itself uses Bash specific features, like the `<<<` operator, which won't work if another shell is used as interpreter.

Initial Slack thread by @LutzLange: https://gigantic.slack.com/archives/CLPMFRVU6/p1721828188822059
 