### PR TITLE
fix: hint at management cluster login for every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Commands that fail because you are not logged into a management cluster now print a hint telling you to run `kubectl gs login`, instead of only a raw client error such as `dial tcp 127.0.0.1:8080: connect: connection refused` or `no matches for kind "AppCatalogEntry"`. The hint is added for every command, not just `template cluster`.
+
 ## [5.7.2] - 2026-07-22
 
 ### Fixed

--- a/cmd/template/cluster/common/common.go
+++ b/cmd/template/cluster/common/common.go
@@ -169,7 +169,9 @@ func GetLatestVersion(ctx context.Context, ctrlClient client.Client, app, catalo
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("failed to get latest version of https://github.com/giantswarm/%s. Did you log into the management cluster so the catalog %s can be accessed? You can follow the instructions at https://docs.giantswarm.io/getting-started/create-workload-cluster/ to successfully create a workload cluster. Either the KUBECONFIG environment variable or default kubectl context should be set correctly and point to your management cluster, not to a workload cluster. Detailed error: %w", app, catalog, microerror.Mask(err))
+		// Advice about logging into a management cluster is added centrally,
+		// see pkg/errorprinter.
+		return "", fmt.Errorf("failed to get the latest version of https://github.com/giantswarm/%s from the %s catalog: %w", app, catalog, microerror.Mask(err))
 	} else if len(catalogEntryList.Items) != 1 {
 		return "", microerror.Maskf(invalidFlagError, "version not specified for %s and latest release couldn't be uniquely determined in %s catalog", app, catalog)
 	}

--- a/pkg/errorprinter/errorprinter.go
+++ b/pkg/errorprinter/errorprinter.go
@@ -45,6 +45,11 @@ func (ep *ErrorPrinter) Format(err error) string {
 		builder.WriteString(ep.formatBody(rows[1]))
 	}
 
+	if h := hint(err); h != "" {
+		builder.WriteString("\n\n")
+		builder.WriteString(h)
+	}
+
 	return builder.String()
 }
 

--- a/pkg/errorprinter/hint.go
+++ b/pkg/errorprinter/hint.go
@@ -1,0 +1,98 @@
+package errorprinter
+
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const notLoggedInHint = `Hint: this looks like you are not logged into a Giant Swarm management cluster.
+Log in using 'kubectl gs login <management-cluster>'. The KUBECONFIG environment
+variable or your current kubectl context must point to a management cluster, not
+to a workload cluster. See https://docs.giantswarm.io/getting-started/management-cluster/`
+
+// hint returns an actionable hint for errors whose cause is that the user is
+// not logged into a management cluster, or has their kubectl context pointed
+// somewhere else. For every other error it returns an empty string, so that
+// unrelated failures are printed unchanged.
+func hint(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if anyInChain(err, isNotLoggedIn) || messageLooksLikeNotLoggedIn(err.Error()) {
+		return notLoggedInHint
+	}
+
+	return ""
+}
+
+// isNotLoggedIn reports whether a single error in the chain identifies a
+// missing or misdirected management cluster connection.
+func isNotLoggedIn(err error) bool {
+	switch {
+	// There is no kubeconfig at all, or no usable current context in it.
+	case clientcmd.IsEmptyConfig(err), clientcmd.IsConfigurationInvalid(err):
+		return true
+
+	// Without a usable kubeconfig, client-go falls back to localhost:8080,
+	// where nothing is listening.
+	case utilnet.IsConnectionRefused(err):
+		return true
+
+	// The Giant Swarm CRDs are unknown to the API server, so this is a
+	// workload cluster or not a Giant Swarm cluster at all.
+	case meta.IsNoMatchError(err):
+		return true
+
+	// The kubeconfig exists but its token is no longer accepted. Note that we
+	// deliberately do not treat 403 the same way: being logged in without the
+	// required permissions is a different problem.
+	case apierrors.IsUnauthorized(err):
+		return true
+	}
+
+	return false
+}
+
+// messageLooksLikeNotLoggedIn is a fallback for the cases above, for error
+// chains where an intermediate wrapper dropped the cause and the typed checks
+// can therefore not see it.
+func messageLooksLikeNotLoggedIn(message string) bool {
+	message = strings.ToLower(message)
+
+	return strings.Contains(message, "connection refused") ||
+		strings.Contains(message, "no matches for kind")
+}
+
+// anyInChain reports whether pred holds for err or any error wrapped by it.
+// We cannot rely on errors.As/errors.Is alone, because some of the predicates
+// used above (the clientcmd ones in particular) type-assert on the error they
+// are given instead of unwrapping it.
+func anyInChain(err error, pred func(error) bool) bool {
+	for err != nil {
+		if pred(err) {
+			return true
+		}
+
+		switch unwrappable := err.(type) {
+		case interface{ Unwrap() error }:
+			err = unwrappable.Unwrap()
+		case interface{ Unwrap() []error }:
+			for _, wrapped := range unwrappable.Unwrap() {
+				if anyInChain(wrapped, pred) {
+					return true
+				}
+			}
+
+			return false
+		default:
+			return false
+		}
+	}
+
+	return false
+}

