### PR TITLE
Add support for unified cluster-vsphere app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support for unified cluster-vsphere app. With cluster-vsphere v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.
+
 ## [4.0.0] - 2024-08-22
 
 ### Changed

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -235,7 +235,7 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_template_cluster_capz.golden",
 		},
 		{
-			name: "case 5: template cluster capv",
+			name: "case 5: template cluster capv (cluster-vsphere and default-apps-vsphere)",
 			flags: &flags.Flag{
 				Name:              "test1",
 				Provider:          "vsphere",
@@ -243,7 +243,7 @@ func Test_run(t *testing.T) {
 				Organization:      "test",
 				KubernetesVersion: "v1.2.3",
 				App: common.AppConfig{
-					ClusterVersion:     "1.2.3",
+					ClusterVersion:     "0.59.0",
 					ClusterCatalog:     "foo-catalog",
 					DefaultAppsCatalog: "foo-default-catalog",
 					DefaultAppsVersion: "3.2.1",
@@ -273,10 +273,49 @@ func Test_run(t *testing.T) {
 				},
 			},
 			args:               nil,
-			expectedGoldenFile: "run_template_cluster_capv.golden",
+			expectedGoldenFile: "run_template_cluster_capv_1.golden",
 		},
 		{
-			name: "case 6: template cluster capa with custom network CIDR",
+			name: "case 6: template cluster capv (unified cluster-vsphere)",
+			flags: &flags.Flag{
+				Name:              "test1",
+				Provider:          "vsphere",
+				Description:       "yet another test cluster",
+				Organization:      "test",
+				KubernetesVersion: "v1.2.3",
+				App: common.AppConfig{
+					ClusterVersion: "1.2.3",
+					ClusterCatalog: "foo-catalog",
+				},
+				VSphere: common.VSphereConfig{
+					ServiceLoadBalancerCIDR: "1.2.3.4/32",
+					ResourcePool:            "foopool",
+					NetworkName:             "foonet",
+					SvcLbIpPoolName:         "svc-foo-pool",
+					CredentialsSecretName:   "foosecret",
+					ImageTemplate:           "foobar",
+					ControlPlane: common.VSphereControlPlane{
+						VSphereMachineTemplate: common.VSphereMachineTemplate{
+							DiskGiB:   42,
+							MemoryMiB: 42000,
+							NumCPUs:   6,
+							Replicas:  5,
+						},
+						IpPoolName: "foo-pool",
+					},
+					Worker: common.VSphereMachineTemplate{
+						DiskGiB:   43,
+						MemoryMiB: 43000,
+						NumCPUs:   7,
+						Replicas:  4,
+					},
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_capv_2.golden",
+		},
+		{
+			name: "case 7: template cluster capa with custom network CIDR",
 			flags: &flags.Flag{
 				Name:                     "test6",
 				Provider:                 "capa",
@@ -312,7 +351,7 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_template_cluster_capa_6.golden",
 		},
 		{
-			name: "case 7: template cluster capa with custom network CIDR 3 AZ",
+			name: "case 8: template cluster capa with custom network CIDR 3 AZ",
 			flags: &flags.Flag{
 				Name:                     "test7",
 				Provider:                 "capa",
@@ -348,7 +387,7 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_template_cluster_capa_7.golden",
 		},
 		{
-			name: "case 8: template cluster capa with custom network CIDR 1 AZ",
+			name: "case 9: template cluster capa with custom network CIDR 1 AZ",
 			flags: &flags.Flag{
 				Name:                     "test8",
 				Provider:                 "capa",

--- a/cmd/template/cluster/testdata/run_template_cluster_capv_1.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capv_1.golden
@@ -93,7 +93,7 @@ spec:
     secret:
       name: foosecret
       namespace: org-test
-  version: 1.2.3
+  version: 0.59.0
 ---
 apiVersion: v1
 data:

--- a/cmd/template/cluster/testdata/run_template_cluster_capv_2.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capv_2.golden
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+data:
+  values: |
+    global:
+      connectivity:
+        baseDomain: test.gigantic.io
+        network:
+          controlPlaneEndpoint:
+            host: ""
+            ipPoolName: foo-pool
+            port: 6443
+          loadBalancers:
+            cidrBlocks:
+            - 1.2.3.4/32
+            ipPoolName: svc-foo-pool
+      controlPlane:
+        image:
+          repository: gsoci.azurecr.io/giantswarm
+        machineTemplate:
+          cloneMode: linkedClone
+          diskGiB: 42
+          memoryMiB: 42000
+          network:
+            devices:
+            - dhcp4: true
+              networkName: foonet
+          numCPUs: 6
+          resourcePool: foopool
+          template: foobar
+        replicas: 5
+      metadata:
+        description: yet another test cluster
+        organization: test
+      nodeClasses:
+        default:
+          cloneMode: linkedClone
+          diskGiB: 43
+          memoryMiB: 43000
+          network:
+            devices:
+            - dhcp4: true
+              networkName: foonet
+          numCPUs: 7
+          resourcePool: foopool
+          template: foobar
+      nodePools:
+        worker:
+          class: default
+          replicas: 4
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    giantswarm.io/cluster: test1
+  name: test1-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: test1
+  namespace: org-test
+spec:
+  catalog: foo-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  extraConfigs:
+  - kind: secret
+    name: container-registries-configuration
+    namespace: default
+    priority: 25
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: cluster-vsphere
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test1-userconfig
+      namespace: org-test
+    secret:
+      name: foosecret
+      namespace: org-test
+  version: 1.2.3

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.0
 require (
 	dario.cat/mergo v1.0.1
 	github.com/3th1nk/cidr v0.2.0
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ProtonMail/gopenpgp/v2 v2.7.5
 	github.com/blang/semver v3.5.1+incompatible
@@ -57,7 +58,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/longrunning v0.5.7 // indirect
 	cloud.google.com/go/storage v1.42.0 // indirect
-	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.12 // indirect


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3125

> [!CAUTION]
> cluster-vsphere v0.61.0 is not yet released.
> 
> cluster-vsphere v0.61.0 with default apps will be released once [this PR](https://github.com/giantswarm/cluster-vsphere/pull/262) has been merged. Only then kubectl-gs with this change can be used.

### What does this PR do?

Add support for unified cluster-vsphere app. With cluster-vsphere v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.

### What is the effect of this change to users?

When rendering manifests for a CAPV cluster, with cluster-vsphere v0.61.0 the default-apps-vsphere App CR is not rendered anymore.

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3125

### Do the docs need to be updated?

Yes, this page https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/template-cluster/.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No.