### PR TITLE
Make `deploy chart` more flexible with `--update-only` and `--namespace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `--update-only` flag to `deploy chart` command to only update pre-existing `OCIRepository` and `HelmRelease` resources and fail if they do not exist
+
 ## [5.3.1] - 2026-04-04
 
 ### Fixed
 
--  Updated dependencies
+- Updated dependencies
 
 ## [5.3.0] - 2026-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add `--update-only` flag to `deploy chart` command to only update pre-existing `OCIRepository` and `HelmRelease` resources and fail if they do not exist
+- Add `--namespace` flag to `deploy chart` command to set the target namespace directly, as an alternative to `--organization` which derives the namespace as `org-<organization>`. The two flags are mutually exclusive.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add `--update-only` flag to `deploy chart` command to only update pre-existing `OCIRepository` and `HelmRelease` resources and fail if they do not exist
 
+### Fixed
+
+- Remove semver validation from `--version` flag of `deploy chart` command to allow arbitrary version strings (such as commit-suffixed pre-release versions `X.Y.Z-commit`). The command already verifies that an image with the given version exists in the OCI repository, so the extra check was redundant and rejected otherwise valid versions.
+
 ## [5.3.1] - 2026-04-04
 
 ### Fixed

--- a/cmd/deploy/chart/command.go
+++ b/cmd/deploy/chart/command.go
@@ -28,7 +28,8 @@ are created in the organization namespace.
 Resource names default to <cluster>-<chart-name> and can be overridden with --name.
 
 Use --dry-run to perform server-side validation without persisting resources.
-Use --management-cluster to deploy to the MC itself (no --target-cluster needed).`
+Use --management-cluster to deploy to the MC itself (no --target-cluster needed).
+Use --update-only to only update pre-existing resources and fail if they are missing.`
 
 	examples = `  # Deploy a chart with a specific version
   kubectl gs deploy chart \
@@ -87,7 +88,16 @@ Use --management-cluster to deploy to the MC itself (no --target-cluster needed)
       --chart-name hello-world-app \
       --organization acme \
       --target-namespace hello \