--- a/pkg/errorprinter/hint_test.go
+++ b/pkg/errorprinter/hint_test.go
@@ -1,0 +1,148 @@
+package errorprinter
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// connectionRefused builds the error chain client-go produces when it falls
+// back to localhost:8080 because no kubeconfig is available.
+func connectionRefused() error {
+	return &url.Error{
+		Op:  "Get",
+		URL: "http://localhost:8080/api",
+		Err: &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: os.NewSyscallError("connect", syscall.ECONNREFUSED),
+		},
+	}
+}
+
+func TestHint(t *testing.T) {
+	testCases := []struct {
+		name        string
+		err         error
+		expectsHint bool
+	}{
+		{
+			name:        "case 0: no error",
+			err:         nil,
+			expectsHint: false,
+		},
+		{
+			name:        "case 1: empty kubeconfig",
+			err:         clientcmd.ErrEmptyConfig,
+			expectsHint: true,
+		},
+		{
+			name:        "case 2: no context chosen",
+			err:         clientcmd.ErrNoContext,
+			expectsHint: true,
+		},
+		{
+			name:        "case 3: connection refused on the localhost fallback",
+			err:         connectionRefused(),
+			expectsHint: true,
+		},
+		{
+			name:        "case 4: connection refused, wrapped by microerror",
+			err:         microerror.Mask(fmt.Errorf("failed to get server groups: %w", connectionRefused())),
+			expectsHint: true,
+		},
+		{
+			name: "case 5: Giant Swarm CRD unknown to the API server",
+			err: &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "application.giantswarm.io", Kind: "AppCatalogEntry"},
+				SearchedVersions: []string{"v1alpha1"},
+			},
+			expectsHint: true,
+		},
+		{
+			name: "case 6: Giant Swarm CRD unknown, wrapped by microerror",
+			err: microerror.Mask(&meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "application.giantswarm.io", Kind: "AppCatalogEntry"},
+				SearchedVersions: []string{"v1alpha1"},
+			}),
+			expectsHint: true,
+		},
+		{
+			name:        "case 7: expired token",
+			err:         apierrors.NewUnauthorized("Unauthorized"),
+			expectsHint: true,
+		},
+		{
+			name:        "case 8: generic error",
+			err:         errors.New("something went wrong"),
+			expectsHint: false,
+		},
+		{
+			name:        "case 9: invalid flag",
+			err:         microerror.Maskf(&microerror.Error{Kind: "invalidFlagError"}, "--name must not be empty"),
+			expectsHint: false,
+		},
+		{
+			name:        "case 10: resource not found on a reachable cluster",
+			err:         apierrors.NewNotFound(schema.GroupResource{Group: "cluster.x-k8s.io", Resource: "clusters"}, "test1234"),
+			expectsHint: false,
+		},
+		{
+			name: "case 11: missing permissions on a reachable cluster",
+			err: apierrors.NewForbidden(schema.GroupResource{Group: "cluster.x-k8s.io", Resource: "clusters"},
+				"test1234", errors.New("not allowed")),
+			expectsHint: false,
+		},
+		{
+			name:        "case 12: connection reset is not a login problem",
+			err:         &url.Error{Op: "Get", URL: "https://api.example.com/api", Err: os.NewSyscallError("read", syscall.ECONNRESET)},
+			expectsHint: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hint(tc.err) != ""
+			if got != tc.expectsHint {
+				t.Fatalf("hint(%v) returned a hint == %t, expected %t", tc.err, got, tc.expectsHint)
+			}
+		})
+	}
+}
+
+// TestHint_aggregate makes sure we also look into aggregated errors, which is
+// how clientcmd reports an invalid kubeconfig.
+func TestHint_aggregate(t *testing.T) {
+	err := fmt.Errorf("outer: %w", errors.Join(errors.New("unrelated"), clientcmd.ErrEmptyConfig))
+
+	if hint(err) == "" {
+		t.Fatalf("expected a hint for an aggregated error containing %v", clientcmd.ErrEmptyConfig)
+	}
+}
+
+// TestFormat_withHint makes sure the hint ends up in the printed output,
+// separated from the error message itself.
+func TestFormat_withHint(t *testing.T) {
+	ep := New(Config{DisableColors: true})
+
+	message := ep.Format(microerror.Mask(fmt.Errorf("failed to get server groups: %w", connectionRefused())))
+
+	expected := "Hint: this looks like you are not logged into a Giant Swarm management cluster."
+	if !strings.Contains(message, expected) {
+		t.Fatalf("expected formatted output to contain %q, got:\n%s", expected, message)
+	}
+	if !strings.Contains(message, "get server groups") {
+		t.Fatalf("expected formatted output to keep the original message, got:\n%s", message)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/2881.

### Why

`kubectl gs` commands that need a management cluster fail with a raw client error when you are not logged into one. Only `template cluster` explained what to do — and only on the code path that resolves the latest chart version:

```
$ KUBECONFIG=/empty kubectl gs get clusters
Error: Failed to get server groups: Get "http://localhost:8080/api": dial tcp 127.0.0.1:8080: connect: connection refused
```

The same happens when the current kubectl context points at a **workload** cluster, which is the case roadmap#2881 originally reported:

```
$ kubectl gs get clusters          # context = a WC
Error: Unable to retrieve the complete list of server APIs: cluster.x-k8s.io/v1beta2: no matches for cluster.x-k8s.io/v1beta2, Resource=
```

### What

The advice now lives in `pkg/errorprinter`, which `main.go` already uses to format every error before exit, so every command benefits instead of just one:

```
Error: Failed to get server groups: Get "http://localhost:8080/api": dial tcp 127.0.0.1:8080: connect: connection refused

Hint: this looks like you are not logged into a Giant Swarm management cluster.
Log in using 'kubectl gs login <management-cluster>'. The KUBECONFIG environment
variable or your current kubectl context must point to a management cluster, not
to a workload cluster. See https://docs.giantswarm.io/getting-started/management-cluster/
```

Detection (`pkg/errorprinter/hint.go`) is deliberately conservative and type-based — an empty or invalid kubeconfig, connection refused on client-go's `localhost:8080` fallback, an unknown Giant Swarm CRD (`meta.IsNoMatchError`), or a 401. It walks the whole wrap chain, because some of those predicates type-assert rather than unwrap, and `microerror.Mask` sits in between.

Explicitly **not** hinted: flag validation errors, not-found, 403 (logged in but lacking permissions is a different problem), and connection timeouts.

The bespoke message in `cmd/template/cluster/common/common.go` is reduced to a plain wrap, so there is one wording to maintain.

### Testing

- `go test ./...` passes; the existing `pkg/errorprinter` golden files are byte-identical, which confirms detection does not fire on generic errors.
- New `pkg/errorprinter/hint_test.go` covers each signal plus the negative cases above.
- Manually, with an empty kubeconfig: `get clusters`, `get releases`, `get nodepools`, `get organizations` and `template cluster --provider eks` all show the hint; `template cluster --provider capa --release 35.0.0 --region eu-west-1` still templates successfully offline with no hint.
- Manually, with the current context on a real workload cluster: `get clusters` shows the hint (the roadmap#2881 case).
- Against an unreachable MC (i/o timeout): no hint, as intended.
