### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.3.0
+  architect: giantswarm/architect@9.1.0
 
 jobs:
   debug-tag:
@@ -36,161 +36,66 @@ jobs:
           name: Execute krew-release-bot
           command: ./krew-release-bot action
 
-  go-build-386:
-    executor: architect/architect
-    resource_class: "medium+"
-    steps:
-      - checkout
-      - architect/tools-info
-      - architect/go-cache-restore
-      # We don't test for 386 specifically
-      - run:
-          name: Build binary (linux/386)
-          command: |
-            CGO_ENABLED=0 GOOS="linux" GOARCH=386 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-386 .
-      - architect/go-cache-save
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./kubectl-gs-386
-
-  go-build-amd64:
-    executor: architect/architect
-    resource_class: "medium+"
-    steps:
-      - checkout
-      - architect/tools-info
-      - architect/go-cache-restore
-      - architect/go-test
-      - run:
-          name: Build binary (linux/amd64)
-          command: |
-            CGO_ENABLED=0 GOOS="linux" GOARCH=amd64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-amd64 .
-      - architect/go-cache-save
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./kubectl-gs-amd64
-
-  go-build-arm64:
-    executor: architect/architect
-    resource_class: "arm.medium"
-    steps:
-      - checkout
-      - architect/tools-info
-      - architect/go-cache-restore
-      - architect/go-test
-      - run:
-         name: Build binary (linux/arm64)
-         command: |
-           CGO_ENABLED=0 GOOS="linux" GOARCH=arm64 go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-arm64 .
-      - architect/go-cache-save
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./kubectl-gs-arm64
-
-  # go-build-ppc64le:
-  #   executor: architect/architect
-  #   resource_class: "medium+"
-  #   steps:
-  #     - checkout
-  #     - architect/tools-info
-  #     - architect/go-cache-restore
-  #     - run:
-  #        name: Build binary (linux/ppc64le)
-  #        command: |
-  #          CGO_ENABLED=0 GOOS="linux" GOARCH=ppc64le go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-ppc64le .
-  #     - architect/go-cache-save
-  #     - persist_to_workspace:
-  #         root: .
-  #         paths:
-  #           - ./kubectl-gs-ppc64le
-
-  # go-build-s390x:
-  #   executor: architect/architect
-  #   resource_class: "medium+"
-  #   steps:
-  #     - checkout
-  #     - architect/tools-info
-  #     - architect/go-cache-restore
-  #     - run:
-  #        name: Build binary (linux/s390x)
-  #        command: |
-  #          CGO_ENABLED=0 GOOS="linux" GOARCH=s390x go build -ldflags "$(cat .ldflags)" -o ./kubectl-gs-s390x .
-  #     - architect/go-cache-save
-  #     - persist_to_workspace:
-  #         root: .
-  #         paths:
-  #           - ./kubectl-gs-s390x
-
 workflows:
   go-build-multiarch:
     jobs:
-      - go-build-amd64:
+      - architect/go-build:
           context: architect
-          name: go-build-amd64
+          name: go-build
+          binary: kubectl-gs
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
           filters:
             tags:
               only: /^v.*/
-      - go-build-arm64:
-          context: architect
-          name: go-build-arm64
-          filters:
-            tags:
-              only: /^v.*/
-      - go-build-386:
-          context: architect
-          name: go-build-386
-          filters:
-            tags:
-              only: /^v.*/
-      # Docker image: linux/amd64 + linux/arm64 only. The alpine base image
-      # in gsoci.azurecr.io/giantswarm/alpine does not ship a linux/386
-      # variant, so the legacy inline job's 386 build silently failed every
-      # run (the `tee` pipe always returned 0 and masked the buildx error).
-      # The standalone linux/386 kubectl-gs binary is still produced by
-      # go-build-386 and distributed through GitHub releases / krew.
+
       - architect/push-to-registries:
           context: architect
