### PR TITLE
ci: migrate to architect-orb 8.1.0 multi-arch path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@8.1.0
 
 jobs:
   debug-tag:
@@ -124,78 +124,6 @@ jobs:
   #         paths:
   #           - ./kubectl-gs-s390x
 
-  push-to-registries-multiarch:
-    executor: architect/architect
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: default
-      - attach_workspace:
-          at: .
-      - architect/image-prepare-tag
-      - architect/image-login-to-registries
-      - run:
-          name: Create a docker-container-driven custom builder
-          command: |
-            docker buildx create --name container-builder --driver docker-container --bootstrap --use
-      - run:
-          name: Push image to registries
-          command: |
-            IMAGE_ACCESS=public
-            #PLATFORMS=linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/s390x
-            PLATFORMS=linux/amd64,linux/arm64,linux/386
-
-            if ! [[ "${REGISTRIES_DATA_BASE64}" ]]; then
-              echo "Environment variable REGISTRIES_DATA_BASE64 is not set properly in circleci's context."
-              exit 1
-            fi
-            echo $REGISTRIES_DATA_BASE64 | base64 -d > .registries_data
-
-
-            cat .registries_data | while read -r access reg _ _ push_dev; do
-              echo -e "\nProcessing image push config for registry ${reg}."
-              if [[ "${push_dev}" == "false" ]] && [[ "${DOCKER_IMAGE_TAG}" =~ [a-f0-9]{40} ]]; then
-                echo "Not uploading image with tag ${DOCKER_IMAGE_TAG}, as 'push-dev' is 'false'"
-                continue
-              fi
-
-              if [[ "${access}" == *"${IMAGE_ACCESS}"* ]]; then
-                echo "Tagging the image as ${DOCKER_IMAGE_TAG}"
-                TAGS="-t ${reg}/giantswarm/kubectl-gs:${DOCKER_IMAGE_TAG}"
-
-                if [[ "main" == "${CIRCLE_BRANCH}" ]]; then
-                  echo "Tagging the image as 'latest'"
-                  TAGS="$TAGS -t ${reg}/giantswarm/kubectl-gs:latest"
-                fi
-
-                echo "Building and pushing image to the ${reg} registry"
-                CMD="docker buildx build --push --provenance=false --platform ${PLATFORMS} ${TAGS} -f ./Dockerfile . --progress plain 2>&1 | tee .docker.log"
-
-                SUCCESS=false
-                for i in $(seq 1 4); do
-                  echo "attempt: ${i}"
-                  if bash -c "${CMD}"; then
-                    echo "Image is built and pushed to the registry."
-                    SUCCESS=true
-                    break
-                  fi
-                  echo "Waiting 5 seconds before the next attempt."
-                  sleep 5
-                done
-                if [[ "${SUCCESS}" == "false" ]]; then
-                  echo "${reg}:${DOCKER_IMAGE_TAG}" >> .failed_images
-                fi
-
-              else
-                echo "Registry ${reg} is not configured for ${IMAGE_ACCESS} images, skipping"
-              fi
-            done
-
-            if [[ -f .failed_images ]]; then
-              echo "Some images couldn't be built and pushed, check: $(cat .failed_images)"
-              exit 1
-            fi
-
 workflows:
   go-build-multiarch:
     jobs:
@@ -217,9 +145,12 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - push-to-registries-multiarch:
+      - architect/push-to-registries:
           context: architect
           name: push-to-registries-multiarch
+          multiarch: true
+          platforms: "linux/amd64,linux/arm64,linux/386"
+          force-public: true
           requires:
             - go-build-amd64
             - go-build-arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `giantswarm/architect` orb to `8.1.0` and replace the hand-rolled inline `push-to-registries-multiarch` job (~75 lines of `docker buildx` wrapper) with `architect/push-to-registries` and `multiarch: true`. The orb job builds the same `linux/amd64,linux/arm64,linux/386` matrix from the per-arch binaries produced by `go-build-{amd64,arm64,386}` and reuses the Dockerfile's `COPY ./kubectl-gs-${TARGETARCH}` step. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels for free.
+
 ## [5.5.0] - 2026-05-12
 
 ### Added


### PR DESCRIPTION
## Summary

- Bump `giantswarm/architect` orb to `8.1.0`.
- Replace the hand-rolled inline `push-to-registries-multiarch` job (~75 lines of `docker buildx` wrapper code) with `architect/push-to-registries` and `multiarch: true`.

## Why

The custom job was a private fork of the orb's deprecated `push-to-registries-multiarch`. The orb's `push-to-registries` (`multiarch: true`) does the same thing and is the supported path going forward.

v8.1.0 also brings:

- Automatic QEMU/binfmt registration before `docker buildx build`.
- Hardened buildx builder bootstrap that surfaces failures instead of masking them.
- Standard OCI image labels and manifest-index annotations emitted by default.

## How it works

The orb job builds the same `linux/amd64,linux/arm64,linux/386` matrix from the per-arch binaries that `go-build-{amd64,arm64,386}` persist to the workspace (`kubectl-gs-amd64`, `kubectl-gs-arm64`, `kubectl-gs-386`). The Dockerfile's `COPY ./kubectl-gs-${TARGETARCH}` step picks the right binary for each platform unchanged.

`force-public: true` is passed because kubectl-gs is intentionally always public — matching the previous `IMAGE_ACCESS=public` filter in the custom job.

## Test plan

- [x] Branch CI builds and pushes the multi-arch image via the new job on this PR.
- [ ] On the next `v*` tag release, the `update-krew-index` job (`requires: push-to-registries-multiarch, debug-tag`) still fires after the orb job, since the workflow job name is preserved.


Made with [Cursor](https://cursor.com)