### PR TITLE
Correctly parse flag keep-context for login cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Flag `keep-context` for login command is no longer ignored
+
 ## [4.8.0] - 2025-05-01
 
 ### Changed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -38,10 +38,6 @@ const (
 	envKeepContext = "KUBECTL_GS_LOGIN_KEEP_CONTEXT"
 )
 
-var (
-	keepContext bool
-)
-
 type flag struct {
 	CallbackServerHost string
 	CallbackServerPort int
@@ -78,7 +74,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 	viper.AutomaticEnv()
 	keepContextDefault := viper.GetBool(envKeepContext)
-	cmd.Flags().BoolVar(&keepContext, flagKeepContext, keepContextDefault, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
+	cmd.Flags().BoolVar(&f.KeepContext, flagKeepContext, keepContextDefault, "Keep the current kubectl context. If not set/false, will set the current-context to the one representing the cluster to log in to.")
 
 	cmd.Flags().StringVar(&f.WCName, flagWCName, "", "For client certificate creation. Specify the name of a workload cluster to work with. If omitted, a management cluster will be accessed.")
 	cmd.Flags().StringVar(&f.WCOrganization, flagWCOrganization, "", fmt.Sprintf("For client certificate creation. Organization that owns the workload cluster. Requires --%s.", flagWCName))


### PR DESCRIPTION
### What does this PR do?

Up to now `kubectl gs login --workload-cluster foobar --keep-context` would switch the kubeconfig context to that of the WC, even though the flag should prevent that. Looks like during parsing of cli args the flag value was not properly populated. This PR fixes that.

### What is the effect of this change to users?

`kubectl gs login --keep-context` now works as expected

### What does it look like?

```shell
$ kubectl gs login --workload-cluster foobar --keep-context
Context 'gs-mymc' is already selected.

Created client certificate for workload cluster 'foobar'.
A new kubectl context has been created named 'gs-mymc-foobar-clientcert'. To switch back to this context later, use this command:

  kubectl config use-context gs-mymc-foobar-clientcert
```

### Any background context you can provide?

N/A

### What is needed from the reviewers?
Was there special meaning behind how the flag was implemented?

### Do the docs need to be updated?
No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?
No
