### PR TITLE
ci: scoped .nancy-ignore for cilium/ebpf and runc CVEs with no upgrade path

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -4,3 +4,8 @@ CVE-2026-42506 until=2026-06-28 # golang.org/x/net@v0.54.0
 CVE-2026-25680 until=2026-06-28 # golang.org/x/net@v0.54.0
 CVE-2026-25681 until=2026-06-28 # golang.org/x/net@v0.54.0
 CVE-2026-39821 until=2026-06-28 # golang.org/x/net@v0.54.0
+
+# Transitive CVEs with no clean upgrade path (kubectl-gs#2024). Scoped, not blanket
+# suppression: re-review by the until date and bump + remove once upstream ships a fix.
+CVE-2026-10722 until=2026-09-30 # github.com/cilium/ebpf BTF integer overflow; latest release v0.21.0 still flagged, no fixed release yet. Transitive only, not compiled into kubectl-gs. Track cilium/ebpf for a fixed release, then bump.
+CVE-2026-41579 until=2026-09-30 # github.com/opencontainers/runc symlink following (GHSA-xjvp-4fhw-gc47); fix is in runc 1.3.6+ but that removes libcontainer/user which github.com/ory/dockertest (latest) imports, so runc cannot move off the flagged release. Transitive test/tooling dep. Track ory/dockertest dropping runc/libcontainer/user, then bump.


### PR DESCRIPTION
## Summary

`ci/circleci: go-build` runs the nancy / Sonatype OSS Index scan in module-graph mode, which flags transitive modules even when they are not compiled in. Two findings have **no clean upgrade path**:

- **CVE-2026-10722** — `github.com/cilium/ebpf` (BTF integer overflow). The latest release `v0.21.0` is still flagged; no fixed release exists yet.
- **CVE-2026-41579** — `github.com/opencontainers/runc` (symlink following, [GHSA-xjvp-4fhw-gc47](https://github.com/opencontainers/runc/security/advisories/GHSA-xjvp-4fhw-gc47)). The fix lands in runc `1.3.6+`, but that release removes `libcontainer/user`, which `github.com/ory/dockertest` (already latest) imports — so runc cannot be moved off the flagged release without breaking the build.

This adds **scoped, commented** `.nancy-ignore` entries with rationale and upstream-tracking notes, plus an `until=2026-09-30` date to force re-review — no blanket suppression. Each entry documents what to bump and remove once upstream ships a fix.

## Test plan

- [ ] `ci/circleci: go-build` passes with the scoped ignores in place.
- [ ] Re-review on/before the `until` date; remove each entry once the upstream fix is available.

Closes #2024

Made with [Cursor](https://cursor.com)