### PR TITLE
feat(login): add --oidc-scope flag for direct OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- `login`: new `--oidc-scope` flag (repeatable, comma-separated) appends extra scopes to the direct workload-cluster OIDC request. Use `--oidc-scope=groups` with Okta to receive group memberships in the ID token when the workload cluster's structured auth is configured with `groupsClaim`.
+
 ## [5.6.3] - 2026-05-28
 
 ### Fixed

--- a/cmd/login/flag.go
+++ b/cmd/login/flag.go
@@ -29,6 +29,7 @@ const (
 	flagWCOIDCIssuer   = "oidc-issuer"
 	flagWCOIDCClientID = "oidc-client-id"
 	flagWCOIDCCAFile   = "api-ca-file"
+	flagWCOIDCScope    = "oidc-scope"
 
 	flagProxy     = "proxy"
 	flagProxyPort = "proxy-port"
@@ -62,6 +63,7 @@ type flag struct {
 	WCOIDCIssuer   string
 	WCOIDCClientID string
 	WCOIDCCAFile   string
+	WCOIDCScopes   []string
 
 	Proxy     bool
 	ProxyPort int
@@ -96,6 +98,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.WCOIDCIssuer, flagWCOIDCIssuer, "", fmt.Sprintf("Override the OIDC issuer URL for direct workload cluster OIDC login. When set together with --%s, skips auto-detection from the management cluster.", flagWCOIDCClientID))
 	cmd.Flags().StringVar(&f.WCOIDCClientID, flagWCOIDCClientID, "", fmt.Sprintf("Override the OIDC client ID for direct workload cluster OIDC login. When set together with --%s, skips auto-detection from the management cluster.", flagWCOIDCIssuer))
 	cmd.Flags().StringVar(&f.WCOIDCCAFile, flagWCOIDCCAFile, "", "Override the path to the CA certificate file for the workload cluster API server. When set, skips fetching the CA from the management cluster.")
+	cmd.Flags().StringSliceVar(&f.WCOIDCScopes, flagWCOIDCScope, nil, "Additional OIDC scopes to request from the issuer, on top of the defaults (openid, profile, email, offline_access). Repeat the flag or pass a comma-separated list. Example: --oidc-scope=groups to receive group memberships from Okta into the ID token.")
 
 	cmd.Flags().BoolVar(&f.Proxy, flagProxy, false, "Enable socks proxy configuration for the cluster. Only Supported for Workload Cluster using clientcert auth mode")
 	cmd.Flags().IntVar(&f.ProxyPort, flagProxyPort, 9000, "Port for the socks proxy configuration for the cluster")

--- a/cmd/login/wc_oidc.go
+++ b/cmd/login/wc_oidc.go
@@ -58,7 +58,7 @@ func (r *runner) createOIDCKubeconfig(ctx context.Context, k8sClient k8sclient.I
 	if r.flag.DeviceAuth {
 		authResult, err = handleDirectDeviceOIDC(r.stdout, r.stderr, authConfig.IssuerURL, authConfig.ClientID)
 	} else {
-		authResult, err = handleDirectOIDC(ctx, r.stdout, r.stderr, authConfig.IssuerURL, authConfig.ClientID, r.flag.CallbackServerHost, r.flag.CallbackServerPort, r.flag.LoginTimeout)
+		authResult, err = handleDirectOIDC(ctx, r.stdout, r.stderr, authConfig.IssuerURL, authConfig.ClientID, r.flag.CallbackServerHost, r.flag.CallbackServerPort, r.flag.LoginTimeout, r.flag.WCOIDCScopes)
 	}
 	if err != nil {
 		return "", false, microerror.Mask(err)
@@ -233,7 +233,7 @@ func printWCOIDCCredentials(k8sConfigAccess clientcmd.ConfigAccess, fs afero.Fs,
 
 // handleDirectOIDC performs the browser-based OIDC flow directly against
 // a non-Dex issuer (e.g., Azure AD via structured authentication).
-func handleDirectOIDC(ctx context.Context, out io.Writer, errOut io.Writer, issuerURL, oidcClientID, host string, port int, timeout time.Duration) (authInfo, error) {
+func handleDirectOIDC(ctx context.Context, out io.Writer, errOut io.Writer, issuerURL, oidcClientID, host string, port int, timeout time.Duration, extraScopes []string) (authInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -255,11 +255,16 @@ func handleDirectOIDC(ctx context.Context, out io.Writer, errOut io.Writer, issu
 		}
 	}
 
+	scopes := directOIDCScopes
+	if len(extraScopes) > 0 {
+		scopes = append(append([]string{}, directOIDCScopes...), extraScopes...)
+	}
+
 	oidcConfig := oidc.Config{
 		ClientID:    oidcClientID,
 		Issuer:      issuerURL,
 		RedirectURL: fmt.Sprintf("%s:%d", oidcCallbackURL, authProxy.Port()),
-		AuthScopes:  directOIDCScopes,
+		AuthScopes:  scopes,
 	}
 	auther, err := oidc.New(ctx, oidcConfig)
 	if err != nil {


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C092KTAL79V/p1780088861572729

- New `--oidc-scope` flag on `kubectl gs login` that appends extra scopes to the default direct-OIDC scope list (`openid`, `profile`, `email`, `offline_access`).

### Why a flag instead of a default

`groups` is not an RFC 6749 standard scope. Some IdPs strictly validate scope requests and reject unknown values, so adding it unconditionally would risk regressing other direct-OIDC integrations. 

### Usage

```
kubectl gs login \\
  --organization <org> \\
  --workload-cluster <name> \\
  --self-contained kubeconfig \\
  --oidc-scope=groups
```

Multiple scopes: `--oidc-scope=groups,custom` or repeat the flag.
