### PR TITLE
fix: include LICENSE in krew release archives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ workflows:
                     cp "$binary" "$inner"
                     chmod +x "$inner"
                     archive="kubectl-gs-${tag}-${os}-${arch}.tar.gz"
-                    tar -czf "$archive" "$inner"
+                    tar -czf "$archive" "$inner" LICENSE
                     rm -f "$inner"
                     archives+=( "$archive" )
                   done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- krew archives now include the `LICENSE` file, so `validate-krew-manifest` accepts the `gs` plugin release.
+
 ## [5.7.1] - 2026-07-22
 
 ### Fixed


### PR DESCRIPTION
The `gs` krew plugin release PRs against `kubernetes-sigs/krew-index` fail `validate-krew-manifest`:

```
spec.platforms[0] failed to install: LICENSE (or alike) file is not extracted
from the archive as part of installation: could not find license file among [kubectl-gs]
```

krew requires a license file inside every plugin archive. The custom packaging step in `.circleci/config.yml` (`architect/upload-release-assets` post-step) tarred only the binary, so the extracted archive contained just `kubectl-gs`.

Adding `LICENSE` (already checked out at repo root) to each `tar -czf` produces archives krew accepts. Needs a fresh patch release cut so the archives are rebuilt; the existing v5.7.1 assets will not retroactively contain LICENSE.