### PR TITLE
fix: send the version as TelemetryDeck.AppInfo.version so the dashboard's App Versions insight shows kubectl-gs versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Usage telemetry: the version is also sent as `TelemetryDeck.AppInfo.version`, the parameter the TelemetryDeck dashboard's standard "App Versions" insight reads (it was only in the payload key `appVersion`, so that chart stayed empty). telemetrydeck-go v0.2.0.
+
 ## [5.8.0] - 2026-08-25
 
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,11 @@ func New(config Config) (*cobra.Command, error) {
 				return
 			}
 
-			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID)
+			// WithAppVersion sends the version as TelemetryDeck.AppInfo.version,
+			// the parameter the dashboard's standard "App Versions" insight
+			// reads; the payload's appVersion below is what the usage reports
+			// query.
+			tdClient, err := telemetrydeck.NewClient(telemetrydeckAppID, telemetrydeck.WithAppVersion(project.Version()))
 			if err != nil {
 				log.Printf("error creating telemetrydeck client: %s", err)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/giantswarm/micrologger v1.1.2
 	github.com/giantswarm/organization-operator v1.6.4
 	github.com/giantswarm/releases/sdk v0.13.0
-	github.com/giantswarm/telemetrydeck-go v0.1.26
+	github.com/giantswarm/telemetrydeck-go v0.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/giantswarm/organization-operator v1.6.4 h1:t0G0hoB7TfeGzRnr58NIwO6LAm
 github.com/giantswarm/organization-operator v1.6.4/go.mod h1:Rw9gG/ReI5YfvoC85F9H5wH2aWguUR7JY/NfTjZC2Jc=
 github.com/giantswarm/releases/sdk v0.13.0 h1:xEAO+rI820X/XTeMDF2IowmBKEbHQ0PS5LkpDAMRmmY=
 github.com/giantswarm/releases/sdk v0.13.0/go.mod h1:YBRAKlJhZkt3hIxOIuQN5CD7A67it67s7GjGaE1yedU=
-github.com/giantswarm/telemetrydeck-go v0.1.26 h1:CX8Df6SMhbfbCetc/biRrXf4YHgZUmC2LyJyULH92EA=
-github.com/giantswarm/telemetrydeck-go v0.1.26/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.2.0 h1:Ojw0XncmOEQyM68TK+4T9IYnU6xmJMFM/vr3oS8eb+I=
+github.com/giantswarm/telemetrydeck-go v0.2.0/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=


### PR DESCRIPTION
## Problem

The TelemetryDeck dashboard's Overview "App Versions" insight is empty for kubectl-gs, although the app shows 9,033 events and 1,848 users in the last 30 days. The insight breaks down by the reserved parameter `TelemetryDeck.AppInfo.version`, which the official TelemetryDeck SDKs set on every signal; kubectl-gs sends its version only in the payload key `appVersion`, which that insight does not read.

## Solution

telemetrydeck-go v0.2.0 ([giantswarm/telemetrydeck-go#121](https://github.com/giantswarm/telemetrydeck-go/pull/121)) adds `WithAppVersion`, which sends `TelemetryDeck.AppInfo.version` with every signal, and reports the real library version in `TelemetryDeck.SDK.nameAndVersion` instead of the constant `0.0.1`. This PR bumps the library and passes `project.Version()`. The payload's `appVersion` stays untouched, so the usage-reporting queries keep working. CHANGELOG entry under Unreleased.

## Verification

- `go build ./... && go vet ./cmd/` green.
- The same change in agentlab ([giantswarm/agentlab#99](https://github.com/giantswarm/agentlab/pull/99)): with Test Mode on in the dashboard, a signal carrying `TelemetryDeck.AppInfo.version` is the only one the App Versions chart shows; signals with the legacy key alone stay invisible to it.
- Historical signals keep only `appVersion`; the standard chart shows versions from the release that includes this change on.

Opened by Team Bumblebee (owner of telemetrydeck-go); for Team Honeybadger to review and merge with the next kubectl-gs release.