### PR TITLE
Add command usage tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@5.9.0
+  architect: giantswarm/architect@5.10.0
 
 jobs:
   debug-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `TELEMETRY_OPTOUT` to an arbitrary value to disable this. The details submitted are:
+  - kubectl-gs version
+  - Command name (e. g. `kubectl gs get clusters`)
+  - Operating system name (e.g. `linux`, `darwin`, `windows`)
+  - Processor architecture (e.g. `amd64`, `arm64`)
+  - The library and version used to submit the data (`telemetrydeck-go/0.0.1`).
+  - An anonymized user identifier hash, to enable counting unique users.
+
 ## [4.1.0] - 2024-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `TELEMETRY_OPTOUT` to an arbitrary value to disable this. The details submitted are:
+- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to an arbitrary value to disable this. The details submitted are:
   - kubectl-gs version
   - Command name (e. g. `kubectl gs get clusters`)
   - Operating system name (e.g. `linux`, `darwin`, `windows`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to an arbitrary value to disable this. Data is submitted to [TelemetryDeck](https://telemetrydeck.com/) in the EU.
-  
-  The details submitted are:
-  - kubectl-gs version
-  - Command name (e. g. `kubectl gs get clusters`)
-  - Operating system name (e.g. `linux`, `darwin`, `windows`)
-  - Processor architecture (e.g. `amd64`, `arm64`)
-  - The library and version used to submit the data (`telemetrydeck-go/0.0.1`).
-  - An anonymized user identifier hash, to enable counting unique users.
+- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to an arbitrary value to disable this. Data is submitted to [TelemetryDeck](https://telemetrydeck.com/) in the EU. More details are available in our [docs](https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/telemetry/).
 
 ## [4.2.0] - 2024-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to an arbitrary value to disable this. The details submitted are:
+- Basic usage tracking data is now collected for every command execution. This should help us maintain and develop the tool. Set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to an arbitrary value to disable this. Data is submitted to [TelemetryDeck](https://telemetrydeck.com/) in the EU.
+  
+  The details submitted are:
   - kubectl-gs version
   - Command name (e. g. `kubectl gs get clusters`)
   - Operating system name (e.g. `linux`, `darwin`, `windows`)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,9 +83,8 @@ func New(config Config) (*cobra.Command, error) {
 				return
 			}
 
-			logger := log.New(os.Stdout, "", 0)
+			logger := log.New(os.Stdout, "", 0) // to bring telemetry errors to the surface
 			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID,
-				telemetrydeck.WithTestMode(),
 				telemetrydeck.WithLogger(logger),
 			)
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ Get more information at https://docs.giantswarm.io/use-the-api/kubectl-gs/
 `
 	telemetrydeckAppID = "4539763B-A291-4835-B832-9BEB80CA7039"
 
-	telemetryOptOutVariable = "TELEMETRY_OPTOUT"
+	telemetryOptOutVariable = "KUBECTL_GS_TELEMETRY_OPTOUT"
 )
 
 type Config struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/telemetrydeck-go"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
@@ -26,6 +29,9 @@ const (
 
 Get more information at https://docs.giantswarm.io/use-the-api/kubectl-gs/
 `
+	telemetrydeckAppID = "4539763B-A291-4835-B832-9BEB80CA7039"
+
+	telemetryOptOutVariable = "TELEMETRY_OPTOUT"
 )
 
 type Config struct {
@@ -66,9 +72,35 @@ func New(config Config) (*cobra.Command, error) {
 	}
 
 	c := &cobra.Command{
-		Use:                name,
-		Short:              description,
-		Long:               description,
+		Use:   name,
+		Short: description,
+		Long:  description,
+
+		// Called for every subcommand execution
+		// to track command usage.
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if os.Getenv(telemetryOptOutVariable) != "" {
+				return
+			}
+
+			logger := log.New(os.Stdout, "", 0)
+			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID,
+				telemetrydeck.WithTestMode(),
+				telemetrydeck.WithLogger(logger),
+			)
+			if err != nil {
+				log.Printf("error creating telemetrydeck client: %s", err)
+			} else {
+				err = tdClient.SendSignal(context.Background(), "GiantSwarm.command", map[string]interface{}{
+					"appVersion": project.Version(),
+					"command":    cmd.CommandPath(),
+				})
+				if err != nil {
+					log.Printf("error sending telemetrydeck signal: %s", err)
+				}
+			}
+		},
+
 		RunE:               r.Run,
 		PersistentPostRunE: r.PersistentPostRun,
 		SilenceUsage:       true,

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/giantswarm/micrologger v1.1.1
 	github.com/giantswarm/organization-operator v1.6.4
 	github.com/giantswarm/release-operator/v4 v4.2.0
+	github.com/giantswarm/telemetrydeck-go v0.0.0-20241011124412-94d192a4aad6
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/giantswarm/organization-operator v1.6.4 h1:t0G0hoB7TfeGzRnr58NIwO6LAm
 github.com/giantswarm/organization-operator v1.6.4/go.mod h1:Rw9gG/ReI5YfvoC85F9H5wH2aWguUR7JY/NfTjZC2Jc=
 github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cOlZfhgK4/oBfMPbg=
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241011124412-94d192a4aad6 h1:IHUooOg3MXokQgrIyrX8TCrYT4SqA3S4OIRA7TYHG0Y=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241011124412-94d192a4aad6/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.0.4 h1:VsjPI33J0SB9vQM6PLmNjoHqMQNGPiZ0rHL7Ni7Q6/E=


### PR DESCRIPTION
### What does this PR do?

This PR adds sending of telemetry data.

For each command executed, we send one signal to TelemetryDeck.

To opt out, users have to set the `KUBECTL_GS_TELEMETRY_OPTOUT` environment variable to any value.

### What is the effect of this change to users?

No user-facing changes.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/31025

### Do the docs need to be updated?

Yes

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No
