### PR TITLE
fix: render --service-priority as global.metadata.servicePriority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - `template cluster`: `--service-priority` takes effect again. The flag was accepted and validated
   but its value never reached the rendered manifests, because its only consumers were the vintage
   AWS/Azure providers removed in v5.0.0. It is now rendered as `global.metadata.servicePriority`
-  for every provider. Clusters templated without the flag are unaffected, since the flag default
-  and the chart default are both `highest`.
+  for every provider. Because the flag defaults to `highest`, templated manifests now always
+  carry `global.metadata.servicePriority`; this is semantically a no-op against the chart
+  default of `highest`, but re-templated clusters will show the added key in a GitOps diff.
 
 - Usage telemetry: the version is also sent as `TelemetryDeck.AppInfo.version`, the parameter the TelemetryDeck dashboard's standard "App Versions" insight reads (it was only in the payload key `appVersion`, so that chart stayed empty). telemetrydeck-go v0.2.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
+- `template cluster`: `--service-priority` takes effect again. The flag was accepted and validated
+  but its value never reached the rendered manifests, because its only consumers were the vintage
+  AWS/Azure providers removed in v5.0.0. It is now rendered as `global.metadata.servicePriority`
+  for every provider. Clusters templated without the flag are unaffected, since the flag default
+  and the chart default are both `highest`.
+
 - Usage telemetry: the version is also sent as `TelemetryDeck.AppInfo.version`, the parameter the TelemetryDeck dashboard's standard "App Versions" insight reads (it was only in the payload key `appVersion`, so that chart stayed empty). telemetrydeck-go v0.2.0.
 
 ## [5.8.0] - 2026-08-25