-          name: push-to-registries-multiarch
-          multiarch: true
+          name: push-to-registries
           platforms: "linux/amd64,linux/arm64"
           force-public: true
           split-china-push: true
           requires:
-            - go-build-amd64
-            - go-build-arm64
-            # - go-build-ppc64le
-            # - go-build-s390x
+            - go-build
           filters:
             branches:
               ignore:
                 - main
             tags:
               only: /^v.*/
-      # Mirror gsoci -> Aliyun via the in-China giantswarm/galaxy-runner on
-      # tag builds only. Replaces the cross-Pacific docker buildx push to
-      # Aliyun that timed out on tag jobs.
+
       - architect/sync-china-registry:
           context: architect
           name: sync-china-registry
           requires:
-            - push-to-registries-multiarch
+            - push-to-registries
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/upload-release-assets:
+          context: architect
+          name: upload-release-assets
+          binary: kubectl-gs
+          requires:
+            - go-build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
       - debug-tag:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+
       - update-krew-index:
           requires:
-            - push-to-registries-multiarch
+            - upload-release-assets
             - debug-tag
           filters:
             branches:

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -14,44 +14,35 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
-    files:
-    - from: ./kubectl-gs-*/*
-      to: .
-    bin: ./kubectl-gs
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-darwin-amd64" .TagName }}
+    bin: kubectl-gs
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-arm64.tar.gz" .TagName }}
-    files:
-    - from: ./kubectl-gs-*/*
-      to: .
-    bin: ./kubectl-gs
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-darwin-arm64" .TagName }}
+    bin: kubectl-gs
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
-    files:
-    - from: ./kubectl-gs-*/*
-      to: .
-    bin: ./kubectl-gs
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-linux-amd64" .TagName }}
+    bin: kubectl-gs
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-arm64.tar.gz" .TagName }}
-    files:
-    - from: ./kubectl-gs-*/*
-      to: .
-    bin: ./kubectl-gs
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-linux-arm64" .TagName }}
+    bin: kubectl-gs
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-windows-amd64.zip" .TagName }}
-    files:
-    - from: ./kubectl-gs-*/*
-      to: .
-    bin: ./kubectl-gs.exe
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-windows-amd64.exe" .TagName }}
+    bin: kubectl-gs.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-windows-arm64.exe" .TagName }}
+    bin: kubectl-gs.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `kubectl-gs-windows-<arch>.exe`.
+- krew manifest updated to reference bare binaries directly instead of tarballs, and extended with `windows/arm64` support.
+
 ## [5.6.4] - 2026-06-01
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 ARG TARGETARCH
 
 COPY --from=binaries /binaries/* /usr/bin/
-COPY ./kubectl-gs-${TARGETARCH} /usr/bin/kubectl-gs
+COPY ./kubectl-gs-linux-${TARGETARCH} /usr/bin/kubectl-gs
 RUN ln -s /usr/bin/kubectl-gs /usr/bin/kgs
 
 ENTRYPOINT ["kubectl-gs"]


### PR DESCRIPTION
## What

- `go-build`: replaces the three custom `go-build-{386,amd64,arm64}` jobs (which used the removed `os:` parameter) with a single `architect/go-build` job covering `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64`. Drops `linux/386` (no consumers).
- `push-to-registries`: replaces the removed `push-to-registries-multiarch` job with `push-to-registries`; keeps `force-public`, `split-china-push`, `platforms: "linux/amd64,linux/arm64"`.
- `upload-release-assets`: new job; uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- `update-krew-index`: now requires `upload-release-assets` instead of `push-to-registries`, ensuring bare binaries are present on the release before krew-release-bot downloads them for SHA computation.
- `.krew.yaml`: updated to reference bare binaries directly (no tarball extraction); adds `windows/arm64`. krew-release-bot resolves URLs and SHAs at release time.
- Bumps architect orb 8.3.0 to 9.1.0.

Same pattern as giantswarm/muster#796.