### PR TITLE
Adjust columns for kubectl gs get releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Adjust columns for `kubectl gs get releases`.
+
 ## [4.4.0] - 2024-11-13
 
 ### Added

--- a/cmd/get/releases/printer.go
+++ b/cmd/get/releases/printer.go
@@ -36,9 +36,11 @@ func (r *runner) printOutput(rResource release.Resource) error {
 				{Name: "Status", Type: "string"},
 				{Name: "Age", Type: "string", Format: "date-time"},
 				{Name: "Kubernetes", Type: "string"},
-				{Name: "Container Linux", Type: "string"},
+				{Name: "Flatcar", Type: "string"},
+				{Name: "Cilium", Type: "string"},
 				{Name: "CoreDNS", Type: "string"},
-				{Name: "Calico", Type: "string"},
+				{Name: "Observability Bundle", Type: "string"},
+				{Name: "Security Bundle", Type: "string"},
 			},
 		}
 
@@ -109,28 +111,33 @@ func getTableRow(release release.Release) metav1.TableRow {
 	status := getReleaseStatus(release.CR.Spec.State)
 
 	kubernetesVersion := naValue
-	containerLinuxVersion := naValue
+	flatcarVersion := naValue
 	coreDNSVersion := naValue
-	calicoVersion := naValue
+	ciliumVersion := naValue
+	securityBundleVersion := naValue
+	observabilityBundleVersion := naValue
 
 	for _, component := range release.CR.Spec.Components {
 		if component.Name == "kubernetes" {
 			kubernetesVersion = component.Version
 		}
-		if component.Name == "containerlinux" {
-			containerLinuxVersion = component.Version
-		}
-		if component.Name == "coredns" {
-			coreDNSVersion = component.Version
-		}
-		if component.Name == "calico" {
-			calicoVersion = component.Version
+		if component.Name == "flatcar" {
+			flatcarVersion = component.Version
 		}
 	}
 
 	for _, app := range release.CR.Spec.Apps {
 		if app.Name == "coredns" {
-			coreDNSVersion = app.ComponentVersion
+			coreDNSVersion = app.Version
+		}
+		if app.Name == "cilium" {
+			ciliumVersion = app.Version
+		}
+		if app.Name == "observability-bundle" {
+			observabilityBundleVersion = app.Version
+		}
+		if app.Name == "security-bundle" {
+			securityBundleVersion = app.Version
 		}
 	}
 
@@ -140,9 +147,11 @@ func getTableRow(release release.Release) metav1.TableRow {
 			status,
 			output.TranslateTimestampSince(release.CR.CreationTimestamp),
 			kubernetesVersion,
-			containerLinuxVersion,
+			flatcarVersion,
+			ciliumVersion,
 			coreDNSVersion,
-			calicoVersion,
+			observabilityBundleVersion,
+			securityBundleVersion,
 		},
 		Object: runtime.RawExtension{
 			Object: release.CR,


### PR DESCRIPTION
### What does this PR do?

Before:

```
VERSION                 STATUS   AGE   KUBERNETES   CONTAINER LINUX   COREDNS   CALICO
cloud-director-27.0.0   ACTIVE   44h   1.27.16      n/a                         n/a
```

After:

```
VERSION                 STATUS   AGE   KUBERNETES   FLATCAR    CILIUM   COREDNS   OBSERVABILITY BUNDLE   SECURITY BUNDLE
cloud-director-27.0.0   ACTIVE   44h   1.27.16      3815.2.5   0.25.1   1.21.0    1.5.3                  1.8.0
```


### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commands/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)