### PR TITLE
change link to vintage, since redirect is pointing to a subpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Check the [installation docs](https://docs.giantswarm.io/vintage/use-the-api/kub
 
 ## Documentation
 
-Find the [kubectl gs reference](https://docs.giantswarm.io/use-the-api/kubectl-gs/) in our documentation site.
+Find the [kubectl gs reference](https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/) in our documentation site.
 
 ## Publishing a release
 


### PR DESCRIPTION
### What does this PR do?

I noticed that the current link redirects to `https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/update-cluster/` which is a subpage of the `kubectl gs` docs so i changed the link to point to the vintage URL like the other doc URLs in the README.

### What is the effect of this change to users?

They have one less click and are maybe not confused

### What does it look like?


### Any background context you can provide?


### What is needed from the reviewers?

Decide whether all links should be changed to the vintage links or if the redirects need to be checked/regenerated.

### Do the docs need to be updated?

The actual docs not, maybe the redirects from old links to vintage links.

### Should this change be mentioned in the release notes?

no

### Is this a breaking change?

no
