### PR TITLE
fix: template cluster: fall back to cluster-<provider> chart for unpublished releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
+- `template cluster`: releases without a published `release-<provider>` chart, such as a hand-crafted
+  Release CR used for testing (e.g. `35.0.0-andreas`), no longer produce an App CR pointing to a chart
+  which does not exist. The `cluster-<provider>` chart is used instead, which resolves the Release CR in
+  the management cluster.
+  ([#4347](https://github.com/giantswarm/roadmap/issues/4347))
+- `template cluster`: `--cluster-version` is no longer ignored for CAPA, CAPZ and AKS. Setting it templates
+  the given `cluster-<provider>` app version instead of the `release-<provider>` chart, which allows testing
+  a provider chart build together with a release.
+
 - Commands that fail because you are not logged into a management cluster now print a hint telling you to run `kubectl gs login`, instead of only a raw client error such as `dial tcp 127.0.0.1:8080: connect: connection refused` or `no matches for kind "AppCatalogEntry"`. The hint is added for every command, not just `template cluster`.
 
 ## [5.7.2] - 2026-07-22

--- a/cmd/template/cluster/common/common.go
+++ b/cmd/template/cluster/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -142,6 +143,10 @@ type ClusterConfig struct {
 	BastionReplicas          int
 	ControlPlaneInstanceType string
 
+	// UseReleaseChart tells whether the cluster App CR should point to the
+	// release-<provider> chart instead of the cluster-<provider> chart.
+	UseReleaseChart bool
+
 	App           AppConfig
 	AWS           AWSConfig
 	Azure         AzureConfig
@@ -212,4 +217,33 @@ func IsReleaseVersion(version string) bool {
 	}
 
 	return v.Major() >= ReleaseVersionMajorThreshold
+}
+
+// ReleaseChartAvailable checks whether the given version of a
+// release-<provider> chart is available in the catalog.
+//
+// Release CRs created by hand for testing purposes (e.g. `35.0.0-andreas`,
+// copied from a released one) have no matching release-<provider> chart, so
+// pulling that chart would fail. In such cases the cluster-<provider> chart
+// has to be used instead, which resolves the Release CR at runtime.
+func ReleaseChartAvailable(ctx context.Context, ctrlClient client.Client, app, catalog, version string) (bool, error) {
+	var catalogEntryList applicationv1alpha1.AppCatalogEntryList
+	err := ctrlClient.List(ctx, &catalogEntryList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app.kubernetes.io/name":            app,
+			"application.giantswarm.io/catalog": catalog,
+		}),
+		Namespace: "giantswarm",
+	})
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	for _, entry := range catalogEntryList.Items {
+		if strings.TrimPrefix(entry.Spec.Version, "v") == strings.TrimPrefix(version, "v") {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/cmd/template/cluster/flags/flag.go
+++ b/cmd/template/cluster/flags/flag.go
@@ -226,7 +226,7 @@ func (f *Flag) Init(cmd *cobra.Command) {
 
 	// App-based clusters only.
 	cmd.Flags().StringVar(&f.App.ClusterCatalog, flagClusterCatalog, "cluster", "Catalog for cluster app.")
-	cmd.Flags().StringVar(&f.App.ClusterVersion, flagClusterVersion, "", "Version of cluster to be created.")
+	cmd.Flags().StringVar(&f.App.ClusterVersion, flagClusterVersion, "", "Version of the cluster-<provider> app to be created. Setting this uses the cluster-<provider> chart instead of the release-<provider> chart.")
 	cmd.Flags().StringVar(&f.App.DefaultAppsCatalog, flagDefaultAppsCatalog, "cluster", "Catalog for cluster default apps app.")
 	cmd.Flags().StringVar(&f.App.DefaultAppsVersion, flagDefaultAppsVersion, "", "Version of default apps to be created.")
 

--- a/cmd/template/cluster/provider/aks.go
+++ b/cmd/template/cluster/provider/aks.go
@@ -40,7 +40,7 @@ func templateClusterAKS(ctx context.Context, k8sClient k8sclient.Interface, outp
 
 		// For release versions, the release version is baked into the chart,
 		// so we don't need to include it in the user config.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			flagValues.Global.Release = nil
 		}
 
@@ -79,7 +79,7 @@ func templateClusterAKS(ctx context.Context, k8sClient k8sclient.Interface, outp
 		// These charts have the release version baked into values.yaml.
 		// For older chart versions, use cluster-<provider> and let the webhook handle version.
 		chartName := ClusterAKSRepoName
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			chartName = ReleaseAKSRepoName
 		}
 
@@ -93,9 +93,12 @@ func templateClusterAKS(ctx context.Context, k8sClient k8sclient.Interface, outp
 			ExtraLabels:             map[string]string{},
 		}
 		// Set version for release charts where the chart version equals the release version.
-		// For cluster-<provider> charts, the webhook handles version mutation.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		// For cluster-<provider> charts, only an explicitly requested version is set,
+		// otherwise the webhook handles version mutation.
+		if config.UseReleaseChart {
 			clusterAppConfig.Version = config.ReleaseVersion
+		} else {
+			clusterAppConfig.Version = config.App.ClusterVersion
 		}
 		for k, v := range config.Labels {
 			clusterAppConfig.ExtraLabels[k] = v

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -71,7 +71,7 @@ func templateClusterCAPA(ctx context.Context, k8sClient k8sclient.Interface, out
 
 		// For release versions, the release version is baked into the chart,
 		// so we don't need to include it in the user config.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			flagValues.Global.Release = nil
 		}
 
@@ -287,7 +287,7 @@ func templateClusterCAPA(ctx context.Context, k8sClient k8sclient.Interface, out
 		// These charts have the release version baked into values.yaml.
 		// For older chart versions, use cluster-<provider> and let the webhook handle version.
 		chartName := ClusterAWSRepoName
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			chartName = ReleaseAWSRepoName
 		}
 
@@ -301,9 +301,12 @@ func templateClusterCAPA(ctx context.Context, k8sClient k8sclient.Interface, out
 			ExtraLabels:             map[string]string{},
 		}
 		// Set version for release charts where the chart version equals the release version.
-		// For cluster-<provider> charts, the webhook handles version mutation.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		// For cluster-<provider> charts, only an explicitly requested version is set,
+		// otherwise the webhook handles version mutation.
+		if config.UseReleaseChart {
 			clusterAppConfig.Version = config.ReleaseVersion
+		} else {
+			clusterAppConfig.Version = config.App.ClusterVersion
 		}
 		for k, v := range config.Labels {
 			clusterAppConfig.ExtraLabels[k] = v

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -40,7 +40,7 @@ func templateClusterCAPZ(ctx context.Context, k8sClient k8sclient.Interface, out
 
 		// For release versions, the release version is baked into the chart,
 		// so we don't need to include it in the user config.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			flagValues.Global.Release = nil
 		}
 
@@ -79,7 +79,7 @@ func templateClusterCAPZ(ctx context.Context, k8sClient k8sclient.Interface, out
 		// These charts have the release version baked into values.yaml.
 		// For older chart versions, use cluster-<provider> and let the webhook handle version.
 		chartName := ClusterAzureRepoName
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		if config.UseReleaseChart {
 			chartName = ReleaseAzureRepoName
 		}
 
@@ -93,9 +93,12 @@ func templateClusterCAPZ(ctx context.Context, k8sClient k8sclient.Interface, out
 			ExtraLabels:             map[string]string{},
 		}
 		// Set version for release charts where the chart version equals the release version.
-		// For cluster-<provider> charts, the webhook handles version mutation.
-		if common.IsReleaseVersion(config.ReleaseVersion) {
+		// For cluster-<provider> charts, only an explicitly requested version is set,
+		// otherwise the webhook handles version mutation.
+		if config.UseReleaseChart {
 			clusterAppConfig.Version = config.ReleaseVersion
+		} else {
+			clusterAppConfig.Version = config.App.ClusterVersion
 		}
 		for k, v := range config.Labels {
 			clusterAppConfig.ExtraLabels[k] = v

--- a/cmd/template/cluster/runner.go
+++ b/cmd/template/cluster/runner.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -73,6 +74,8 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 		return microerror.Mask(err)
 	}
 
+	config.UseReleaseChart = r.useReleaseChart(ctx, client, config)
+
 	switch r.flag.Provider {
 	case key.ProviderCAPA:
 		err = provider.WriteCAPATemplate(ctx, client, output, config)
@@ -109,6 +112,79 @@ func (r *runner) run(ctx context.Context, client k8sclient.Interface) error {
 	}
 
 	return nil
+}
+
+// useReleaseChart tells whether the cluster App CR should point to the
+// release-<provider> chart (the flow used since release v35) or to the
+// cluster-<provider> chart.
+//
+// The release-<provider> chart has the release version baked in, so it only
+// works for releases which are actually published as a chart. Developers
+// commonly create a Release CR by hand to test a change (e.g. a copy of
+// `aws-35.0.0` named `aws-35.0.0-andreas`). For those, no release-<provider>
+// chart exists and we have to fall back to the cluster-<provider> chart, which
+// resolves the Release CR at runtime.
+func (r *runner) useReleaseChart(ctx context.Context, client k8sclient.Interface, config common.ClusterConfig) bool {
+	if !common.IsReleaseVersion(config.ReleaseVersion) {
+		return false
+	}
+
+	clusterChart, releaseChart := providerChartNames(r.flag.Provider)
+	if releaseChart == "" {
+		return false
+	}
+
+	// An explicitly requested cluster-<provider> chart version is a clear
+	// opt-in to the cluster-<provider> chart, as used for testing.
+	if config.App.ClusterVersion != "" {
+		return false
+	}
+
+	available, err := common.ReleaseChartAvailable(ctx, client.CtrlClient(), releaseChart, config.App.ClusterCatalog, config.ReleaseVersion)
+	if err != nil {
+		// We cannot tell, so we stick to the default flow for releases.
+		r.warnf("Warning: could not check whether the %s chart exists in the %s catalog: %s\n", releaseChart, config.App.ClusterCatalog, err)
+		return true
+	}
+
+	if !available {
+		r.warnf(
+			"Warning: no %s chart with version %s found in the %s catalog, using the %s chart instead. Make sure the Release CR for %s exists in the management cluster.\n",
+			releaseChart, config.ReleaseVersion, config.App.ClusterCatalog, clusterChart, config.ReleaseVersion,
+		)
+		return false
+	}
+
+	return true
+}
+
+func (r *runner) warnf(format string, a ...interface{}) {
+	if r.stderr == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintf(r.stderr, format, a...)
+}
+
+// providerChartNames returns the names of the cluster-<provider> and
+// release-<provider> charts for the given provider.
+func providerChartNames(providerName string) (clusterChart string, releaseChart string) {
+	switch providerName {
+	case key.ProviderCAPA:
+		return provider.ClusterAWSRepoName, provider.ReleaseAWSRepoName
+	case key.ProviderCAPZ:
+		return provider.ClusterAzureRepoName, provider.ReleaseAzureRepoName
+	case key.ProviderAKS:
+		return provider.ClusterAKSRepoName, provider.ReleaseAKSRepoName
+	case key.ProviderEKS:
+		return provider.ClusterEKSRepoName, provider.ReleaseEKSRepoName
+	case key.ProviderVSphere:
+		return provider.ClusterVsphereRepoName, provider.ReleaseVsphereRepoName
+	case key.ProviderCloudDirector:
+		return provider.ClusterCloudDirectorRepoName, provider.ReleaseCloudDirectorRepoName
+	default:
+		return "", ""
+	}
 }
 
 func (r *runner) getClusterConfig() (common.ClusterConfig, error) {

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	goflag "flag"
+	"fmt"
 	"strings"
 	"testing"
 
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/micrologger"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	//nolint:staticcheck
@@ -45,6 +49,15 @@ func Test_run(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	// Catalog entries for the release-<provider> charts which are published
+	// for release v35.0.0. Release versions without such an entry, e.g. a
+	// hand-crafted Release CR used for testing, must fall back to the
+	// cluster-<provider> chart.
+	releaseCatalogEntries := []runtime.Object{
+		newAppCatalogEntry("cluster", "release-aws", "35.0.0"),
+		newAppCatalogEntry("cluster", "release-aks", "35.0.0"),
 	}
 
 	testCases := []struct {
@@ -444,6 +457,73 @@ func Test_run(t *testing.T) {
 			expectedGoldenFile: "run_template_cluster_capa_9.golden",
 		},
 		{
+			name: "case 13: template cluster capa with a release version which has no release chart",
+			flags: &flags.Flag{
+				Name:                     "test13",
+				Provider:                 "capa",
+				Description:              "cluster using a hand-crafted release for testing",
+				Release:                  "35.0.0-andreas",
+				Region:                   "the-region",
+				Organization:             "test",
+				ControlPlaneInstanceType: "control-plane-instance-type",
+				App: common.AppConfig{
+					ClusterCatalog: "cluster",
+				},
+				AWS: common.AWSConfig{
+					MachinePool: common.AWSMachinePoolConfig{
+						Name:             "worker1",
+						AZs:              []string{"eu-west-1a", "eu-west-1b"},
+						InstanceType:     "big-one",
+						MaxSize:          5,
+						MinSize:          2,
+						RootVolumeSizeGB: 200,
+						CustomNodeLabels: []string{"label=value"},
+					},
+					AWSClusterRoleIdentityName: "default",
+					NetworkVPCCIDR:             "10.123.0.0/16",
+					PublicSubnetMask:           20,
+					PrivateSubnetMask:          18,
+					NetworkAZUsageLimit:        3,
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_capa_11.golden",
+		},
+		{
+			name: "case 14: template cluster capa with release version and explicit cluster chart version",
+			flags: &flags.Flag{
+				Name:                     "test14",
+				Provider:                 "capa",
+				Description:              "cluster testing a cluster-aws dev build",
+				Release:                  "35.0.0",
+				Region:                   "the-region",
+				Organization:             "test",
+				ControlPlaneInstanceType: "control-plane-instance-type",
+				App: common.AppConfig{
+					ClusterCatalog: "cluster",
+					ClusterVersion: "9.0.1-dev.private-karpenter.2026-08-20.16-33-07.h62652f9",
+				},
+				AWS: common.AWSConfig{
+					MachinePool: common.AWSMachinePoolConfig{
+						Name:             "worker1",
+						AZs:              []string{"eu-west-1a", "eu-west-1b"},
+						InstanceType:     "big-one",
+						MaxSize:          5,
+						MinSize:          2,
+						RootVolumeSizeGB: 200,
+						CustomNodeLabels: []string{"label=value"},
+					},
+					AWSClusterRoleIdentityName: "default",
+					NetworkVPCCIDR:             "10.123.0.0/16",
+					PublicSubnetMask:           20,
+					PrivateSubnetMask:          18,
+					NetworkAZUsageLimit:        3,
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_capa_12.golden",
+		},
+		{
 			name: "case 11: template cluster capa with small VPC for single AZ",
 			flags: &flags.Flag{
 				Name:                     "test11",
@@ -537,7 +617,7 @@ func Test_run(t *testing.T) {
 				stdout: out,
 			}
 
-			k8sClient := kubeclient.FakeK8sClient()
+			k8sClient := kubeclient.FakeK8sClient(releaseCatalogEntries...)
 			if tc.flags.Provider == "capa" {
 				err = k8sClient.CtrlClient().Create(ctx, capaManagementCluster.DeepCopy())
 				if err != nil {
@@ -575,6 +655,105 @@ func Test_run(t *testing.T) {
 			diff := cmp.Diff(string(expectedResult), out.String())
 			if diff != "" {
 				t.Fatalf("no difference from golden file %s expected, got:\n %s", tc.expectedGoldenFile, diff)
+			}
+		})
+	}
+}
+
+func newAppCatalogEntry(catalog, app, version string) *applicationv1alpha1.AppCatalogEntry {
+	return &applicationv1alpha1.AppCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", catalog, app, version),
+			Namespace: "giantswarm",
+			Labels: map[string]string{
+				"app.kubernetes.io/name":            app,
+				"application.giantswarm.io/catalog": catalog,
+			},
+		},
+		Spec: applicationv1alpha1.AppCatalogEntrySpec{
+			AppName: app,
+			Version: version,
+		},
+	}
+}
+
+func Test_useReleaseChart(t *testing.T) {
+	testCases := []struct {
+		name           string
+		provider       string
+		release        string
+		clusterVersion string
+		catalogEntries []runtime.Object
+		expected       bool
+		expectedWarn   string
+	}{
+		{
+			name:           "case 0: legacy cluster chart version",
+			provider:       "capa",
+			release:        "25.0.0",
+			catalogEntries: []runtime.Object{newAppCatalogEntry("cluster", "release-aws", "35.0.0")},
+			expected:       false,
+		},
+		{
+			name:           "case 1: published release version",
+			provider:       "capa",
+			release:        "35.0.0",
+			catalogEntries: []runtime.Object{newAppCatalogEntry("cluster", "release-aws", "35.0.0")},
+			expected:       true,
+		},
+		{
+			name:           "case 2: release version without release chart falls back",
+			provider:       "capa",
+			release:        "35.0.0-andreas",
+			catalogEntries: []runtime.Object{newAppCatalogEntry("cluster", "release-aws", "35.0.0")},
+			expected:       false,
+			expectedWarn:   "no release-aws chart with version 35.0.0-andreas found",
+		},
+		{
+			name:           "case 3: explicit cluster chart version wins",
+			provider:       "capa",
+			release:        "35.0.0",
+			clusterVersion: "9.0.1-dev.private-karpenter.2026-08-20.16-33-07.h62652f9",
+			catalogEntries: []runtime.Object{newAppCatalogEntry("cluster", "release-aws", "35.0.0")},
+			expected:       false,
+		},
+		{
+			name:           "case 4: release chart of another provider does not count",
+			provider:       "capz",
+			release:        "35.0.0",
+			catalogEntries: []runtime.Object{newAppCatalogEntry("cluster", "release-aws", "35.0.0")},
+			expected:       false,
+			expectedWarn:   "no release-azure chart with version 35.0.0 found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			stderr := new(bytes.Buffer)
+
+			r := &runner{
+				flag:   &flags.Flag{Provider: tc.provider},
+				stderr: stderr,
+			}
+			config := common.ClusterConfig{
+				ReleaseVersion: tc.release,
+				App: common.AppConfig{
+					ClusterCatalog: "cluster",
+					ClusterVersion: tc.clusterVersion,
+				},
+			}
+
+			result := r.useReleaseChart(ctx, kubeclient.FakeK8sClient(tc.catalogEntries...), config)
+			if result != tc.expected {
+				t.Fatalf("useReleaseChart() = %v, want %v", result, tc.expected)
+			}
+
+			if tc.expectedWarn == "" && stderr.Len() > 0 {
+				t.Fatalf("unexpected warning: %s", stderr.String())
+			}
+			if tc.expectedWarn != "" && !strings.Contains(stderr.String(), tc.expectedWarn) {
+				t.Fatalf("expected warning containing %q, got %q", tc.expectedWarn, stderr.String())
 			}
 		})
 	}

--- a/cmd/template/cluster/testdata/run_template_cluster_capa.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa.golden
@@ -84,4 +84,4 @@ spec:
     configMap:
       name: test1-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_10.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_10.golden
@@ -75,4 +75,4 @@ spec:
     configMap:
       name: test11-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_11.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_11.golden
@@ -4,34 +4,32 @@ data:
   values: |
     global:
       connectivity:
-        availabilityZoneUsageLimit: 2
+        availabilityZoneUsageLimit: 3
         network:
           vpcCidr: 10.123.0.0/16
-        proxy:
-          enabled: true
-          httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-          httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-          noProxy: test-domain.com
         subnets:
         - cidrBlocks:
           - availabilityZone: a
-            cidr: 10.123.0.0/18
-          - availabilityZone: b
             cidr: 10.123.64.0/18
+          - availabilityZone: b
+            cidr: 10.123.128.0/18
+          - availabilityZone: c
+            cidr: 10.123.192.0/18
           isPublic: false
-        topology:
-          mode: GiantSwarmManaged
-        vpcMode: private
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.0.0/20
+          - availabilityZone: b
+            cidr: 10.123.16.0/20
+          - availabilityZone: c
+            cidr: 10.123.32.0/20
+          isPublic: true
+        topology: {}
       controlPlane:
-        apiMode: private
         instanceType: control-plane-instance-type
-        loadBalancerIngressAllowCidrBlocks:
-        - 1.2.3.4/32
-        - 5.6.7.8/32
-        - 9.10.11.12/32
       metadata:
-        description: just a test cluster
-        name: test1
+        description: cluster using a hand-crafted release for testing
+        name: test13
         organization: test
         preventDeletion: false
       nodePools:
@@ -49,12 +47,12 @@ data:
         awsClusterRoleIdentityName: default
         region: the-region
       release:
-        version: 25.0.0
+        version: 35.0.0-andreas
 kind: ConfigMap
 metadata:
   labels:
-    giantswarm.io/cluster: test1
-  name: test1-userconfig
+    giantswarm.io/cluster: test13
+  name: test13-userconfig
   namespace: org-test
 ---
 apiVersion: application.giantswarm.io/v1alpha1
@@ -62,10 +60,10 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
-  name: test1
+  name: test13
   namespace: org-test
 spec:
-  catalog: the-catalog
+  catalog: cluster
   config:
     configMap:
       name: ""
@@ -84,6 +82,6 @@ spec:
   namespace: org-test
   userConfig:
     configMap:
-      name: test1-userconfig
+      name: test13-userconfig
       namespace: org-test
-  version: 1.0.0
+  version: ""

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_12.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_12.golden
@@ -4,34 +4,32 @@ data:
   values: |
     global:
       connectivity:
-        availabilityZoneUsageLimit: 2
+        availabilityZoneUsageLimit: 3
         network:
           vpcCidr: 10.123.0.0/16
-        proxy:
-          enabled: true
-          httpProxy: http://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-          httpsProxy: https://internal-a1c90e5331e124481a14fb7ad80ae8eb-1778512673.eu-west-2.elb.amazonaws.com:4000
-          noProxy: test-domain.com
         subnets:
         - cidrBlocks:
           - availabilityZone: a
-            cidr: 10.123.0.0/18
-          - availabilityZone: b
             cidr: 10.123.64.0/18
+          - availabilityZone: b
+            cidr: 10.123.128.0/18
+          - availabilityZone: c
+            cidr: 10.123.192.0/18
           isPublic: false
-        topology:
-          mode: GiantSwarmManaged
-        vpcMode: private
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.0.0/20
+          - availabilityZone: b
+            cidr: 10.123.16.0/20
+          - availabilityZone: c
+            cidr: 10.123.32.0/20
+          isPublic: true
+        topology: {}
       controlPlane:
-        apiMode: private
         instanceType: control-plane-instance-type
-        loadBalancerIngressAllowCidrBlocks:
-        - 1.2.3.4/32
-        - 5.6.7.8/32
-        - 9.10.11.12/32
       metadata:
-        description: just a test cluster
-        name: test1
+        description: cluster testing a cluster-aws dev build
+        name: test14
         organization: test
         preventDeletion: false
       nodePools:
@@ -49,12 +47,12 @@ data:
         awsClusterRoleIdentityName: default
         region: the-region
       release:
-        version: 25.0.0
+        version: 35.0.0
 kind: ConfigMap
 metadata:
   labels:
-    giantswarm.io/cluster: test1
-  name: test1-userconfig
+    giantswarm.io/cluster: test14
+  name: test14-userconfig
   namespace: org-test
 ---
 apiVersion: application.giantswarm.io/v1alpha1
@@ -62,10 +60,10 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
-  name: test1
+  name: test14
   namespace: org-test
 spec:
-  catalog: the-catalog
+  catalog: cluster
   config:
     configMap:
       name: ""
@@ -84,6 +82,6 @@ spec:
   namespace: org-test
   userConfig:
     configMap:
-      name: test1-userconfig
+      name: test14-userconfig
       namespace: org-test
-  version: 1.0.0
+  version: 9.0.1-dev.private-karpenter.2026-08-20.16-33-07.h62652f9

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_3.golden
@@ -89,4 +89,4 @@ spec:
     configMap:
       name: test1-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_6.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_6.golden
@@ -80,4 +80,4 @@ spec:
     configMap:
       name: test6-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_7.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_7.golden
@@ -84,4 +84,4 @@ spec:
     configMap:
       name: test7-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_8.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_8.golden
@@ -76,4 +76,4 @@ spec:
     configMap:
       name: test8-userconfig
       namespace: org-test
-  version: ""
+  version: 1.0.0

--- a/cmd/template/cluster/testdata/run_template_cluster_capz.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capz.golden
@@ -54,4 +54,4 @@ spec:
     configMap:
       name: test1-userconfig
       namespace: org-test
-  version: ""
+  version: 0.17.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4347

Since v35 the cluster App CR points to the release-<provider> chart, which only exists for published releases. A hand-crafted Release CR for testing (e.g. `35.0.0-andreas`) therefore produced an App CR referencing a chart that cannot be pulled.

kubectl-gs now checks whether the release-<provider> chart version exists in the catalog and uses the cluster-<provider> chart otherwise, keeping `global.release.version` in the values. `--cluster-version` is also honoured for CAPA/CAPZ/AKS again, to test a provider chart build together with a release.
