### PR TITLE
Enable ARM build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           paths:
             - ./kubectl-gs-amd64
             - ./kubectl-gs-386
-            #- ./kubectl-gs-arm64
+            - ./kubectl-gs-arm64
             #- ./kubectl-gs-ppc64le
             #- ./kubectl-gs-s390x
             #- ./kubectl-gs-386

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:3c7435a90cdf36c177226806f9fbdb94226c06cb
-
+  architect: giantswarm/architect@6.7.0
 jobs:
   debug-tag:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             IMAGE_ACCESS=public
             #PLATFORMS=linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/s390x
-            PLATFORMS=linux/amd64,linux/386
+            PLATFORMS=linux/amd64,linux/arm64,linux/386
 
             if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
               echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@6.6.1
+  architect: giantswarm/architect@dev:b49cfa87c2d250563d50a3383d570bc7019a5c5c
 
 jobs:
   debug-tag:
@@ -74,12 +74,12 @@ jobs:
 
   go-build-arm64:
     executor: architect/architect
-    resource_class: "medium+" # Can't use "arm.medium" as long as architect doesn't support it
+    resource_class: "arm.medium"
     steps:
       - checkout
       - architect/tools-info
       - architect/go-cache-restore
-      # - architect/go-test # Only would make sense if resource_class: "arm.medium" is used
+      - architect/go-test
       - run:
          name: Build binary (linux/arm64)
          command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,10 @@ jobs:
           name: Build binary (linux/386)
           command: |
             CGO_ENABLED=0 GOOS="linux" GOARCH=386 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-386 .
-      #- run:
-      #    name: Build binary (linux/arm64)
-      #    command: |
-      #      CGO_ENABLED=0 GOOS="linux" GOARCH=arm64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-arm64 .
+      - run:
+         name: Build binary (linux/arm64)
+         command: |
+           CGO_ENABLED=0 GOOS="linux" GOARCH=arm64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-arm64 .
       #- run:
       #    name: Build binary (linux/ppc64le)
       #    command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,25 @@ jobs:
           name: Execute krew-release-bot
           command: ./krew-release-bot action
 
-  go-build-multiarch:
+  go-build-386:
+    executor: architect/architect
+    resource_class: "medium+"
+    steps:
+      - checkout
+      - architect/tools-info
+      - architect/go-cache-restore
+      # We don't test for 386 specifically
+      - run:
+          name: Build binary (linux/386)
+          command: |
+            CGO_ENABLED=0 GOOS="linux" GOARCH=386 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-386 .
+      - architect/go-cache-save
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./kubectl-gs-386
+
+  go-build-amd64:
     executor: architect/architect
     resource_class: "medium+"
     steps:
@@ -48,32 +66,63 @@ jobs:
           name: Build binary (linux/amd64)
           command: |
             CGO_ENABLED=0 GOOS="linux" GOARCH=amd64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-amd64 .
-      - run:
-          name: Build binary (linux/386)
-          command: |
-            CGO_ENABLED=0 GOOS="linux" GOARCH=386 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-386 .
-      - run:
-         name: Build binary (linux/arm64)
-         command: |
-           CGO_ENABLED=0 GOOS="linux" GOARCH=arm64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-arm64 .
-      #- run:
-      #    name: Build binary (linux/ppc64le)
-      #    command: |
-      #      CGO_ENABLED=0 GOOS="linux" GOARCH=ppc64le go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-ppc64le .
-      #- run:
-      #    name: Build binary (linux/s390x)
-      #    command: |
-      #      CGO_ENABLED=0 GOOS="linux" GOARCH=s390x go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-s390x .
       - architect/go-cache-save
       - persist_to_workspace:
           root: .
           paths:
             - ./kubectl-gs-amd64
-            - ./kubectl-gs-386
+
+  go-build-arm64:
+    executor: architect/architect
+    resource_class: "arm.medium"
+    steps:
+      - checkout
+      - architect/tools-info
+      - architect/go-cache-restore
+      - architect/go-test
+      - run:
+         name: Build binary (linux/arm64)
+         command: |
+           CGO_ENABLED=0 GOOS="linux" GOARCH=arm64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-arm64 .
+      - architect/go-cache-save
+      - persist_to_workspace:
+          root: .
+          paths:
             - ./kubectl-gs-arm64
-            #- ./kubectl-gs-ppc64le
-            #- ./kubectl-gs-s390x
-            #- ./kubectl-gs-386
+
+  # go-build-ppc64le:
+  #   executor: architect/architect
+  #   resource_class: "medium+"
+  #   steps:
+  #     - checkout
+  #     - architect/tools-info
+  #     - architect/go-cache-restore
+  #     - run:
+  #        name: Build binary (linux/ppc64le)
+  #        command: |
+  #          CGO_ENABLED=0 GOOS="linux" GOARCH=ppc64le go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-ppc64le .
+  #     - architect/go-cache-save
+  #     - persist_to_workspace:
+  #         root: .
+  #         paths:
+  #           - ./kubectl-gs-ppc64le
+
+  # go-build-s390x:
+  #   executor: architect/architect
+  #   resource_class: "medium+"
+  #   steps:
+  #     - checkout
+  #     - architect/tools-info
+  #     - architect/go-cache-restore
+  #     - run:
+  #        name: Build binary (linux/s390x)
+  #        command: |
+  #          CGO_ENABLED=0 GOOS="linux" GOARCH=s390x go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-s390x .
+  #     - architect/go-cache-save
+  #     - persist_to_workspace:
+  #         root: .
+  #         paths:
+  #           - ./kubectl-gs-s390x
 
   push-to-registries-multiarch:
     executor: architect/architect