-      --management-cluster`
+      --management-cluster
+
+  # Update an already-deployed chart to a new version (fail if not deployed yet)
+  kubectl gs deploy chart \
+      --chart-name hello-world-app \
+      --version 1.2.4 \
+      --organization acme \
+      --target-cluster mycluster01 \
+      --target-namespace hello \
+      --update-only`
 )
 
 type Config struct {

--- a/cmd/deploy/chart/error.go
+++ b/cmd/deploy/chart/error.go
@@ -37,3 +37,12 @@ var confirmationRequiredError = &microerror.Error{
 func IsConfirmationRequired(err error) bool {
 	return microerror.Cause(err) == confirmationRequiredError
 }
+
+var resourceNotFoundError = &microerror.Error{
+	Kind: "resourceNotFoundError",
+}
+
+// IsResourceNotFound asserts resourceNotFoundError.
+func IsResourceNotFound(err error) bool {
+	return microerror.Cause(err) == resourceNotFoundError
+}

--- a/cmd/deploy/chart/flag.go
+++ b/cmd/deploy/chart/flag.go
@@ -2,15 +2,11 @@ package chart
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )
-
-// semverRe matches a basic semver string like "1.2.3" or "v1.2.3".
-var semverRe = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 const (
 	flagChartName         = "chart-name"
@@ -95,10 +91,6 @@ func (f *flag) Validate() error {
 	}
 	if f.TargetNS == "" {
 		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagTargetNS)
-	}
-
-	if f.Version != "" && !semverRe.MatchString(f.Version) {
-		return microerror.Maskf(invalidFlagError, "--%s must be a valid semver version (e.g. 1.2.3), got %q", flagVersion, f.Version)
 	}
 
 	if f.AutoUpgrade != "" {

--- a/cmd/deploy/chart/flag.go
+++ b/cmd/deploy/chart/flag.go
@@ -11,6 +11,7 @@ import (
 const (
 	flagChartName         = "chart-name"
 	flagOrganization      = "organization"
+	flagNamespace         = "namespace"
 	flagCluster           = "target-cluster"
 	flagTargetNS          = "target-namespace"
 	flagOCIURLPrefix      = "oci-url-prefix"
@@ -38,6 +39,7 @@ var validRegistryProviders = []string{"aws", "azure", "gcp"}
 type flag struct {
 	ChartName         string
 	Organization      string
+	Namespace         string
 	Cluster           string
 	TargetNS          string
 	OCIURLPrefix      string
@@ -56,7 +58,8 @@ type flag struct {
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ChartName, flagChartName, "", "Name of the chart to deploy.")
-	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Giant Swarm organization name owning the target cluster.")
+	cmd.Flags().StringVar(&f.Organization, flagOrganization, "", "Giant Swarm organization name owning the target cluster. The namespace is derived as `org-<organization>`. Mutually exclusive with --namespace.")
+	cmd.Flags().StringVar(&f.Namespace, flagNamespace, "", "Namespace in which to create or update the resources. Mutually exclusive with --organization.")
 	cmd.Flags().StringVar(&f.Cluster, flagCluster, "", "Name of the target workload cluster.")
 	cmd.Flags().StringVar(&f.TargetNS, flagTargetNS, "", "Target namespace in the workload cluster.")
 	cmd.Flags().StringVar(&f.OCIURLPrefix, flagOCIURLPrefix, defaultOCIURLPrefix, "OCI URL prefix for the chart registry.")
@@ -80,8 +83,11 @@ func (f *flag) Validate() error {
 	if strings.Contains(f.ChartName, "/") {
 		return microerror.Maskf(invalidFlagError, "--%s must not contain '/'", flagChartName)
 	}
-	if f.Organization == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagOrganization)
+	if f.Organization == "" && f.Namespace == "" {
+		return microerror.Maskf(invalidFlagError, "one of --%s or --%s must be specified", flagOrganization, flagNamespace)
+	}
+	if f.Organization != "" && f.Namespace != "" {
+		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagOrganization, flagNamespace)
 	}
 	if f.ManagementCluster && f.Cluster != "" {
 		return microerror.Maskf(invalidFlagError, "--%s and --%s are mutually exclusive", flagManagementCluster, flagCluster)

--- a/cmd/deploy/chart/flag.go
+++ b/cmd/deploy/chart/flag.go
@@ -27,6 +27,7 @@ const (
 	flagRegistryProvider  = "registry-provider"
 	flagValuesFrom        = "values-from"
 	flagManagementCluster = "management-cluster"
+	flagUpdateOnly        = "update-only"
 	flagDryRun            = "dry-run"
 
 	envRegistryPassword = "KUBECTL_GS_REGISTRY_PASSWORD" //nolint:gosec // Not a credential, just the env var name.
@@ -53,6 +54,7 @@ type flag struct {
 	RegistryProvider  string
 	ValuesFrom        []string
 	ManagementCluster bool
+	UpdateOnly        bool
 	DryRun            bool
 }
 
@@ -71,6 +73,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.RegistryProvider, flagRegistryProvider, "", "Cloud provider for registry authentication via workload identity (aws, azure, gcp). When set, no registry Secret is created.")
 	cmd.Flags().StringSliceVar(&f.ValuesFrom, flagValuesFrom, nil, "Reference to a ConfigMap or Secret containing chart values (format: ConfigMap/name or Secret/name). Can be specified multiple times.")
 	cmd.Flags().BoolVar(&f.ManagementCluster, flagManagementCluster, false, "Deploy to the management cluster itself. Cluster name is derived from the current kubectl context.")
+	cmd.Flags().BoolVar(&f.UpdateOnly, flagUpdateOnly, false, "Only update existing OCIRepository and HelmRelease resources; fail if they do not exist.")
 	cmd.Flags().BoolVar(&f.DryRun, flagDryRun, false, "Perform server-side validation without applying. Prints manifests to stdout.")
 }
 

--- a/cmd/deploy/chart/flag_test.go
+++ b/cmd/deploy/chart/flag_test.go
@@ -48,7 +48,7 @@ func TestFlagValidate(t *testing.T) {
 			errMsg:  "must not contain '/'",
 		},
 		{
-			name: "missing organization",
+			name: "missing organization and namespace",
 			flag: flag{
 				ChartName:    "hello-world-app",
 				Cluster:      "mycluster01",
@@ -57,7 +57,32 @@ func TestFlagValidate(t *testing.T) {
 				Interval:     defaultInterval,
 			},
 			wantErr: true,
-			errMsg:  "organization",
+			errMsg:  "one of --organization or --namespace",
+		},
+		{
+			name: "namespace alone is valid",
+			flag: flag{
+				ChartName:    "hello-world-app",
+				Namespace:    "my-namespace",
+				Cluster:      "mycluster01",
+				TargetNS:     "hello",
+				OCIURLPrefix: defaultOCIURLPrefix,
+				Interval:     defaultInterval,
+			},
+		},
+		{
+			name: "organization and namespace are mutually exclusive",
+			flag: flag{
+				ChartName:    "hello-world-app",
+				Organization: "acme",
+				Namespace:    "my-namespace",
+				Cluster:      "mycluster01",
+				TargetNS:     "hello",
+				OCIURLPrefix: defaultOCIURLPrefix,
+				Interval:     defaultInterval,
+			},
+			wantErr: true,
+			errMsg:  "mutually exclusive",
 		},
 		{
 			name: "missing cluster",

--- a/cmd/deploy/chart/runner.go
+++ b/cmd/deploy/chart/runner.go
@@ -291,6 +291,23 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		manifest{"HelmRelease", crdVersions.HelmReleaseAPIVersion, resourceName, helmReleaseYAML},
 	)
 
+	if r.flag.UpdateOnly {
+		for _, m := range manifests {
+			gvr, err := deploychart.ResourceGVR(m.apiVersion, m.kind)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			existing, err := deploychart.GetExistingResource(ctx, dynClient, gvr, namespace, m.resourceName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if existing == nil {
+				return microerror.Maskf(resourceNotFoundError,
+					"--%s is set but %s %s/%s does not exist", flagUpdateOnly, m.kind, namespace, m.resourceName)
+			}
+		}
+	}
+
 	for _, m := range manifests {
 		gvr, err := deploychart.ResourceGVR(m.apiVersion, m.kind)
 		if err != nil {

--- a/cmd/deploy/chart/runner.go
+++ b/cmd/deploy/chart/runner.go
@@ -49,7 +49,10 @@ func (r *runner) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
-	namespace := key.OrganizationNamespaceFromName(r.flag.Organization)
+	namespace := r.flag.Namespace
+	if namespace == "" {
+		namespace = key.OrganizationNamespaceFromName(r.flag.Organization)
+	}
 
 	// Split the OCI URL prefix into registry host and repository prefix.
 	// OCIURLPrefix is normalized to "oci://host/path/" by flag.Validate().
@@ -139,13 +142,16 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		return microerror.Mask(err)
 	}
 
-	// Verify the organization namespace exists.
+	// Verify the namespace exists.
 	_, err = k8sClients.K8sClient().CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return microerror.Maskf(invalidFlagError,
-				"the organization %q wasn't found\nPlease check for existing organizations using\n\n    kubectl gs get organizations",
-				r.flag.Organization)
+			if r.flag.Organization != "" {
+				return microerror.Maskf(invalidFlagError,
+					"the organization %q wasn't found\nPlease check for existing organizations using\n\n    kubectl gs get organizations",
+					r.flag.Organization)
+			}
+			return microerror.Maskf(invalidFlagError, "namespace %q does not exist", namespace)
 		}
 		return microerror.Mask(err)
 	}
@@ -177,8 +183,8 @@ func (r *runner) run(ctx context.Context, _ *cobra.Command, _ []string) error {
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return microerror.Maskf(invalidFlagError,
-					"cluster %q not found in organization %q\n\n  Please check for existing clusters using\n\n    kubectl gs get clusters --namespace %s",
-					clusterName, r.flag.Organization, namespace)
+					"cluster %q not found in namespace %q\n\n  Please check for existing clusters using\n\n    kubectl gs get clusters --namespace %s",
+					clusterName, namespace, namespace)
 			}
 			return microerror.Mask(err)
 		}

--- a/pkg/credentialcache/cache.go
+++ b/pkg/credentialcache/cache.go
@@ -93,7 +93,7 @@ func WriteWithoutLock(issuerURL, clientID, idToken, refreshToken string) error {
 		return err
 	}
 
-	data, err := json.Marshal(Entry{IDToken: idToken, RefreshToken: refreshToken})
+	data, err := json.Marshal(Entry{IDToken: idToken, RefreshToken: refreshToken}) //nolint:gosec // Field name matches pattern but contains no hardcoded credential
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I tried to use this to edit `HelmRelease`/`OCIRepository` for MC operators. The first issue is that the command upserts, but we don't want to _create_ objects, so I introduced `--update-only` as safety measure. Second, `--organization` was the only way to choose the object namespace, while our operators are in namespace `giantswarm`, so I added `--namespace` as alternative. The last issue, not solved in this PR, is prefixing the object names with `<cluster>-` as expected for workload clusters.

Essentially, I'm not sure if MC operators _should_ be deployable with this tool, so this PR is still a draft to show the issues that arose for Giant Swarm developers. Let's decide if we want to have that functionality in this tool, as we did before with `kubectl gs update app`. Once we've done that, there's another issue: suspending Flux reconciliation is needed for our purposes.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

No