### PR TITLE
ci: drop linux/386 from docker image platforms (fix #1965 follow-up)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,16 +145,21 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      # Docker image: linux/amd64 + linux/arm64 only. The alpine base image
+      # in gsoci.azurecr.io/giantswarm/alpine does not ship a linux/386
+      # variant, so the legacy inline job's 386 build silently failed every
+      # run (the `tee` pipe always returned 0 and masked the buildx error).
+      # The standalone linux/386 kubectl-gs binary is still produced by
+      # go-build-386 and distributed through GitHub releases / krew.
       - architect/push-to-registries:
           context: architect
           name: push-to-registries-multiarch
           multiarch: true
-          platforms: "linux/amd64,linux/arm64,linux/386"
+          platforms: "linux/amd64,linux/arm64"
           force-public: true
           requires:
             - go-build-amd64
             - go-build-arm64
-            - go-build-386
             # - go-build-ppc64le
             # - go-build-s390x
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Bump `giantswarm/architect` orb to `8.1.0` and replace the hand-rolled inline `push-to-registries-multiarch` job (~75 lines of `docker buildx` wrapper) with `architect/push-to-registries` and `multiarch: true`. The orb job builds the same `linux/amd64,linux/arm64,linux/386` matrix from the per-arch binaries produced by `go-build-{amd64,arm64,386}` and reuses the Dockerfile's `COPY ./kubectl-gs-${TARGETARCH}` step. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels for free.
+- Bump `giantswarm/architect` orb to `8.1.0` and replace the hand-rolled inline `push-to-registries-multiarch` job (~75 lines of `docker buildx` wrapper) with `architect/push-to-registries` and `multiarch: true`. The orb job builds the multi-arch image from the per-arch binaries produced by `go-build-{amd64,arm64}` and reuses the Dockerfile's `COPY ./kubectl-gs-${TARGETARCH}` step. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels for free.
+
+### Fixed
+
+- Drop `linux/386` from the docker image's `--platform` list. The base image `gsoci.azurecr.io/giantswarm/alpine` does not ship a `linux/386` variant, so the legacy inline `push-to-registries-multiarch` job's `buildx` invocation has been silently failing for that platform on every run -- the bug was masked by the script's `... | tee .docker.log` pipe always returning `0`, so the failed buildx output never affected the job's exit code. The pushed multi-arch image therefore never actually contained a `linux/386` variant. The standalone `linux/386` `kubectl-gs` binary continues to be produced by `go-build-386` and shipped through GitHub releases / krew.
 
 ## [5.5.0] - 2026-05-12
 


### PR DESCRIPTION
## Summary

- Remove `linux/386` from the docker image's `--platform` list.

## Why this PR exists

In #1965 the inline `push-to-registries-multiarch` job was migrated to `architect/push-to-registries` with `multiarch: true`. That orb job correctly reports `buildx` failures, which exposed an existing bug: the alpine base image `gsoci.azurecr.io/giantswarm/alpine:3.23.4` only ships `linux/{amd64,arm64,arm,ppc64le}` -- no `linux/386`. Every previous CI run on a non-main branch hit `ERROR: no match for platform in manifest: not found` for `linux/386` but the old script's `docker buildx build … | tee .docker.log` pipe always returned `0`, masking the failure. The published multi-arch image therefore never actually contained a `linux/386` manifest.

This PR removes `linux/386` from the docker image platforms list so the orb job can succeed. The standalone `linux/386` `kubectl-gs` binary continues to be produced by `go-build-386` and shipped through GitHub releases / krew.

## Test plan

- [x] Branch CI now builds and pushes a `linux/amd64,linux/arm64` multi-arch image successfully on this PR.
- [ ] Next `v*` tag release verifies the tag-build path.

## Refs

- #1965 (orb migration that exposed the bug)

Made with [Cursor](https://cursor.com)