### PR TITLE
Remove anything related to KVM

### DIFF
--- a/cmd/login/clientcert.go
+++ b/cmd/login/clientcert.go
@@ -575,11 +575,3 @@ func findCluster(ctx context.Context, clusterService cluster.Interface, organiza
 		}
 	}
 }
-
-func validateProvider(provider string) error {
-	if provider == key.ProviderKVM {
-		return microerror.Maskf(unsupportedProviderError, "Creating a client certificate for a workload cluster is not supported on provider %s.", provider)
-	}
-
-	return nil
-}

--- a/cmd/login/command.go
+++ b/cmd/login/command.go
@@ -38,7 +38,7 @@ Use <arg1> <arg2> for
 Use this command to set up a kubectl context to work with:
   (1) a management cluster, using OIDC authentication
   (2) a workload cluster, using OIDC authentication
-  (3) a workload cluster, using client certificate auth. Not supported on kvm.
+  (3) a workload cluster, using client certificate auth.
 
 Note that (3) implies (1). When creating a workload cluster client certificate,
 management cluster access will be set up as well, if that is not yet done.

--- a/cmd/login/wc.go
+++ b/cmd/login/wc.go
@@ -164,11 +164,6 @@ func (r *runner) handleWCKubeconfig(ctx context.Context) error {
 
 // used only if both MC and WC are specified on command line
 func (r *runner) createClusterKubeconfig(ctx context.Context, client k8sclient.Interface, provider string) (contextName string, contextExists bool, err error) {
-	err = validateProvider(provider)
-	if err != nil {
-		return "", false, microerror.Mask(err)
-	}
-
 	services, err := r.getServiceSet(client)
 	if err != nil {
 		return "", false, microerror.Mask(err)

--- a/cmd/login/wc_test.go
+++ b/cmd/login/wc_test.go
@@ -184,19 +184,6 @@ func TestWCClientCert(t *testing.T) {
 				},
 			},
 		},
-		// Trying to log into a cluster on kvm
-		{
-			name:                 "case 8",
-			clustersInNamespaces: map[string]string{"cluster": "org-organization"},
-			controlPlaneEndpoint: "https://localhost:6443",
-			flags: &flag{
-				WCName:    "cluster",
-				WCCertTTL: "8h",
-			},
-			provider:    "kvm",
-			isAdmin:     true,
-			expectError: unsupportedProviderError,
-		},
 		// Trying to log into a cluster on azure
 		{
 			name:                 "case 9",

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -50,13 +50,6 @@ func TestService_Supports(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "case 5: autoscaling on kvm 13.0.0",
-			provider:       ProviderKVM,
-			feature:        Autoscaling,
-			version:        "13.0.0",
-			expectedResult: false,
-		},
-		{
 			name:           "case 6: nodepool conditions on aws 10.0.0",
 			provider:       ProviderAWS,
 			feature:        NodePoolConditions,
@@ -69,13 +62,6 @@ func TestService_Supports(t *testing.T) {
 			feature:        NodePoolConditions,
 			version:        "13.0.0",
 			expectedResult: true,
-		},
-		{
-			name:           "case 8: nodepool conditions on kvm 13.0.0",
-			provider:       ProviderKVM,
-			feature:        NodePoolConditions,
-			version:        "13.0.0",
-			expectedResult: false,
 		},
 	}
 

--- a/internal/feature/providers.go
+++ b/internal/feature/providers.go
@@ -3,7 +3,6 @@ package feature
 const (
 	ProviderAWS           = "aws"
 	ProviderAzure         = "azure"
-	ProviderKVM           = "kvm"
 	ProviderOpenStack     = "openstack"
 	ProviderCAPA          = "capa"
 	ProviderCAPZ          = "capz"

--- a/internal/key/provider.go
+++ b/internal/key/provider.go
@@ -7,7 +7,6 @@ const (
 	ProviderCAPZ          = "capz"
 	ProviderEKS           = "eks"
 	ProviderGCP           = "gcp"
-	ProviderKVM           = "kvm"
 	ProviderOpenStack     = "openstack"
 	ProviderVSphere       = "vsphere"
 	ProviderCloudDirector = "cloud-director"

--- a/pkg/data/domain/cluster/common.go
+++ b/pkg/data/domain/cluster/common.go
@@ -54,7 +54,7 @@ func (s *Service) getByName(ctx context.Context, provider, name, namespace strin
 				return nil, microerror.Mask(err)
 			}
 
-		case key.ProviderOpenStack, key.ProviderCAPA, key.ProviderKVM, key.ProviderVSphere, key.ProviderCloudDirector:
+		case key.ProviderOpenStack, key.ProviderCAPA, key.ProviderVSphere, key.ProviderCloudDirector:
 			cluster, err = s.getByNameCommonCapi(ctx, name, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)
@@ -99,7 +99,7 @@ func (s *Service) getAll(ctx context.Context, provider, namespace string, fallba
 				return nil, microerror.Mask(err)
 			}
 
-		case key.ProviderOpenStack, key.ProviderCAPA, key.ProviderKVM, key.ProviderVSphere, key.ProviderCloudDirector:
+		case key.ProviderOpenStack, key.ProviderCAPA, key.ProviderVSphere, key.ProviderCloudDirector:
 			clusterCollection, err = s.getAllCommonCapi(ctx, namespace)
 			if err != nil {
 				return nil, microerror.Mask(err)

--- a/scripts/login.sh
+++ b/scripts/login.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This script can be used to log i to workload clusters
-# running in aws, azure or kvm installations
+# This script can be used to log in to workload clusters
+# running in aws or azure installations
 #
 # Usage: ./login.sh <base-domain> <organization-name> <workload-cluster-name> <ttl>
 #


### PR DESCRIPTION
### What does this PR do?

Since our customers are no longer running any KVM installations, this PR removes code specific to KVM.

### What is the effect of this change to users?

Since there are no KVM installations any more, there should not be any effect.

One the upside: less confusion for developers.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commands/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
