### PR TITLE
Update github.com/ProtonMail/gopenpgp to v3, adapt to API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Remove node classes from vsphere template used in `kubectl gs template cluster` command.
-- Adapt keyx pair creation in `gitops` command family to use `github.com/ProtonMail/gopenpgp/v3`.
 
 ## [4.5.0] - 2024-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Remove node classes from vsphere template used in `kubectl gs template cluster` command.
+- Adapt keyx pair creation in `gitops` command family to use `github.com/ProtonMail/gopenpgp/v3`.
 
 ## [4.5.0] - 2024-11-15
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/3th1nk/cidr v0.2.0
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/ProtonMail/gopenpgp/v2 v2.8.0
+	github.com/ProtonMail/gopenpgp/v3 v3.1.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-oidc/v3 v3.11.0
@@ -101,8 +101,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/ProtonMail/go-crypto v1.1.0 // indirect
-	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f // indirect
+	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go v1.55.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,12 +60,10 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/ProtonMail/go-crypto v1.1.0 h1:OnlSGxXflfrWJESDsGQOmACNQRM9IflG3q8XTrOqvbE=
-github.com/ProtonMail/go-crypto v1.1.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ekTTXpdwKYF8eBlsYsDVoggDAuAjoK66k=
-github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
-github.com/ProtonMail/gopenpgp/v2 v2.8.0 h1:WvMv3CMcFsqKSM4/Qf8sf3tgyQkzDqQmoSE49bnBuP4=
-github.com/ProtonMail/gopenpgp/v2 v2.8.0/go.mod h1:qb2GUSnmA9ipBW5GVtCtEhkummSlqs2A8Ar3S0HBgSY=
+github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
+github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/ProtonMail/gopenpgp/v3 v3.1.0 h1:CQpcOakpfEFi5FHB6Ogbq+Uqq3oNr4xIW6Rt/9R9G8Y=
+github.com/ProtonMail/gopenpgp/v3 v3.1.0/go.mod h1:om9qDnbxuh/LAE7MTdaRu2Rilw9q2Lwe2fz9JQnOcm0=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=

--- a/internal/gitops/encryption/encryption.go
+++ b/internal/gitops/encryption/encryption.go
@@ -1,7 +1,7 @@
 package encryption
 
 import (
-	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/giantswarm/microerror"
 )
 
@@ -12,23 +12,26 @@ type KeyPair struct {
 }
 
 func GenerateKeyPair(name string) (KeyPair, error) {
-	encKeys, err := crypto.GenerateKey(name, "", "x25519", 0)
+	// Generate a PGP key to use as private
+	pgp := crypto.PGP()
+	genHandle := pgp.KeyGeneration().AddUserId(name, "").New()
+	prvKey, err := genHandle.GenerateKey()
 	if err != nil {
 		return KeyPair{}, microerror.Mask(err)
 	}
 
-	prvArmor, err := encKeys.Armor()
+	prvArmor, err := prvKey.Armor()
 	if err != nil {
 		return KeyPair{}, microerror.Mask(err)
 	}
 
-	pubArmor, err := encKeys.GetArmoredPublicKey()
+	pubArmor, err := prvKey.GetArmoredPublicKey()
 	if err != nil {
 		return KeyPair{}, microerror.Mask(err)
 	}
 
 	keyPair := KeyPair{
-		Fingerprint: encKeys.GetFingerprint(),
+		Fingerprint: prvKey.GetFingerprint(),
 		PrivateData: prvArmor,
 		PublicData:  pubArmor,
 	}


### PR DESCRIPTION
### What does this PR do?

Bumps `github.com/ProtonMail/gopenpgp` to v3.

### What is the effect of this change to users?

The intend is that there is no effect

### What is needed from the reviewers?

Testing. The function is used in these commands:

- `gitops add encryption`
- `gitops add management-cluster`

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

No

### Is this a breaking change?

No
