### PR TITLE
Remove manual approval from krew update workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,19 +177,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-      - request-manual-approval:
-          type: approval
-          requires:
-            - debug-tag
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - update-krew-index:
           requires:
             - debug-tag
-            - request-manual-approval
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
### What does this PR do?

This a change to the workflow for automating the Krew plugin index.

In the past the approval has been forgotten a few times when a release was published. The manual approval isn't really required.

### What is the effect of this change to users?

None

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commands/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