--- a/cmd/template/cluster/provider/aks.go
+++ b/cmd/template/cluster/provider/aks.go
@@ -146,6 +146,7 @@ func BuildAKSClusterConfig(config common.ClusterConfig) aks.ClusterConfig {
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			ControlPlane: &aks.ControlPlane{
 				SKU: &aks.SKU{

--- a/cmd/template/cluster/provider/capa.go
+++ b/cmd/template/cluster/provider/capa.go
@@ -350,6 +350,7 @@ func BuildCapaClusterConfig(config common.ClusterConfig) capa.ClusterConfig {
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			NodePools: &map[string]capa.MachinePool{
 				config.AWS.MachinePool.Name: {

--- a/cmd/template/cluster/provider/capv.go
+++ b/cmd/template/cluster/provider/capv.go
@@ -182,6 +182,7 @@ func BuildCapvClusterConfig(config common.ClusterConfig) capv.ClusterConfig {
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			NodePools: map[string]*capv.NodePool{
 				"worker": getNodePool(getMachineTemplate(&config.VSphere.Worker, &config), config.VSphere.Worker.Replicas),

--- a/cmd/template/cluster/provider/capvcd.go
+++ b/cmd/template/cluster/provider/capvcd.go
@@ -163,6 +163,7 @@ func BuildCapvcdClusterConfig(config common.ClusterConfig) capvcd.ClusterConfig 
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			NodePools: map[string]*capvcd.NodePool{
 				"worker": {

--- a/cmd/template/cluster/provider/capz.go
+++ b/cmd/template/cluster/provider/capz.go
@@ -145,6 +145,7 @@ func BuildCapzClusterConfig(config common.ClusterConfig) capz.ClusterConfig {
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			ProviderSpecific: providerSpecific,
 			Connectivity: &capz.Connectivity{

--- a/cmd/template/cluster/provider/eks.go
+++ b/cmd/template/cluster/provider/eks.go
@@ -133,6 +133,7 @@ func BuildEKSClusterConfig(config common.ClusterConfig) eks.ClusterConfig {
 				Labels:          config.Labels,
 				Organization:    config.Organization,
 				PreventDeletion: config.PreventDeletion,
+				ServicePriority: config.ServicePriority,
 			},
 			Release: &eks.Release{
 				Version: config.ReleaseVersion,

--- a/cmd/template/cluster/provider/templates/aks/types.go
+++ b/cmd/template/cluster/provider/templates/aks/types.go
@@ -18,6 +18,7 @@ type Metadata struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type ControlPlane struct {

--- a/cmd/template/cluster/provider/templates/capa/types.go
+++ b/cmd/template/cluster/provider/templates/capa/types.go
@@ -19,6 +19,7 @@ type Metadata struct {
 	Name            string            `json:"name,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type Release struct {

--- a/cmd/template/cluster/provider/templates/capv/types.go
+++ b/cmd/template/cluster/provider/templates/capv/types.go
@@ -18,6 +18,7 @@ type Metadata struct {
 	Name            string            `json:"name,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type DefaultAppsConfig struct {

--- a/cmd/template/cluster/provider/templates/capvcd/types.go
+++ b/cmd/template/cluster/provider/templates/capvcd/types.go
@@ -61,6 +61,7 @@ type Metadata struct {
 	Name            string            `json:"name,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type NodePool struct {

--- a/cmd/template/cluster/provider/templates/capz/types.go
+++ b/cmd/template/cluster/provider/templates/capz/types.go
@@ -18,6 +18,7 @@ type Metadata struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type ProviderSpecific struct {

--- a/cmd/template/cluster/provider/templates/eks/types.go
+++ b/cmd/template/cluster/provider/templates/eks/types.go
@@ -15,6 +15,7 @@ type Metadata struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	Organization    string            `json:"organization,omitempty"`
 	PreventDeletion bool              `json:"preventDeletion,omitempty"`
+	ServicePriority string            `json:"servicePriority,omitempty"`
 }
 
 type Release struct {

--- a/cmd/template/cluster/runner_test.go
+++ b/cmd/template/cluster/runner_test.go
@@ -597,6 +597,43 @@ func Test_run(t *testing.T) {
 				return err != nil && strings.Contains(err.Error(), "too small to host 3 availability zones")
 			},
 		},
+		{
+			name: "case 13: template cluster capa with a non-default service priority",
+			flags: &flags.Flag{
+				Name:                     "test13",
+				Provider:                 "capa",
+				Description:              "just a test cluster",
+				Release:                  "25.0.0",
+				Region:                   "the-region",
+				Organization:             "test",
+				ControlPlaneInstanceType: "control-plane-instance-type",
+				ServicePriority:          "medium",
+				App: common.AppConfig{
+					ClusterVersion:     "1.0.0",
+					ClusterCatalog:     "the-catalog",
+					DefaultAppsCatalog: "the-default-catalog",
+					DefaultAppsVersion: "2.0.0",
+				},
+				AWS: common.AWSConfig{
+					MachinePool: common.AWSMachinePoolConfig{
+						Name:             "worker1",
+						AZs:              []string{"eu-west-1a", "eu-west-1b"},
+						InstanceType:     "big-one",
+						MaxSize:          5,
+						MinSize:          2,
+						RootVolumeSizeGB: 200,
+						CustomNodeLabels: []string{"label=value"},
+					},
+					AWSClusterRoleIdentityName: "default",
+					NetworkVPCCIDR:             "10.123.0.0/16",
+					PublicSubnetMask:           20,
+					PrivateSubnetMask:          18,
+					NetworkAZUsageLimit:        3,
+				},
+			},
+			args:               nil,
+			expectedGoldenFile: "run_template_cluster_capa_service_priority.golden",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/template/cluster/testdata/run_template_cluster_capa_service_priority.golden
+++ b/cmd/template/cluster/testdata/run_template_cluster_capa_service_priority.golden
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+data:
+  values: |
+    global:
+      connectivity:
+        availabilityZoneUsageLimit: 3
+        network:
+          vpcCidr: 10.123.0.0/16
+        subnets:
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.64.0/18
+          - availabilityZone: b
+            cidr: 10.123.128.0/18
+          - availabilityZone: c
+            cidr: 10.123.192.0/18
+          isPublic: false
+        - cidrBlocks:
+          - availabilityZone: a
+            cidr: 10.123.0.0/20
+          - availabilityZone: b
+            cidr: 10.123.16.0/20
+          - availabilityZone: c
+            cidr: 10.123.32.0/20
+          isPublic: true
+        topology: {}
+      controlPlane:
+        instanceType: control-plane-instance-type
+      metadata:
+        description: just a test cluster
+        name: test13
+        organization: test
+        preventDeletion: false
+        servicePriority: medium
+      nodePools:
+        worker1:
+          availabilityZones:
+          - eu-west-1a
+          - eu-west-1b
+          customNodeLabels:
+          - label=value
+          instanceType: big-one
+          maxSize: 5
+          minSize: 2
+          rootVolumeSizeGB: 200
+      providerSpecific:
+        awsClusterRoleIdentityName: default
+        region: the-region
+      release:
+        version: 25.0.0
+kind: ConfigMap
+metadata:
+  labels:
+    giantswarm.io/cluster: test13
+  name: test13-userconfig
+  namespace: org-test
+---
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    app-operator.giantswarm.io/version: 0.0.0
+  name: test13
+  namespace: org-test
+spec:
+  catalog: the-catalog
+  config:
+    configMap:
+      name: ""
+      namespace: ""
+    secret:
+      name: ""
+      namespace: ""
+  kubeConfig:
+    context:
+      name: ""
+    inCluster: true
+    secret:
+      name: ""
+      namespace: ""
+  name: cluster-aws
+  namespace: org-test
+  userConfig:
+    configMap:
+      name: test13-userconfig
+      namespace: org-test
+  version: 1.0.0


### PR DESCRIPTION
### What does this PR do?

Makes `template cluster --service-priority` actually reach the rendered manifests. The flag
was registered and validated, and its value was copied into `common.ClusterConfig`, but
nothing read it back out — so it was a silent no-op for all six providers.

The value is now rendered as `global.metadata.servicePriority`, mirroring how
`--prevent-deletion` reaches `global.metadata.preventDeletion`: one field added to each
provider's `Metadata` struct in `templates/*/types.go`, and one pass-through line in each
`Build*ClusterConfig`. 12 one-line changes, no new logic.

### What is the effect of this change to users?

`--service-priority medium` and `--service-priority lowest` now do what they say. Before
this, they were silently ignored and every templated cluster came out as `highest`.

**Clusters templated without the flag are unaffected.** The flag defaults to `highest` and
`global.metadata.servicePriority` defaults to `highest` in the chart, so rendered output is
byte-identical unless a non-default value is passed. Existing golden files are unchanged.

### What does it look like?

<!-- TODO: replace with real output from your build -->

    kubectl gs template cluster --provider capa --name test --organization test \
      --release 35.0.0 --service-priority medium

The user ConfigMap values gain one key:

```yaml
global:
  metadata:
    name: test
    organization: test
    servicePriority: medium
```

which the `cluster` library chart turns into `giantswarm.io/service-priority: medium` on the
cluster resources (`helm/cluster/templates/_helpers.tpl`, `cluster.labels.common`), and which
then shows up in the `SERVICE PRIORITY` column of `kubectl gs get clusters`.

### Any background context you can provide?

`--service-priority` was added in #827 and given its `highest` default in #812, but it was
only ever wired into the **vintage** AWS/Azure templating paths, which set the label directly
on a typed `Cluster` CR. Those blocks were deleted along with the vintage providers in #1871
(02776da7), shipping in v5.0.0, and the flag, its validation and the `ClusterConfig` field
were left behind with no consumer.

The same commit also broke `--label`, which was fixed the same day in #1877 and shipped in
v5.0.1. `--service-priority` was missed in that fix, so this is the remaining half of that
regression rather than an intentional deprecation — nothing in `CHANGELOG.md` announced
dropping the flag.

CAPI-side the label is a first-class value, not a generic label:
`global.metadata.servicePriority` is schema-**required** with `enum: [highest, medium, lowest]`
and `default: highest`, present in all six provider charts (`cluster-aws`, `-azure`, `-aks`,
`-eks`, `-vsphere`, `-cloud-director`), per the
[classify-cluster-priority RFC](https://github.com/giantswarm/rfc/tree/main/classify-cluster-priority).

### What is needed from the reviewers?

Two things:

1. **Sanity-check the mechanism.** Setting the dedicated `servicePriority` value is, I believe,
   the right route. Going via `global.metadata.labels` instead would collide with the chart's
   own emission of `giantswarm.io/service-priority` in `cluster.labels.common` and produce a
   duplicate YAML key, so I deliberately did not touch the labels map.
2. **A follow-up worth its own issue:** `pkg/labels/labels.go` still exempts
   `giantswarm.io/service-priority` from the forbidden-`giantswarm.io`-prefix check. That
   exemption made sense in the vintage code, which read the key back out of `config.Labels`,
   but today `--label giantswarm.io/service-priority=...` walks straight into the duplicate-key
   collision above. Happy to open that separately rather than widen this PR.

No golden test case is included — the change is pure pass-through and the existing goldens are
unaffected. If you'd like one pinned, add `ServicePriority: "medium"` to a `Test_run` case and
re