### PR TITLE
Filter base on the spec instead of status

### DIFF
--- a/pkg/data/domain/release/common.go
+++ b/pkg/data/domain/release/common.go
@@ -47,7 +47,7 @@ func (s *Service) getByName(ctx context.Context, name, namespace string, activeO
 			return nil, microerror.Mask(err)
 		}
 
-		if activeOnly && !rel.Status.Ready {
+		if activeOnly && rel.Spec.State != releasev1alpha1.StateActive {
 			return nil, microerror.Mask(noMatchError)
 		}
 
@@ -82,7 +82,7 @@ func (s *Service) getAll(ctx context.Context, namespace string, activeOnly bool)
 		}
 
 		for _, rel := range releases.Items {
-			if activeOnly && !rel.Status.Ready {
+			if activeOnly && rel.Spec.State != releasev1alpha1.StateActive {
 				continue
 			}
 


### PR DESCRIPTION
I found a bug, there is no status on releases, the state Is under the Spec field