### PR TITLE
fix(deploy chart): set storageNamespace to targetNamespace for workload clusters

### DIFF
--- a/internal/deploychart/manifest.go
+++ b/internal/deploychart/manifest.go
@@ -124,6 +124,7 @@ func BuildHelmRelease(opts HelmReleaseOptions) *helmv2.HelmRelease {
 				Name: fmt.Sprintf("%s-kubeconfig", opts.ClusterName),
 			},
 		}
+		hr.Spec.StorageNamespace = opts.TargetNamespace
 	}
 
 	if opts.Values != nil {

--- a/internal/deploychart/manifest_test.go
+++ b/internal/deploychart/manifest_test.go
@@ -267,6 +267,7 @@ spec:
     secretRef:
       name: mycluster01-kubeconfig
   releaseName: hello-world-app
+  storageNamespace: hello
   targetNamespace: hello
 `,
 		},
@@ -305,6 +306,7 @@ spec:
     secretRef:
       name: mycluster01-kubeconfig
   releaseName: hello-world-app
+  storageNamespace: hello
   targetNamespace: hello
   values:
     ingress:
@@ -374,6 +376,7 @@ spec:
     secretRef:
       name: mycluster01-kubeconfig
   releaseName: hello-world-app
+  storageNamespace: hello
   targetNamespace: hello
   valuesFrom:
   - kind: ConfigMap


### PR DESCRIPTION
When `kubectl gs deploy chart` targets a workload cluster, the generated HelmRelease had no `spec.storageNamespace`. Flux then defaults storage to the HelmRelease's own namespace (e.g. `org-theo`), which doesn't exist on the workload cluster. Helm fails immediately:

```
Helm install failed: create: failed to create: namespaces "org-theo" not found
```

`spec.storageNamespace` tells Flux where to write Helm release secrets on the **target** cluster. For workload cluster deployments it must match `spec.targetNamespace` (a namespace that `spec.install.createNamespace: true` will ensure exists).

Management cluster deployments are unaffected — they have no `kubeConfig` and Flux correctly defaults storage to the HelmRelease's own namespace.