### PR TITLE
fix: publish tar.gz release archives for krew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,49 @@ workflows:
           binary: kubectl-gs
           requires:
             - go-build
+          post-steps:
+            - run:
+                name: Package binaries as krew archives and upload
+                command: |
+                  set -euo pipefail
+
+                  tag="${CIRCLE_TAG:?CIRCLE_TAG must be set}"
+                  shopt -s nullglob
+
+                  archives=()
+                  for binary in kubectl-gs-*-*; do
+                    case "$binary" in
+                      *.bundle | *.tar.gz) continue ;;
+                    esac
+
+                    platform="${binary#kubectl-gs-}"
+                    os="${platform%%-*}"
+                    arch="${platform#*-}"; arch="${arch%.exe}"
+
+                    if [[ "$os" == "windows" ]]; then
+                      inner="kubectl-gs.exe"
+                    else
+                      inner="kubectl-gs"
+                    fi
+
+                    cp "$binary" "$inner"
+                    chmod +x "$inner"
+                    archive="kubectl-gs-${tag}-${os}-${arch}.tar.gz"
+                    tar -czf "$archive" "$inner"
+                    rm -f "$inner"
+                    archives+=( "$archive" )
+                  done
+
+                  if [[ ${#archives[@]} -eq 0 ]]; then
+                    echo "No binaries found to package." >&2
+                    ls -la
+                    exit 1
+                  fi
+
+                  echo "Uploading ${#archives[@]} krew archive(s):"
+                  printf '  %s\n' "${archives[@]}"
+                  gh release upload "$tag" "${archives[@]}" --clobber \
+                    --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
           filters:
             tags:
               only: /^v.*/

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -14,35 +14,35 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-darwin-amd64" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-amd64.tar.gz" .TagName }}
     bin: kubectl-gs
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-darwin-arm64" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-darwin-arm64.tar.gz" .TagName }}
     bin: kubectl-gs
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-linux-amd64" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-amd64.tar.gz" .TagName }}
     bin: kubectl-gs
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-linux-arm64" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-linux-arm64.tar.gz" .TagName }}
     bin: kubectl-gs
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-windows-amd64.exe" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-windows-amd64.tar.gz" .TagName }}
     bin: kubectl-gs.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-windows-arm64.exe" .TagName }}
+    {{addURIAndSha "https://github.com/giantswarm/kubectl-gs/releases/download/{{ .TagName }}/kubectl-gs-{{ .TagName }}-windows-arm64.tar.gz" .TagName }}
     bin: kubectl-gs.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- krew install of the `gs` plugin: releases again publish `.tar.gz` archives (`kubectl-gs-<tag>-<os>-<arch>.tar.gz`) for every platform and the krew manifest references them.
+
 ## [5.7.0] - 2026-07-22
 
 ### Added
@@ -18,11 +22,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `kubectl-gs-windows-<arch>.exe`.
-- krew manifest extended with `windows/arm64` support.
-
-### Fixed
-
-- krew install of the `gs` plugin. Releases again publish `.tar.gz` archives (`kubectl-gs-<tag>-<os>-<arch>.tar.gz`) for every platform and the krew manifest references them; krew cannot unpack the bare binaries the previous release published.
+- krew manifest updated to reference bare binaries directly instead of tarballs, and extended with `windows/arm64` support.
 - (CAPA): Derive the number of VPC chunks from `--az-usage-limit`. This enables small single-AZ VPC layouts (e.g. a `/24` VPC with a `/25` private subnet and a `/26` public subnet).
 
 ## [5.6.4] - 2026-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `kubectl-gs-windows-<arch>.exe`.
-- krew manifest updated to reference bare binaries directly instead of tarballs, and extended with `windows/arm64` support.
+- krew manifest extended with `windows/arm64` support.
+
+### Fixed
+
+- krew install of the `gs` plugin. Releases again publish `.tar.gz` archives (`kubectl-gs-<tag>-<os>-<arch>.tar.gz`) for every platform and the krew manifest references them; krew cannot unpack the bare binaries the previous release published.
 - (CAPA): Derive the number of VPC chunks from `--az-usage-limit`. This enables small single-AZ VPC layouts (e.g. a `/24` VPC with a `/25` private subnet and a `/26` public subnet).
 
 ## [5.6.4] - 2026-06-01


### PR DESCRIPTION
## What

Package each released binary into `kubectl-gs-<tag>-<os>-<arch>.tar.gz` and point the krew manifest at those archives.

## Why

The move to the standard `architect` release pipeline (`go-build` + `upload-release-assets`) publishes **bare binaries** (`kubectl-gs-<os>-<arch>`, plus cosign `.bundle`s). krew cannot install those: it downloads the `uri`, expects an archive, and extracts the file named in `bin:`. With a raw binary it fails during unpack:

```
mime type "application/octet-stream" for archive file is not a supported archive format
```

That is why [krew-index#6109](https://github.com/kubernetes-sigs/krew-index/pull/6109) (v5.7.0) fails its manifest validation. The `architect` orb no longer produces archives, and kubectl-gs is the only consumer that needs them, so the packaging lives here.

## How

- `.circleci/config.yml`: `post-steps` on `upload-release-assets` tars each built binary (inner name `kubectl-gs` / `kubectl-gs.exe`) into a per-platform `.tar.gz` and uploads it to the GitHub release. Runs in the same job, so it reuses the attached workspace, the generated `GITHUB_TOKEN`, and `gh`.
- `.krew.yaml`: manifest URIs point at the `.tar.gz` archives for all six platforms.
- Bare binaries are still published unchanged, so direct `curl` installs and the container image keep working.

Requires a new release (v5.7.1) to take effect; krew-release-bot then opens a fresh krew-index PR and #6109 can be closed.