@@ -150,9 +199,21 @@ jobs:
 workflows:
   go-build-multiarch:
     jobs:
-      - go-build-multiarch:
+      - go-build-amd64:
           context: architect
-          name: go-build-multiarch
+          name: go-build-amd64
+          filters:
+            tags:
+              only: /^v.*/
+      - go-build-arm64:
+          context: architect
+          name: go-build-arm64
+          filters:
+            tags:
+              only: /^v.*/
+      - go-build-386:
+          context: architect
+          name: go-build-386
           filters:
             tags:
               only: /^v.*/
@@ -160,7 +221,11 @@ workflows:
           context: architect
           name: push-to-registries-multiarch
           requires:
-            - go-build-multiarch
+            - go-build-amd64
+            - go-build-arm64
+            - go-build-386
+            # - go-build-ppc64le
+            # - go-build-s390x
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - checkout
       - architect/tools-info
       - architect/go-cache-restore
-      - architect/go-test
+      # - architect/go-test # Only would make sense if resource_class: "arm.medium" is used
       - run:
          name: Build binary (linux/arm64)
          command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:b49cfa87c2d250563d50a3383d570bc7019a5c5c
+  architect: giantswarm/architect@dev:3c7435a90cdf36c177226806f9fbdb94226c06cb
 
 jobs:
   debug-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
 
   go-build-arm64:
     executor: architect/architect
-    resource_class: "arm.medium"
+    resource_class: "medium+" # Can't use "arm.medium" as long as architect doesn't support it
     steps:
       - checkout
       - architect/tools-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- The container image now also supports arm64.
+
 ### Removed
 
 - Remove CAPG (GCP) support from all commands


### PR DESCRIPTION
### What does this PR do?

- Adds arm64 to the supported architectures of the kubectl-gs container image.
- Changes CircieCI config to run Go builds in parallel

### What is the effect of this change to users?

E. g. users of Apple Silicon CPUs should be able to run kubectl-gs natively. On some other ARM machines, kuebctl-gs might be running for the first time.

### What does it look like?

```shell
# On an M1 Mac
$ docker run --rm -ti gsoci.azurecr.io/giantswarm/kubectl-gs:4.8.0-b2c208e7d33fd46b92189804eb6a3316be451db0 --version
kubectl gs version 4.8.1-dev
$ docker inspect gsoci.azurecr.io/giantswarm/kubectl-gs:4.8.0-b2c208e7d33fd46b92189804eb6a3316be451db0
```

```json
[
    {
        "Id": "sha256:35688e688d03ea54842febfb850f699c387e737ac01b05b620f0a658bf4a974b",
        "RepoTags": [
            "gsoci.azurecr.io/giantswarm/kubectl-gs:4.8.0-b2c208e7d33fd46b92189804eb6a3316be451db0"
        ],
        "RepoDigests": [
            "gsoci.azurecr.io/giantswarm/kubectl-gs@sha256:35688e688d03ea54842febfb850f699c387e737ac01b05b620f0a658bf4a974b"
        ],
        "Parent": "",
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2025-09-29T08:55:25.984733899Z",
        "DockerVersion": "",
        "Author": "",
        "Architecture": "arm64",
        "Os": "linux",
        "Size": 63006889,
        "GraphDriver": {
            "Data": null,
            "Name": "overlayfs"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:0b83d017db6efafadf6b3f18d087d2ce1d67d8f0e927dc7254b0ad088074cd3a",
                "sha256:f9ee996359a194674c0e60798fff02f8de3563e92e94b68be59ef6e3ec47bb42",
                "sha256:1b58927682cd46b91dbfd84c128e3cc841b2d35320e9e11ee43fd9d398d24430",
                "sha256:2e2a26bb46a2894627d7036152b4a2e4b29f5b81b578e74758304f44f494661f"
            ]
        },
        "Metadata": {
            "LastTagTime": "2025-09-29T09:15:16.616791042Z"
        },
        "Descriptor": {
            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
            "digest": "sha256:35688e688d03ea54842febfb850f699c387e737ac01b05b620f0a658bf4a974b",
            "size": 965
        },
        "Config": {
            "Cmd": null,
            "Entrypoint": [
                "kubectl-gs"
            ],
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Labels": null,
            "OnBuild": null,
            "User": "",
            "Volumes": null,
            "WorkingDir": "/"
        }
    }
]
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No