### PR TITLE
Enable PKCE on the direct OIDC flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
+- `login`: enable PKCE (RFC 7636) on the direct OIDC flow used for workload clusters with Kubernetes structured authentication. Public OIDC clients registered without a `client_secret` (e.g. Okta SPA / Native apps) previously failed the token exchange with `invalid_client` because neither client authentication nor a PKCE code verifier was sent. The Dex-mediated management cluster flow is unaffected.
 - Drop `linux/386` from the docker image's `--platform` list. The base image `gsoci.azurecr.io/giantswarm/alpine` does not ship a `linux/386` variant, so the legacy inline `push-to-registries-multiarch` job's `buildx` invocation has been silently failing for that platform on every run -- the bug was masked by the script's `... | tee .docker.log` pipe always returning `0`, so the failed buildx output never affected the job's exit code. The pushed multi-arch image therefore never actually contained a `linux/386` variant. The standalone `linux/386` `kubectl-gs` binary continues to be produced by `go-build-386` and shipped through GitHub releases / krew.
 
 ## [5.5.0] - 2026-05-12

--- a/pkg/oidc/oidc.go
+++ b/pkg/oidc/oidc.go
@@ -17,6 +17,7 @@ type Authenticator struct {
 	provider     *gooidc.Provider
 	clientConfig oauth2.Config
 	challenge    string
+	pkceVerifier string
 }
 
 type UserInfo struct {
@@ -105,8 +106,13 @@ func New(ctx context.Context, c Config) (*Authenticator, error) {
 // GetPlainAuthURL returns the authorization URL without any Dex-specific parameters.
 // This is used for direct OIDC flows (e.g., structured authentication) where the
 // issuer is not Dex and doesn't understand connector_id or connector_filter.
+//
+// PKCE (RFC 7636) is enabled on this path because direct OIDC clients are
+// typically registered as public clients (no client_secret) — e.g. an Okta
+// SPA/Native app — which require PKCE for the token exchange to succeed.
 func (a *Authenticator) GetPlainAuthURL() string {
-	return a.clientConfig.AuthCodeURL(a.challenge, oauth2.AccessTypeOffline)
+	a.pkceVerifier = oauth2.GenerateVerifier()
+	return a.clientConfig.AuthCodeURL(a.challenge, oauth2.AccessTypeOffline, oauth2.S256ChallengeOption(a.pkceVerifier))
 }
 
 func (a *Authenticator) GetAuthURL(connectorID string) string {
@@ -157,8 +163,14 @@ func (a *Authenticator) HandleIssuerResponse(ctx context.Context, challenge stri
 
 	var token *oauth2.Token
 	{
-		// Convert the authorization code into a token.
-		token, err = a.clientConfig.Exchange(ctx, code)
+		// Convert the authorization code into a token. Send the PKCE code
+		// verifier when one was generated for this authentication (direct
+		// OIDC flow); Dex flows leave it empty.
+		var exchangeOpts []oauth2.AuthCodeOption
+		if a.pkceVerifier != "" {
+			exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(a.pkceVerifier))
+		}
+		token, err = a.clientConfig.Exchange(ctx, code, exchangeOpts...)
 		if err != nil {
 			return UserInfo{}, microerror.Mask(err)
 		}


### PR DESCRIPTION
Public OIDC clients (e.g. Okta SPA/Native apps) registered without a `client_secret` rejected the token exchange with "invalid_client" . Implement PCKE to allow login using our login.
