### PR TITLE
Update telemetrydeck to fix unique user count problem

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,6 +1,2 @@
 # pkg:golang/github.com/hashicorp/vault/api
-CVE-2024-2660 until=2024-10-30
-CVE-2024-6104 until=2024-10-30
-
-# pkg:golang/golang.org/x/net@v0.27.0
-CVE-2024-8421 until=2024-10-30
+CVE-2024-2660 until=2024-11-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unique user tracking
+
 ## [4.3.0] - 2024-10-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Fixed unique user tracking
+- Remove debug logging regarding telemetry
 
 ## [4.3.0] - 2024-10-28
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,10 +98,6 @@ func New(config Config) (*cobra.Command, error) {
 					log.Printf("error sending telemetrydeck signal: %s", err)
 				}
 			}
-
-			// TODO: remove after testing
-			fmt.Printf("User ID: %q\n", tdClient.UserID())
-			fmt.Printf("User ID hash: %q\n\n", tdClient.UserIDHash())
 		},
 
 		RunE:               r.Run,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,10 @@ func New(config Config) (*cobra.Command, error) {
 					log.Printf("error sending telemetrydeck signal: %s", err)
 				}
 			}
+
+			// TODO: remove after testing
+			fmt.Printf("User ID: %q\n", tdClient.UserID())
+			fmt.Printf("User ID hash: %q\n\n", tdClient.UserIDHash())
 		},
 
 		RunE:               r.Run,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,10 +83,7 @@ func New(config Config) (*cobra.Command, error) {
 				return
 			}
 
-			logger := log.New(os.Stdout, "", 0) // to bring telemetry errors to the surface
-			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID,
-				telemetrydeck.WithLogger(logger),
-			)
+			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID)
 			if err != nil {
 				log.Printf("error creating telemetrydeck client: %s", err)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/giantswarm/micrologger v1.1.1
 	github.com/giantswarm/organization-operator v1.6.4
 	github.com/giantswarm/release-operator/v4 v4.2.0
-	github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a
+	github.com/giantswarm/telemetrydeck-go v0.0.0-20241031123115-8fc0dd371e5b
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/giantswarm/micrologger v1.1.1
 	github.com/giantswarm/organization-operator v1.6.4
 	github.com/giantswarm/release-operator/v4 v4.2.0
-	github.com/giantswarm/telemetrydeck-go v0.0.0-20241017111948-ecfd1a61b319
+	github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,10 @@ github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cO
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
 github.com/giantswarm/telemetrydeck-go v0.0.0-20241017111948-ecfd1a61b319 h1:cLItDxKZDhf7HCe7qhxeY6YL768miTCps860S/KlLvg=
 github.com/giantswarm/telemetrydeck-go v0.0.0-20241017111948-ecfd1a61b319/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031104010-3a4cb143d896 h1:dx1mI+QmliDO2zrf9lu29fYeAk4vlnWMeuJENbGTOqY=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031104010-3a4cb143d896/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a h1:429awTtNklgWcJ1CFJTJxZBr9WAhGqO2AGi6advOE3g=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.0.4 h1:VsjPI33J0SB9vQM6PLmNjoHqMQNGPiZ0rHL7Ni7Q6/E=

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/giantswarm/organization-operator v1.6.4 h1:t0G0hoB7TfeGzRnr58NIwO6LAm
 github.com/giantswarm/organization-operator v1.6.4/go.mod h1:Rw9gG/ReI5YfvoC85F9H5wH2aWguUR7JY/NfTjZC2Jc=
 github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cOlZfhgK4/oBfMPbg=
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a h1:429awTtNklgWcJ1CFJTJxZBr9WAhGqO2AGi6advOE3g=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031123115-8fc0dd371e5b h1:lU3w6TMGW5uJ5akch5DpkWiFiJCkXKI4xprNSpIJxrw=
+github.com/giantswarm/telemetrydeck-go v0.0.0-20241031123115-8fc0dd371e5b/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.0.4 h1:VsjPI33J0SB9vQM6PLmNjoHqMQNGPiZ0rHL7Ni7Q6/E=

--- a/go.sum
+++ b/go.sum
@@ -201,10 +201,6 @@ github.com/giantswarm/organization-operator v1.6.4 h1:t0G0hoB7TfeGzRnr58NIwO6LAm
 github.com/giantswarm/organization-operator v1.6.4/go.mod h1:Rw9gG/ReI5YfvoC85F9H5wH2aWguUR7JY/NfTjZC2Jc=
 github.com/giantswarm/release-operator/v4 v4.2.0 h1:8aU8V3BlF/sKmYG1MgcPGXs8Q/cOlZfhgK4/oBfMPbg=
 github.com/giantswarm/release-operator/v4 v4.2.0/go.mod h1:/ew0vh4BnfJqOddNTcm7iAHvm7g4MBp5C+pxi+H4ydk=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241017111948-ecfd1a61b319 h1:cLItDxKZDhf7HCe7qhxeY6YL768miTCps860S/KlLvg=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241017111948-ecfd1a61b319/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241031104010-3a4cb143d896 h1:dx1mI+QmliDO2zrf9lu29fYeAk4vlnWMeuJENbGTOqY=
-github.com/giantswarm/telemetrydeck-go v0.0.0-20241031104010-3a4cb143d896/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a h1:429awTtNklgWcJ1CFJTJxZBr9WAhGqO2AGi6advOE3g=
 github.com/giantswarm/telemetrydeck-go v0.0.0-20241031105524-19d39c36041a/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=


### PR DESCRIPTION
### What does this PR do?

The same user hash got submitted for all users. This was fixed in https://github.com/giantswarm/telemetrydeck-go/pull/10.

Also this PR removes debug logging related to telemetry, which was a leftover.

### What is the effect of this change to users?

Users should definitely no see any debugging log messages regarding telemetry.

The main change is invisible to users.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No