### PR TITLE
fix: update required flags for template cluster for aks provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Added
 
-- `template cluster`: support `--provider aks` for templating AKS workload clusters via the `cluster-aks` / `release-aks` chart. Reuses `--region`, `--azure-subscription-id`, and `--management-cluster` for the required Azure inputs.
+- `template cluster`: support `--provider aks` for templating AKS workload clusters via the `cluster-aks` / `release-aks` chart. Requires `--region` and `--azure-subscription-id`; `--management-cluster` is optional.
 - `template cluster`: new `--azure-cluster-identity-name` and `--azure-cluster-identity-namespace` flags for both `capz` and `aks`, setting `global.providerSpecific.azureClusterIdentity`. Omitted when unset so the chart's built-in defaults apply.
 
 ### Changed

--- a/cmd/template/cluster/flags/flag.go
+++ b/cmd/template/cluster/flags/flag.go
@@ -395,9 +395,6 @@ func (f *Flag) Validate(cmd *cobra.Command) error {
 			if f.Azure.SubscriptionID == "" {
 				return microerror.Maskf(invalidFlagError, "--%s must not be empty for AKS", flagAzureSubscriptionID)
 			}
-			if f.ManagementCluster == "" {
-				return microerror.Maskf(invalidFlagError, "--%s must not be empty for AKS", flagManagementCluster)
-			}
 		}
 
 		if f.Release == "" {


### PR DESCRIPTION
### What does this PR do?

`--management-cluster` is not required

### What is the effect of this change to users?

### What does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated

### Is this a breaking change?

(Breaking changes are, for example, removal of commands/flags or substantial changes in the meaning of a flag. If yes, please add the `breaking-change` label to the PR.)
