### PR TITLE
chore: replace decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/cmd/gitops/add/automatic-updates/command.go
+++ b/cmd/gitops/add/automatic-updates/command.go
@@ -33,7 +33,7 @@ https://github.com/giantswarm/gitops-template/blob/main/docs/apps/automatic_upda
 	examples = `  # Enable automatic updates for hello-world app
     kubectl gs gitops add automatic-update \
     --app hello-world \
-    --version-repository giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app \
+    --version-repository gsoci.azurecr.io/charts/giantswarm/hello-world \
     --management-cluster demomc \
     --organization demoorg \
     --workload-cluster demowc \


### PR DESCRIPTION
### What does this PR do?

Replaces a reference to the decommissioned `giantswarmpublic.azurecr.io` registry in the `gitops add automatic-update` command's example help text.

`giantswarmpublic.azurecr.io` hosted the Giant Swarm Helm chart catalogs and has been decommissioned. Chart catalogs are now consolidated onto `oci://gsoci.azurecr.io/charts/giantswarm/<chart>`. The demo app's chart is named `hello-world` (not `hello-world-app`) on the new registry, so the `--version-repository` example value is updated to `gsoci.azurecr.io/charts/giantswarm/hello-world`.

### What is the effect of this change to users?

The example in the command help now points at a valid, current registry path.

### What does it look like?

```
--version-repository gsoci.azurecr.io/charts/giantswarm/hello-world
```

### Any background context you can provide?

The `giantswarmpublic.azurecr.io` registry has been decommissioned; catalogs now live under `oci://gsoci.azurecr.io/charts/giantswarm/`.

### What is needed from the reviewers?

Confirm the new example path is correct.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated

### Is this a breaking change?

No. This only changes example help text.
