### PR TITLE
ci: enable split-china-push for the Aliyun mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ workflows:
           multiarch: true
           platforms: "linux/amd64,linux/arm64"
           force-public: true
+          split-china-push: true
           requires:
             - go-build-amd64
             - go-build-arm64
@@ -166,6 +167,19 @@ workflows:
             branches:
               ignore:
                 - main
+            tags:
+              only: /^v.*/
+      # Mirror gsoci -> Aliyun via the in-China giantswarm/galaxy-runner on
+      # tag builds only. Replaces the cross-Pacific docker buildx push to
+      # Aliyun that timed out on tag jobs.
+      - architect/sync-china-registry:
+          context: architect
+          name: sync-china-registry
+          requires:
+            - push-to-registries-multiarch
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/
       - debug-tag:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Enable `split-china-push: true` on the tag-build `push-to-registries-multiarch` job and add a companion `sync-china-registry` job. The cross-Pacific `docker buildx` push to the Aliyun mirror is replaced with a `regctl image copy` from gsoci to Aliyun executed on the in-China `giantswarm/galaxy-runner` self-hosted CircleCI runner.
 - Bump `giantswarm/architect` orb to `8.1.0` and replace the hand-rolled inline `push-to-registries-multiarch` job (~75 lines of `docker buildx` wrapper) with `architect/push-to-registries` and `multiarch: true`. The orb job builds the multi-arch image from the per-arch binaries produced by `go-build-{amd64,arm64}` and reuses the Dockerfile's `COPY ./kubectl-gs-${TARGETARCH}` step. Picks up the v8.1.0 QEMU/binfmt auto-registration, hardened buildx bootstrap, and standard OCI image labels for free.
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `split-china-push: true` to the `push-to-registries-multiarch` job.
- Add a companion `architect/sync-china-registry` job (tag-only) that mirrors gsoci -> Aliyun on the in-China `giantswarm/galaxy-runner`.

## Why

`split-china-push` (orb v7.1.0+) replaces the cross-Pacific `docker buildx` push to Aliyun (~10-minute timeout) with a `regctl image copy` from gsoci to Aliyun executed on the in-China `giantswarm/galaxy-runner` self-hosted CircleCI runner. The Singapore geo-replica + 10x retries handle Azure CR eventual consistency.

`sync-china-registry` runs only on `v*` tags (Aliyun receives only stable releases), matching the previous behaviour from the buildx-based job which had `push_dev: false` on Aliyun.

## Test plan

- [x] Branch CI exercises the `push-to-registries-multiarch` (multi-arch, no Aliyun) job on this PR.
- [ ] Next `v*` tag exercises the new `split-china-push` + `sync-china-registry` flow end-to-end.


Made with [Cursor](https://cursor.com)